### PR TITLE
Add phased plan for in-app slide translation agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ presentation.json
 
 /doc-dumps
 /ysweet_data
+
+# Captured Proclaim snapshots may contain live service content; keep them local.
+# Synthetic fixtures (named *_synthetic.json) should still be committed.
+tests/proclaim_snapshots/*_captured.json
+tests/proclaim_snapshots/*_captured.expected.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,7 @@ Proclaim API/DB → Python Service → Y-Sweet → React Components
 ```
 
 The Python service syncs to two Yjs data structures:
-- `proclaimPresentations` (Y.Map): Maps itemId → `{title, itemId, slides: string[]}`
+- `proclaimPresentations` (Y.Map): Maps itemId → `{title, itemId, slides, sourceSlides, storedTranslation, itemKind}` — `slides`: legacy translation-screen content; `sourceSlides`: main-screen source text; `storedTranslation`: existing Proclaim translation; `itemKind`: item type
 - `proclaimStatus` (Y.Map): Current status `{itemId, slideIndex}`
 
 #### React Components
@@ -360,12 +360,15 @@ Python tests in `tests/` cover the Proclaim parsing pipeline. Two files per snap
 
 **When starting work on Proclaim parsing or the slide translation agent, read [`docs/agent-research.md`](docs/agent-research.md) first** — it documents gotchas (VirtualScreens double-encoding, ID hyphen stripping, translation screen index math) that are not obvious from the code.
 
+**The phased implementation plan is in [`PLAN_slide_translation_agent.md`](PLAN_slide_translation_agent.md)** — start here when continuing slide translation agent work.
+
 ## Key Files
 
 ### Backend
 - [server.ts](server.ts) - Express backend with Y-Sweet auth, translation API, and TTS endpoint
 - [nlp.ts](nlp.ts) - Gemini API integration for translation
 - [proclaim_service.py](proclaim_service.py) - Python service that syncs Proclaim presentation data to Yjs
+- [proclaim_lib.py](proclaim_lib.py) - Core Proclaim parsing library (SQLite DB reading, XML parsing, slide extraction)
 
 ### Frontend Core
 - [App.tsx](src/App.tsx) - Main React app with routing and layout system

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,12 @@ npm test
 # Run tests without ANSI color codes (useful for agents/CI)
 npm test -- --no-color
 
+# Run Python tests (Proclaim parsing pipeline)
+uv run pytest tests/ -v
+
+# Regenerate Proclaim expected output files after intentional parse changes
+uv run tests/update_expected.py [--force]
+
 # Run specific test file
 npm test -- path/to/test.ts --run
 
@@ -343,6 +349,16 @@ The app has two modes determined by URL hash (`#editor`):
   - Receives real-time updates from editors
   - Read-only Y-Sweet token
   - Can use TTS (auto or manual mode)
+
+## Proclaim Test Infrastructure
+
+Python tests in `tests/` cover the Proclaim parsing pipeline. Two files per snapshot in `tests/proclaim_snapshots/`:
+- `*.json` — input: raw Proclaim DB + API data (captured with `uv run proclaim_capture.py`)
+- `*.expected.json` — approved parse output used for exact-match comparison
+
+`Grouping` service item kind has no slide content and returns `None` from `parse_item_translation` — skip it in tests.
+
+**When starting work on Proclaim parsing or the slide translation agent, read [`docs/agent-research.md`](docs/agent-research.md) first** — it documents gotchas (VirtualScreens double-encoding, ID hyphen stripping, translation screen index math) that are not obvious from the code.
 
 ## Key Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ The app uses **Yjs** for real-time collaborative state management:
    - `translatedText-{language}` (Y.Text): Translated output for each language
    - `meta` (Y.Map): Metadata (unused currently)
    - `notesTranslationCache` (Y.Map): Translation cache to avoid re-translating unchanged text
-   - `proclaimPresentations` (Y.Map): Maps itemId → presentation data (title, slides)
+   - `proclaimServiceItems` (Y.Map): Maps itemId → presentation data (title, slides)
    - `proclaimStatus` (Y.Map): Current Proclaim status (itemId, slideIndex)
 
 ### Translation Pipeline
@@ -285,7 +285,7 @@ Proclaim API/DB → Python Service → Y-Sweet → React Components
 ```
 
 The Python service syncs to two Yjs data structures:
-- `proclaimPresentations` (Y.Map): Maps itemId → `{title, itemId, slides, sourceSlides, storedTranslation, itemKind}` — `slides`: legacy translation-screen content; `sourceSlides`: main-screen source text; `storedTranslation`: existing Proclaim translation; `itemKind`: item type
+- `proclaimServiceItems` (Y.Map): Maps itemId → `{title, itemId, slides, sourceSlides, storedTranslation, itemKind}` — `slides`: legacy translation-screen content; `sourceSlides`: main-screen source text; `storedTranslation`: existing Proclaim translation; `itemKind`: item type
 - `proclaimStatus` (Y.Map): Current status `{itemId, slideIndex}`
 
 #### React Components

--- a/DUMP_DOCS_README.md
+++ b/DUMP_DOCS_README.md
@@ -32,7 +32,7 @@ node dump-docs.ts [output-dir]
    - **translatedTexts**: Translations for each language (French, Spanish, etc.)
    - **meta**: Metadata (video settings, etc.)
    - **notesTranslationCache**: Translation cache
-   - **proclaimPresentations**: Proclaim presentation data
+   - **proclaimServiceItems**: Proclaim presentation data
    - **proclaimStatus**: Current Proclaim slide status
 
 4. Saves two types of files:

--- a/PLAN_slide_translation_agent.md
+++ b/PLAN_slide_translation_agent.md
@@ -10,7 +10,7 @@ findings and implementation reference.
 - `proclaim_lib.py`: `parse_item_translation()` extracts **translation-screen**
   content into `ServiceItemWithSlides.slides`
 - `proclaim_service.py`: writes `{title, itemId, slides}` to Yjs
-  `proclaimPresentations` map — where `slides` = translation-screen text
+  `proclaimServiceItems` map — where `slides` = translation-screen text
 - `CurrentSlideViewer.tsx`: reads `{title, slides}` from Yjs and displays them
 - No test infrastructure for Proclaim parsing
 - No agent, no chat endpoint, no chat UI

--- a/PLAN_slide_translation_agent.md
+++ b/PLAN_slide_translation_agent.md
@@ -1,0 +1,233 @@
+# Plan: In-App Slide Translation Agent
+
+Replace the current workflow (storing translations in Proclaim) with an in-app
+conversational agent that translates presentation slides. Each phase is a
+mergeable, demoable increment.
+
+## Current State (main)
+
+- `proclaim_lib.py`: `parse_item_translation()` extracts **translation-screen**
+  content into `ServiceItemWithSlides.slides`
+- `proclaim_service.py`: writes `{title, itemId, slides}` to Yjs
+  `proclaimPresentations` map (slides = translation-screen text)
+- `CurrentSlideViewer.tsx`: reads `{title, slides}` from Yjs and displays them
+- No test infrastructure for Proclaim parsing
+- No agent, no chat UI
+
+## Naming Strategy
+
+Existing `slides` field = translation-screen content. To avoid breaking
+`CurrentSlideViewer`, we **add new fields** rather than rename:
+
+| Field              | Meaning                                     | Source            |
+|--------------------|---------------------------------------------|-------------------|
+| `slides`           | (legacy) translation-screen content         | Proclaim DB       |
+| `sourceSlides`     | Main-screen untranslated content            | Proclaim DB       |
+| `storedTranslation`| Existing Proclaim translation (draft quality)| Proclaim DB      |
+| `itemKind`         | Item type (SongLyrics, Content, etc.)       | Proclaim DB       |
+
+The agent writes translations to a **separate** Yjs Y.Map
+(`slideTranslations`) keyed by `{itemId}:{language}`, keeping Proclaim data
+and agent output cleanly separated.
+
+Later, once the agent is working, we can deprecate `slides` in favor of
+`sourceSlides` + agent translations.
+
+---
+
+## Phase 1: Capture & Test Infrastructure
+
+**Goal**: Record real Proclaim data for offline testing. Purely additive — no
+behavior changes.
+
+**Files**:
+- `proclaim_capture.py` — snapshot capture tool (reads API + DB, writes JSON)
+- `tests/conftest.py` — `MockProclaimDB`, `snapshot` fixture
+- `tests/proclaim_snapshots/2026-01-05_synthetic.json` — synthetic fixture
+- `tests/test_proclaim_pipeline.py` — integration tests
+- `pyproject.toml` — add pytest config (`testpaths`, `pythonpath`)
+
+**Synthetic fixture covers**: SongLyrics (with custom order + translation
+screen), Content (with `--` delimiter + translation), BiblePassage (no
+translation), ImageSlideshow (blank), Blank content item.
+
+**Tests verify**:
+- All items parse without error
+- Blank items → `slides=['']`
+- Non-blank items have content
+- Yjs dict has correct keys and types
+- Translation screen detection
+- Song-specific: title as first slide, custom order, English main / French translation
+- Content-specific: delimiter splitting, translation pairing
+
+**Demo**: `uv run pytest tests/ -v` passes.
+
+**Decision points for user**:
+- Does the synthetic fixture cover the real-world cases you see?
+- Want to capture a real session snapshot before moving on?
+
+---
+
+## Phase 2: Extract Source Slides from Proclaim
+
+**Goal**: Parse **both** main-screen and translation-screen content from
+Proclaim, sync both to Yjs. Existing viewer keeps working.
+
+**Changes to `proclaim_lib.py`**:
+- Add `sourceSlides: Optional[List[str]]` and
+  `storedTranslation: Optional[List[str]]` to `ServiceItemWithSlides`
+- Create `parse_item_slides(db, item_id, translation_idx)`:
+  - Always extracts main-screen content → `sourceSlides`
+  - Extracts translation-screen content → `storedTranslation` (if screen exists)
+  - For backward compat: `slides` = `storedTranslation` if available, else
+    `sourceSlides` (so CurrentSlideViewer still shows what it shows today)
+- `translation_idx` is now `Optional[int]` (None when no translation screen)
+- Keep `parse_item_translation()` as a thin wrapper or alias
+
+**Changes to `proclaim_service.py`**:
+- `update_presentation_item_in_yjs()` writes `sourceSlides`, `itemKind`,
+  and optionally `storedTranslation` alongside existing `slides`
+- `_handle_item_change()` works when `translation_idx is None`
+
+**Update tests**: synthetic fixture tests verify both `sourceSlides` and
+`storedTranslation` extraction.
+
+**Demo**: Yjs inspector shows new fields; existing `CurrentSlideViewer` still
+works unchanged.
+
+**Decision points for user**:
+- Confirm the `sourceSlides` / `storedTranslation` naming
+- The French/Haitian interleaving: is `storedTranslation` always the same
+  language, or do some items have French and others Haitian on the same screen?
+  (Affects whether we need per-slide language tagging)
+
+---
+
+## Phase 3: Service Order in Yjs
+
+**Goal**: Sync the full service order (list of all items) to Yjs so the
+client-side agent can enumerate what needs translating.
+
+**Changes to `proclaim_service.py`**:
+- Add `proclaimServiceOrder` Y.Array
+- `update_service_order_in_yjs()`: writes `[{id, title, kind}, ...]` from API
+- Called from `poll_once()` when service order changes
+
+**Frontend**: Add a React hook or helper to read service order — but no UI yet.
+
+**Demo**: Yjs inspector shows `proclaimServiceOrder` array updating as
+Proclaim service order changes.
+
+**Decision points for user**:
+- Should service order include all items or filter out blanks/images?
+- Any metadata beyond `{id, title, kind}` that the agent will need?
+
+---
+
+## Phase 4: Language-Aware Slide Viewer
+
+**Goal**: `CurrentSlideViewer` can show either source or translated slides,
+selected by language.
+
+**Changes to `CurrentSlideViewer.tsx`**:
+- Accept optional `language` prop
+- When `language` is set, use fallback chain:
+  1. `slideTranslations[itemId:language]` (agent-written, not yet populated)
+  2. `storedTranslation` (from Proclaim)
+  3. `sourceSlides` (untranslated fallback)
+- When no `language`, show `sourceSlides` (or `slides` as final fallback)
+
+**Changes to `App.tsx`**:
+- Register `currentSlide-{language}` layout component
+
+**Demo**: URL `/currentSlide-French` shows Proclaim translations for songs
+(from `storedTranslation`), English fallback for items without translation.
+`/currentSlide` shows untranslated source.
+
+**Decision points for user**:
+- Should the viewer visually indicate when it's showing a fallback?
+  (e.g., dimmed text or "(untranslated)" label)
+- Layout: `/slideAgent,currentSlide-French` or different arrangement?
+
+---
+
+## Phase 5: Server Chat Endpoint
+
+**Goal**: Stateless server endpoint that proxies chat messages to Gemini with
+function-calling support.
+
+**Changes to `server.ts`**:
+- `POST /api/chat` — accepts `{messages, tools}`, calls Gemini, returns
+  `{content, functionCalls, text}`
+- Uses `gemini-2.5-flash` with function declarations
+- No server-side state; client owns conversation history
+
+**Demo**: `curl` test showing Gemini responding to "translate this to French"
+with a `write_item_translation` function call.
+
+**Decision points for user**:
+- Gemini model choice (flash vs pro) — flash is faster/cheaper, pro may
+  translate better
+- Should there be a system prompt baked in, or fully client-controlled?
+- Rate limiting / auth on the endpoint?
+
+---
+
+## Phase 6: Agent Loop & Tools
+
+**Goal**: Client-side agent loop that reads Yjs, calls Gemini, and writes
+translations back to Yjs.
+
+**New files**:
+- `src/agentTypes.ts` — Gemini API types (Content, Part, FunctionCall, etc.)
+- `src/useSlideAgent.ts` — agent hook with:
+  - Tool definitions: `get_service_order`, `write_item_translation`
+  - `get_service_order`: reads `proclaimServiceOrder` + `proclaimPresentations`
+    from Yjs, returns items with `sourceSlides`, `storedTranslation`, `itemKind`
+  - `write_item_translation`: writes to `slideTranslations` Y.Map
+  - `runAgentLoop()`: send messages → get response → execute tool calls → loop
+  - Max iterations (20), AbortController for cancellation
+  - `sourceHash` (djb2 of `sourceSlides.join('|')`) for staleness detection
+
+**Demo**: Call `runAgentLoop()` from browser console with "translate the
+service to French" → watch translations appear in `slideTranslations` Y.Map →
+`currentSlide-French` updates live.
+
+**Decision points for user**:
+- Should the agent translate everything at once, or item-by-item with
+  confirmation?
+- For Bible passages: should the agent ask the user to paste authoritative
+  text, or attempt AI translation with a disclaimer?
+- How to handle the French/Haitian interleaving — translate to one language
+  per run, or both?
+
+---
+
+## Phase 7: Chat UI
+
+**Goal**: Visible chat panel for interacting with the agent.
+
+**New file**: `src/SlideAgentChat.tsx`
+- Message bubbles (user / assistant / tool results)
+- "Start Translation" button for one-click full-service translation
+- Tool calls shown as collapsible `<details>` elements
+- Loading state, cancel button
+- Text input for follow-up instructions
+
+**Changes to `App.tsx`**:
+- Register `slideAgent` layout component
+
+**Demo**: `/slideAgent,currentSlide-French` — click "Start Translation",
+watch the agent work through each item, see translations appear in the
+slide viewer in real time.
+
+---
+
+## Future (not phased yet)
+
+- **Approval workflow**: mark translations as reviewed/approved
+- **Caching**: skip re-translating items whose `sourceHash` hasn't changed
+- **Multi-language**: run agent for French then Haitian Creole
+- **TTS for slides**: auto-speak translated slides
+- **Deprecate `slides` field**: once agent is primary, remove legacy field
+- **Offline mode**: pre-translate before service starts

--- a/PLAN_slide_translation_agent.md
+++ b/PLAN_slide_translation_agent.md
@@ -2,232 +2,226 @@
 
 Replace the current workflow (storing translations in Proclaim) with an in-app
 conversational agent that translates presentation slides. Each phase is a
-mergeable, demoable increment.
+mergeable, demoable increment. See `docs/agent-research.md` for technical
+findings and implementation reference.
 
 ## Current State (main)
 
 - `proclaim_lib.py`: `parse_item_translation()` extracts **translation-screen**
   content into `ServiceItemWithSlides.slides`
 - `proclaim_service.py`: writes `{title, itemId, slides}` to Yjs
-  `proclaimPresentations` map (slides = translation-screen text)
+  `proclaimPresentations` map — where `slides` = translation-screen text
 - `CurrentSlideViewer.tsx`: reads `{title, slides}` from Yjs and displays them
 - No test infrastructure for Proclaim parsing
-- No agent, no chat UI
+- No agent, no chat endpoint, no chat UI
 
-## Naming Strategy
+## Design Decisions
+
+### Naming: non-breaking field additions
 
 Existing `slides` field = translation-screen content. To avoid breaking
 `CurrentSlideViewer`, we **add new fields** rather than rename:
 
-| Field              | Meaning                                     | Source            |
-|--------------------|---------------------------------------------|-------------------|
-| `slides`           | (legacy) translation-screen content         | Proclaim DB       |
-| `sourceSlides`     | Main-screen untranslated content            | Proclaim DB       |
-| `storedTranslation`| Existing Proclaim translation (draft quality)| Proclaim DB      |
-| `itemKind`         | Item type (SongLyrics, Content, etc.)       | Proclaim DB       |
+| Field              | Meaning                                      | Written by  |
+|--------------------|----------------------------------------------|-------------|
+| `slides`           | (legacy) translation-screen content          | Proclaim svc|
+| `sourceSlides`     | Main-screen untranslated content             | Proclaim svc|
+| `storedTranslation`| Existing Proclaim translation (draft quality)| Proclaim svc|
+| `itemKind`         | Item type (SongLyrics, Content, etc.)        | Proclaim svc|
 
-The agent writes translations to a **separate** Yjs Y.Map
-(`slideTranslations`) keyed by `{itemId}:{language}`, keeping Proclaim data
-and agent output cleanly separated.
+Agent-produced translations live in a **separate** Yjs Y.Map
+(`slideTranslations`) keyed by `{itemId}:{language}`. This keeps Proclaim
+data and agent output cleanly separated.
 
 Later, once the agent is working, we can deprecate `slides` in favor of
 `sourceSlides` + agent translations.
+
+### Architecture: client-side agent, stateless server
+
+- Client owns conversation history and executes tools (reads/writes Yjs)
+- Server only proxies LLM API calls (`POST /api/chat`)
+- Gemini function calling for structured tool use
+- Agent translates directly in its response text — no separate translate tool
+
+### Translation approach
+
+- Songs with existing Proclaim translations: use `storedTranslation` as draft,
+  agent can revise
+- Bible passages, creeds: agent asks user to paste authoritative text via
+  normal chat (no special tools)
+- Other content: agent AI-translates directly
+- The translation screen interleaves French and Haitian Creole — a single
+  `storedTranslation` field holds whatever's on that screen
 
 ---
 
 ## Phase 1: Capture & Test Infrastructure
 
 **Goal**: Record real Proclaim data for offline testing. Purely additive — no
-behavior changes.
+behavior changes, no existing code modified.
 
-**Files**:
+**New files**:
 - `proclaim_capture.py` — snapshot capture tool (reads API + DB, writes JSON)
-- `tests/conftest.py` — `MockProclaimDB`, `snapshot` fixture
+- `tests/conftest.py` — `MockProclaimDB`, `snapshot` parametrized fixture
 - `tests/proclaim_snapshots/2026-01-05_synthetic.json` — synthetic fixture
 - `tests/test_proclaim_pipeline.py` — integration tests
-- `pyproject.toml` — add pytest config (`testpaths`, `pythonpath`)
+- `pyproject.toml` changes: add `[tool.pytest.ini_options]` with `testpaths`
+  and `pythonpath`
 
-**Synthetic fixture covers**: SongLyrics (with custom order + translation
-screen), Content (with `--` delimiter + translation), BiblePassage (no
-translation), ImageSlideshow (blank), Blank content item.
+**What the synthetic fixture covers**: SongLyrics (custom order + translation
+screen), Content (`--` delimiter + translation), BiblePassage (no translation),
+ImageSlideshow (blank), Blank content item.
 
-**Tests verify**:
+**What the tests verify**:
 - All items parse without error
-- Blank items → `slides=['']`
-- Non-blank items have content
-- Yjs dict has correct keys and types
-- Translation screen detection
-- Song-specific: title as first slide, custom order, English main / French translation
-- Content-specific: delimiter splitting, translation pairing
+- Blank items produce `slides=['']`
+- Non-blank items have at least one non-empty slide
+- Yjs dict has correct required/optional keys and types
+- Translation screen detection (positive and negative)
+- Song parsing: title as first slide, custom order, English/French content
+- Content parsing: delimiter splitting, translation pairing
 
-**Demo**: `uv run pytest tests/ -v` passes.
+**Demo**: `uv run pytest tests/ -v` all green.
 
-**Decision points for user**:
+**Before moving on, decide**:
 - Does the synthetic fixture cover the real-world cases you see?
-- Want to capture a real session snapshot before moving on?
+- Want to capture a real session snapshot?
 
 ---
 
-## Phase 2: Extract Source Slides from Proclaim
+## Phase 2: Extract Source Slides
 
 **Goal**: Parse **both** main-screen and translation-screen content from
-Proclaim, sync both to Yjs. Existing viewer keeps working.
+Proclaim, sync both to Yjs. Existing viewer unaffected.
 
-**Changes to `proclaim_lib.py`**:
-- Add `sourceSlides: Optional[List[str]]` and
-  `storedTranslation: Optional[List[str]]` to `ServiceItemWithSlides`
-- Create `parse_item_slides(db, item_id, translation_idx)`:
-  - Always extracts main-screen content → `sourceSlides`
-  - Extracts translation-screen content → `storedTranslation` (if screen exists)
-  - For backward compat: `slides` = `storedTranslation` if available, else
-    `sourceSlides` (so CurrentSlideViewer still shows what it shows today)
-- `translation_idx` is now `Optional[int]` (None when no translation screen)
-- Keep `parse_item_translation()` as a thin wrapper or alias
+**`proclaim_lib.py` changes**:
+- Add `sourceSlides` and `storedTranslation` (both `Optional[List[str]]`) to
+  `ServiceItemWithSlides`
+- New function `parse_item_slides(db, item_id, translation_idx)`:
+  - `translation_idx` is `Optional[int]` (None = no translation screen)
+  - Always extracts main-screen → `sourceSlides`
+  - Extracts translation-screen → `storedTranslation` (when screen exists)
+  - Sets `slides` = `storedTranslation ?? sourceSlides` for backward compat
+- Keep `parse_item_translation()` as alias
 
-**Changes to `proclaim_service.py`**:
+**`proclaim_service.py` changes**:
 - `update_presentation_item_in_yjs()` writes `sourceSlides`, `itemKind`,
   and optionally `storedTranslation` alongside existing `slides`
 - `_handle_item_change()` works when `translation_idx is None`
 
-**Update tests**: synthetic fixture tests verify both `sourceSlides` and
-`storedTranslation` extraction.
+**Tests**: verify both `sourceSlides` and `storedTranslation` extraction.
 
-**Demo**: Yjs inspector shows new fields; existing `CurrentSlideViewer` still
-works unchanged.
+**Demo**: Yjs inspector shows new fields alongside existing ones.
 
-**Decision points for user**:
-- Confirm the `sourceSlides` / `storedTranslation` naming
-- The French/Haitian interleaving: is `storedTranslation` always the same
-  language, or do some items have French and others Haitian on the same screen?
-  (Affects whether we need per-slide language tagging)
+**Before moving on, decide**:
+- Confirm `sourceSlides`/`storedTranslation` naming
+- Is `storedTranslation` always one language, or mixed French/Haitian per item?
 
 ---
 
 ## Phase 3: Service Order in Yjs
 
-**Goal**: Sync the full service order (list of all items) to Yjs so the
-client-side agent can enumerate what needs translating.
+**Goal**: Sync the full ordered list of service items to Yjs so the agent can
+enumerate what needs translating.
 
-**Changes to `proclaim_service.py`**:
-- Add `proclaimServiceOrder` Y.Array
-- `update_service_order_in_yjs()`: writes `[{id, title, kind}, ...]` from API
+**`proclaim_service.py` changes**:
+- New `proclaimServiceOrder` Y.Array
+- `update_service_order_in_yjs()`: writes `[{id, title, kind}, ...]`
 - Called from `poll_once()` when service order changes
 
-**Frontend**: Add a React hook or helper to read service order — but no UI yet.
+**Frontend**: hook or helper to read service order (no UI yet).
 
-**Demo**: Yjs inspector shows `proclaimServiceOrder` array updating as
-Proclaim service order changes.
+**Demo**: Yjs inspector shows `proclaimServiceOrder` updating.
 
-**Decision points for user**:
-- Should service order include all items or filter out blanks/images?
-- Any metadata beyond `{id, title, kind}` that the agent will need?
+**Before moving on, decide**:
+- Include all items or filter blanks/images?
+- Any metadata beyond `{id, title, kind}`?
 
 ---
 
 ## Phase 4: Language-Aware Slide Viewer
 
-**Goal**: `CurrentSlideViewer` can show either source or translated slides,
-selected by language.
+**Goal**: `CurrentSlideViewer` shows source or translated slides by language.
 
-**Changes to `CurrentSlideViewer.tsx`**:
+**`CurrentSlideViewer.tsx` changes**:
 - Accept optional `language` prop
-- When `language` is set, use fallback chain:
-  1. `slideTranslations[itemId:language]` (agent-written, not yet populated)
-  2. `storedTranslation` (from Proclaim)
-  3. `sourceSlides` (untranslated fallback)
-- When no `language`, show `sourceSlides` (or `slides` as final fallback)
+- Fallback chain when `language` set:
+  1. `slideTranslations[itemId:language]` (agent output — empty until Phase 6)
+  2. `storedTranslation` (Proclaim draft)
+  3. `sourceSlides` (untranslated)
+- Without `language`: show `sourceSlides` (fallback to `slides`)
 
-**Changes to `App.tsx`**:
-- Register `currentSlide-{language}` layout component
+**`App.tsx`**: register `currentSlide-{language}` layout component.
 
-**Demo**: URL `/currentSlide-French` shows Proclaim translations for songs
-(from `storedTranslation`), English fallback for items without translation.
-`/currentSlide` shows untranslated source.
+**Demo**: `/currentSlide-French` shows Proclaim translations for songs,
+English fallback for others. `/currentSlide` shows source text.
 
-**Decision points for user**:
-- Should the viewer visually indicate when it's showing a fallback?
-  (e.g., dimmed text or "(untranslated)" label)
-- Layout: `/slideAgent,currentSlide-French` or different arrangement?
+**Before moving on, decide**:
+- Visual indicator for fallback? (dimmed, "(untranslated)" label)
+- Preferred layout for agent + viewer?
 
 ---
 
 ## Phase 5: Server Chat Endpoint
 
-**Goal**: Stateless server endpoint that proxies chat messages to Gemini with
-function-calling support.
+**Goal**: Stateless endpoint proxying to Gemini with function calling.
 
-**Changes to `server.ts`**:
-- `POST /api/chat` — accepts `{messages, tools}`, calls Gemini, returns
+**`server.ts` changes**:
+- `POST /api/chat` — accepts `{messages, tools}`, returns
   `{content, functionCalls, text}`
-- Uses `gemini-2.5-flash` with function declarations
-- No server-side state; client owns conversation history
+- Gemini `gemini-2.5-flash` with `functionDeclarations`
 
-**Demo**: `curl` test showing Gemini responding to "translate this to French"
-with a `write_item_translation` function call.
+**Demo**: curl showing Gemini returning function calls.
 
-**Decision points for user**:
-- Gemini model choice (flash vs pro) — flash is faster/cheaper, pro may
-  translate better
-- Should there be a system prompt baked in, or fully client-controlled?
-- Rate limiting / auth on the endpoint?
+**Before moving on, decide**:
+- Model choice (flash vs pro)
+- System prompt: baked in or client-controlled?
+- Auth/rate limiting?
 
 ---
 
 ## Phase 6: Agent Loop & Tools
 
-**Goal**: Client-side agent loop that reads Yjs, calls Gemini, and writes
-translations back to Yjs.
+**Goal**: Client-side loop that reads Yjs, calls Gemini, writes translations.
 
 **New files**:
-- `src/agentTypes.ts` — Gemini API types (Content, Part, FunctionCall, etc.)
-- `src/useSlideAgent.ts` — agent hook with:
-  - Tool definitions: `get_service_order`, `write_item_translation`
-  - `get_service_order`: reads `proclaimServiceOrder` + `proclaimPresentations`
-    from Yjs, returns items with `sourceSlides`, `storedTranslation`, `itemKind`
-  - `write_item_translation`: writes to `slideTranslations` Y.Map
-  - `runAgentLoop()`: send messages → get response → execute tool calls → loop
-  - Max iterations (20), AbortController for cancellation
-  - `sourceHash` (djb2 of `sourceSlides.join('|')`) for staleness detection
+- `src/agentTypes.ts` — Gemini Content/Part/FunctionCall types
+- `src/useSlideAgent.ts`:
+  - Tools: `get_service_order` (reads Yjs), `write_item_translation` (writes
+    `slideTranslations` Y.Map)
+  - `runAgentLoop()`: send → response → execute tools → repeat
+  - Max 20 iterations, AbortController, `sourceHash` for staleness
 
-**Demo**: Call `runAgentLoop()` from browser console with "translate the
-service to French" → watch translations appear in `slideTranslations` Y.Map →
+**Demo**: browser console call → translations appear in Yjs →
 `currentSlide-French` updates live.
 
-**Decision points for user**:
-- Should the agent translate everything at once, or item-by-item with
-  confirmation?
-- For Bible passages: should the agent ask the user to paste authoritative
-  text, or attempt AI translation with a disclaimer?
-- How to handle the French/Haitian interleaving — translate to one language
-  per run, or both?
+**Before moving on, decide**:
+- Translate all at once or item-by-item with confirmation?
+- Bible passages: ask user to paste, or AI-translate with disclaimer?
+- One language per run or both French + Haitian?
 
 ---
 
 ## Phase 7: Chat UI
 
-**Goal**: Visible chat panel for interacting with the agent.
+**Goal**: Visible chat panel.
 
 **New file**: `src/SlideAgentChat.tsx`
-- Message bubbles (user / assistant / tool results)
-- "Start Translation" button for one-click full-service translation
-- Tool calls shown as collapsible `<details>` elements
-- Loading state, cancel button
-- Text input for follow-up instructions
+- Message bubbles, "Start Translation" button, collapsible tool calls,
+  loading/cancel, text input for follow-ups
 
-**Changes to `App.tsx`**:
-- Register `slideAgent` layout component
+**`App.tsx`**: register `slideAgent` layout component.
 
 **Demo**: `/slideAgent,currentSlide-French` — click "Start Translation",
-watch the agent work through each item, see translations appear in the
-slide viewer in real time.
+watch translations appear live.
 
 ---
 
 ## Future (not phased yet)
 
-- **Approval workflow**: mark translations as reviewed/approved
-- **Caching**: skip re-translating items whose `sourceHash` hasn't changed
-- **Multi-language**: run agent for French then Haitian Creole
-- **TTS for slides**: auto-speak translated slides
-- **Deprecate `slides` field**: once agent is primary, remove legacy field
-- **Offline mode**: pre-translate before service starts
+- Approval workflow for reviewed translations
+- Skip re-translating unchanged items (sourceHash caching)
+- Multi-language support (French then Haitian)
+- TTS for translated slides
+- Deprecate legacy `slides` field
+- Offline pre-translation before service starts

--- a/PLAN_slide_translation_agent.md
+++ b/PLAN_slide_translation_agent.md
@@ -55,7 +55,7 @@ Later, once the agent is working, we can deprecate `slides` in favor of
 
 ---
 
-## Phase 1: Capture & Test Infrastructure
+## Phase 1: Capture & Test Infrastructure ✅ DONE
 
 **Goal**: Record real Proclaim data for offline testing. Purely additive — no
 behavior changes, no existing code modified.
@@ -89,33 +89,28 @@ ImageSlideshow (blank), Blank content item.
 
 ---
 
-## Phase 2: Extract Source Slides
+## Phase 2: Extract Source Slides ✅ DONE (2026-05-02)
 
 **Goal**: Parse **both** main-screen and translation-screen content from
 Proclaim, sync both to Yjs. Existing viewer unaffected.
 
-**`proclaim_lib.py` changes**:
-- Add `sourceSlides` and `storedTranslation` (both `Optional[List[str]]`) to
-  `ServiceItemWithSlides`
-- New function `parse_item_slides(db, item_id, translation_idx)`:
-  - `translation_idx` is `Optional[int]` (None = no translation screen)
-  - Always extracts main-screen → `sourceSlides`
-  - Extracts translation-screen → `storedTranslation` (when screen exists)
-  - Sets `slides` = `storedTranslation ?? sourceSlides` for backward compat
-- Keep `parse_item_translation()` as alias
+**What was built**:
+- `ServiceItemWithSlides` gains `sourceSlides` and `storedTranslation`
+- `_parse_screen(content, item_kind, screen_idx)` shared helper — None = main
+  content, int = translation screen; `parse_item_translation` now calls it twice
+- `item_to_yjs_dict(item)` pure function used by service and tests
+- `parse_item_translation` signature: `translation_screen_idx: Optional[int]`
+- `_handle_item_change` no longer bails when translation screen is absent
+- `slides` field kept as `storedTranslation ?? sourceSlides` for backward compat
+  (documented in `ServiceItemWithSlides` and `item_to_yjs_dict`)
+- Fixed pre-existing bug: `update_expected.py` was globbing `.expected.json` as snapshots
 
-**`proclaim_service.py` changes**:
-- `update_presentation_item_in_yjs()` writes `sourceSlides`, `itemKind`,
-  and optionally `storedTranslation` alongside existing `slides`
-- `_handle_item_change()` works when `translation_idx is None`
-
-**Tests**: verify both `sourceSlides` and `storedTranslation` extraction.
-
-**Demo**: Yjs inspector shows new fields alongside existing ones.
-
-**Before moving on, decide**:
-- Confirm `sourceSlides`/`storedTranslation` naming
-- Is `storedTranslation` always one language, or mixed French/Haitian per item?
+**Decisions made**:
+- `storedTranslation` is one field — it's whatever is on the translation screen
+  (can be French, Haitian, or mixed depending on the item/service). The agent
+  will treat it as a draft regardless.
+- `slides` backward-compat field is documented as legacy; deprecate once Phase 4
+  updates `CurrentSlideViewer`.
 
 ---
 

--- a/PROCLAIM_INTEGRATION.md
+++ b/PROCLAIM_INTEGRATION.md
@@ -12,8 +12,9 @@ The integration uses **Yjs** for real-time synchronization:
    - Updates Yjs shared state via Y-Sweet WebSocket connection
 
 2. **Yjs Shared State**
-   - `proclaimPresentations` (Y.Map) - Maps itemId → presentation data
-     - Each presentation contains: `{title: string, itemId: string, slides: Y.Array<string>}`
+   - `proclaimServiceItems` (Y.Map) - Maps itemId → service item data
+     - Each entry contains: `{title: string, itemId: string, slides: Y.Array<string>}`
+     - **Schema history**: renamed from `proclaimPresentations` (2026-05-23) — "presentation" referred to the whole service, not an item
    - `proclaimStatus` (Y.Map) - Current status: `{itemId: string, slideIndex: number}`
 
 3. **React Components** (`CurrentSlideViewer.tsx`)
@@ -75,7 +76,7 @@ When a new presentation is detected:
 - Queries Proclaim SQLite database for service item content
 - Parses rich text XML to extract slide text
 - Decodes the custom order sequence to get slides in correct order
-- Stores full presentation in `proclaimPresentations` Yjs map
+- Stores full presentation in `proclaimServiceItems` Yjs map
 - Updates `proclaimStatus` with current itemId and slideIndex
 - Sends update to Y-Sweet WebSocket
 

--- a/docs/agent-research.md
+++ b/docs/agent-research.md
@@ -295,93 +295,111 @@ Phase 7 adds `slideAgent`.
 
 ---
 
-## 7. Test Infrastructure (Phase 1 ready-to-use)
+## 7. Test Infrastructure (Phase 1 as built)
 
-### Synthetic fixture: `tests/proclaim_snapshots/2026-01-05_synthetic.json`
+### Snapshot format (actual)
 
-Shape:
 ```json
 {
-  "captured_at": "2026-01-05T10:00:00+00:00",
-  "presentation_id": "aabbccdd11223344",
-  "status_response": { "presentationId": "...", "status": { "itemId": "...", "slideIndex": 0 } },
-  "onair_response": {
-    "serviceItems": [
-      { "id": "item-song-001", "title": "Amazing Grace", "kind": "SongLyrics", "slides": [...] },
-      { "id": "item-content-002", "title": "Call to Worship", "kind": "Content", "slides": [...] },
-      { "id": "item-bible-003", "title": "Romans 8:1-4", "kind": "BiblePassage", "slides": [...] },
-      { "id": "item-image-004", "title": "NCF Slide", "kind": "ImageSlideshow", "slides": [] },
-      { "id": "item-blank-005", "title": "Blank", "kind": "Content", "slides": [] }
-    ]
+  "date": "2026-05-02",
+  "note": "Captured from live Proclaim session",
+  "current_status": { "itemId": "cadcccaa-...", "slideIndex": 3, ... },
+  "presentation_content": {
+    "VirtualScreens": "[{...JSON string...}]"
   },
-  "presentation_row": {
-    "id": "aabbccdd11223344",
-    "content": {
-      "VirtualScreens": "[{...JSON string...}]"  // MUST be JSON string, not parsed list
-    }
-  },
-  "service_items": {
-    "item-song-001": {
-      "ServiceItemId": "itemsong001",
+  "service_items": [
+    {
+      "ServiceItemId": "cadcccaa301848bcb0738e239fc264b7",
+      "Title": "Revelation Song",
       "ServiceItemKind": "SongLyrics",
-      "Title": "Amazing Grace",
-      "Content": "{...JSON string with _richtextfield:Lyrics, slideOutput:0:RichTextXml, CustomOrderSequence, SongDisplayTitle...}"
+      "content_dict": {
+        "_richtextfield:Lyrics": "<Paragraph ...>...",
+        "slideOutput:1:RichTextXml": "<Paragraph ...>...",
+        "CustomOrderSequence": "v1,c,v2",
+        "SongDisplayTitle": "Revelation Song"
+      }
     }
-  }
+  ]
 }
 ```
 
-Key: `service_items` is keyed by dashed ID. Each `Content` field is a JSON
-string containing the rich text XML fields.
+Differences from the design sketch:
+- `service_items` is a **list** (preserves service order), not a dict
+- `content_dict` stores item content as a **parsed dict**, not a JSON string — `MockProclaimDB` serializes it back to `Content` on access
+- `presentation_content` is a flat dict (just the content, not the full row); `VirtualScreens` is still a JSON string inside it
+- `current_status` is the raw status object from the API (includes extra fields like `mediaState`)
+- No `onair_response` or `captured_at` fields
+
+### Expected output files
+
+Each snapshot has a companion `*.expected.json` with the full parse output:
+
+```json
+{
+  "status": { "itemId": "...", "slideIndex": 3, ... },
+  "presentations": [
+    { "itemId": "...", "title": "Revelation Song", "itemKind": "SongLyrics", "slides": [...] }
+  ]
+}
+```
+
+Regenerate with: `uv run tests/update_expected.py [stem] [--force]`
 
 ### MockProclaimDB (`tests/conftest.py`)
 
 ```python
 class MockProclaimDB:
-    def __init__(self, snapshot):
-        self._items = {}
-        for key, row in snapshot['service_items'].items():
-            self._items[key] = row
-            self._items[key.replace('-', '')] = row  # both forms
-        self._presentation = snapshot['presentation_row']
+    def __init__(self, data):
+        self._items = {
+            item["ServiceItemId"].replace("-", ""): item
+            for item in data["service_items"]
+        }
 
     def get_service_item(self, item_id):
-        return self._items.get(item_id)
-
-    def get_presentation(self, presentation_id):
-        # ID matching with dash stripping
+        item = self._items.get(item_id.replace("-", ""))
+        if item is None:
+            return None
+        result = dict(item)
+        if "content_dict" in result:
+            result["Content"] = json.dumps(result.pop("content_dict"))
+        return result
 ```
 
-### Parametrized fixture
+### Parametrized fixtures
 
 ```python
-SNAPSHOT_DIR = Path(__file__).parent / 'proclaim_snapshots'
+@pytest.fixture(
+    params=sorted(p for p in SNAPSHOTS_DIR.glob("*.json") if not p.stem.endswith(".expected")),
+    ids=lambda p: p.stem,
+)
+def snapshot(request): ...
 
-@pytest.fixture(params=_snapshot_files(), ids=_snapshot_ids())
-def snapshot(request):
-    return json.loads(Path(request.param).read_text())
+@pytest.fixture
+def expected(request, snapshot): ...  # loads *.expected.json alongside snapshot, or None
 ```
-
-All tests in `test_proclaim_pipeline.py` accept `snapshot` fixture and run
-against every `.json` file in the snapshots directory.
 
 ### Capture tool (`proclaim_capture.py`)
 
-Env var `PROCLAIM_CAPTURE_DIR` enables capture in `proclaim_service.py`.
-`capture_snapshot()` gathers: API status response, onair response, all
-service item DB rows, presentation row. `save_snapshot()` writes to
-`YYYY-MM-DD_{hash8}.json` with dedup (won't overwrite if content matches).
+Standalone script, not embedded in `proclaim_service.py`. Calls
+`/onair/session` → `/presentations/onair` → `/onair/statusChanged`, fetches
+`presentation_content` from DB via `presentationId` in status response.
+
+Run: `uv run proclaim_capture.py [--output PATH]`
 
 ### pyproject.toml additions
 
 ```toml
-[tool.pytest.ini_options]
+[tool.pytest]
 testpaths = ["tests"]
 pythonpath = ["."]
 ```
 
-`pythonpath = ["."]` is needed so `from conftest import MockProclaimDB`
-works (tests/ is not a package).
+Uses `[tool.pytest]` (pytest 9 native TOML), not `[tool.pytest.ini_options]`.
+
+### Things from the design sketch worth considering
+
+- **Hash-based dedup in capture**: the sketch proposed not overwriting a snapshot if content matches. Useful once passive capture is running.
+- **Passive capture via env var in `proclaim_service.py`**: embedding `PROCLAIM_CAPTURE_DIR` in the service so snapshots accumulate automatically during live use — good for building a test corpus without manual effort.
 
 ---
 

--- a/docs/agent-research.md
+++ b/docs/agent-research.md
@@ -25,8 +25,8 @@ Phase 2 adds: `sourceSlides: Optional[List[str]] = None`,
 ### Yjs data written by proclaim_service.py
 
 ```python
-# proclaimPresentations Y.Map — keyed by item_id
-presentations_map[item_id] = {
+# proclaimServiceItems Y.Map — keyed by item_id
+service_items_map[item_id] = {
     'title': str,
     'itemId': str,
     'slides': list[str],  # currently = translation-screen content
@@ -38,14 +38,14 @@ status_map['slideIndex'] = int
 ```
 
 Phase 2 adds `sourceSlides`, `storedTranslation`, `itemKind` to the
-presentations_map entry. Phase 3 adds `proclaimServiceOrder` Y.Array.
+service_items_map entry. Phase 3 adds `proclaimServiceOrder` Y.Array.
 
 ### CurrentSlideViewer reads from Yjs (`CurrentSlideViewer.tsx:89-124`)
 
 ```typescript
 const statusMap = useMap('proclaimStatus');
-const presentationsMap = useMap('proclaimPresentations');
-// reads: presentation.title, presentation.slides (cast as {title: string; slides: string[]})
+const serviceItemsMap = useMap('proclaimServiceItems');
+// reads: serviceItem.title, serviceItem.slides (cast as {title: string; slides: string[]})
 ```
 
 ---
@@ -225,7 +225,7 @@ Max 20 iterations. AbortController for cancellation.
 
 ### Tool: get_service_order
 
-Reads `proclaimServiceOrder` Y.Array and `proclaimPresentations` Y.Map.
+Reads `proclaimServiceOrder` Y.Array and `proclaimServiceItems` Y.Map.
 Returns:
 ```json
 {

--- a/docs/agent-research.md
+++ b/docs/agent-research.md
@@ -1,0 +1,457 @@
+# Slide Translation Agent: Technical Reference
+
+Dense reference for AI agents implementing the plan in
+`PLAN_slide_translation_agent.md`. Contains findings from prior research,
+gotchas discovered during prototyping, and ready-to-use code fragments.
+
+---
+
+## 1. Proclaim Data Model (as of main)
+
+### ServiceItemWithSlides dataclass (`proclaim_lib.py:24-28`)
+
+```python
+@dataclass
+class ServiceItemWithSlides:
+    itemId: str
+    title: str
+    slides: List[str]
+    itemKind: str
+```
+
+Phase 2 adds: `sourceSlides: Optional[List[str]] = None`,
+`storedTranslation: Optional[List[str]] = None`.
+
+### Yjs data written by proclaim_service.py
+
+```python
+# proclaimPresentations Y.Map — keyed by item_id
+presentations_map[item_id] = {
+    'title': str,
+    'itemId': str,
+    'slides': list[str],  # currently = translation-screen content
+}
+
+# proclaimStatus Y.Map
+status_map['itemId'] = str
+status_map['slideIndex'] = int
+```
+
+Phase 2 adds `sourceSlides`, `storedTranslation`, `itemKind` to the
+presentations_map entry. Phase 3 adds `proclaimServiceOrder` Y.Array.
+
+### CurrentSlideViewer reads from Yjs (`CurrentSlideViewer.tsx:89-124`)
+
+```typescript
+const statusMap = useMap('proclaimStatus');
+const presentationsMap = useMap('proclaimPresentations');
+// reads: presentation.title, presentation.slides (cast as {title: string; slides: string[]})
+```
+
+---
+
+## 2. Proclaim DB Content Format — Critical Gotchas
+
+### VirtualScreens is double-encoded JSON
+
+The `presentation_row.content` is a parsed dict, but its `VirtualScreens`
+value is a **JSON string** that must be parsed again:
+
+```python
+content = presentation_row['content']  # already a dict
+virtual_screens = json.loads(content.get('VirtualScreens', '[]'))  # parse string → list
+```
+
+Example raw value:
+```json
+"[{\"outputKind\": \"Slides\", \"name\": \"Main Screen\"}, {\"outputKind\": \"SlidesAlternateContent\", \"name\": \"French or Haitian\"}]"
+```
+
+**Gotcha**: Test fixtures must store VirtualScreens as a JSON string, not a
+parsed list. The synthetic fixture was broken until this was corrected.
+
+### Service item IDs: dashed vs undashed
+
+The API returns dashed IDs (`item-song-001`), but the DB strips dashes
+(`itemsong001`). `parse_item_translation()` does
+`item_id.replace('-', '')` before DB lookup.
+
+**Gotcha**: MockProclaimDB must index both forms:
+```python
+for key, row in snapshot['service_items'].items():
+    self._items[key] = row
+    self._items[key.replace('-', '')] = row
+```
+
+### Translation screen index is 1-indexed in detection, 0-indexed in keys
+
+`get_translation_screen_idx()` returns 1-based index among slide screens.
+But the content key uses `idx-1`:
+
+```python
+translation_key = f'slideOutput:{translation_screen_idx-1}:RichTextXml'
+```
+
+For a presentation with screens [Main, French, Green], the French screen is
+at index 1 among slide screens, and the key is `slideOutput:0:RichTextXml`.
+
+### Rich text XML format
+
+```xml
+<Paragraph Language="fr-FR" Margin="0,0,0,0">
+    <Run Text="Grâce infinie" />
+</Paragraph>
+<Paragraph Language="fr-FR" Margin="0,0,0,0">
+    <Run Text="Qui m'a sauvé" />
+</Paragraph>
+```
+
+Decoded by `decode_richtext_xml()` using lxml. The XML is NOT a complete
+document — it's wrapped in `<Song>...</Song>` before parsing.
+
+### Content keys by item kind
+
+```python
+MAIN_CONTENT_KEYS = {
+    'SongLyrics': '_richtextfield:Lyrics',
+    'Content': '_richtextfield:Main Content',
+    'BiblePassage': '_richtextfield:Passage',
+}
+```
+
+Translation-screen content uses: `slideOutput:{idx-1}:RichTextXml`
+
+### Song section parsing
+
+Songs have sections (Verse, Chorus, Bridge, etc.) parsed by
+`split_into_song_sections()`. The `CustomOrderSequence` field (e.g.,
+`"V1, C1"`) controls slide ordering via `get_slides_in_order()`.
+
+`SongDisplayTitle` provides the display title (e.g.,
+"Amazing Grace (My Chains Are Gone)"), inserted as the first slide.
+
+### Blank/skip items
+
+These produce `slides=['']`:
+- `itemKind == 'ImageSlideshow'`
+- `title.lower() in ('blank', 'ncf slide', 'offering slide')`
+
+### Content slide splitting
+
+Non-song content splits on `--` delimiter via `split_into_slides()`.
+
+### Translation screen interleaving
+
+The single "French or Haitian" screen interleaves both languages. Songs
+might have French translation while spoken content has Haitian Creole.
+The `storedTranslation` field captures whatever is on that screen without
+language tagging.
+
+---
+
+## 3. Gemini Function Calling Format
+
+### Request format (server-side)
+
+```typescript
+const model = genAI.getGenerativeModel({
+  model: 'gemini-2.5-flash',
+  tools: [{
+    functionDeclarations: [
+      {
+        name: 'get_service_order',
+        description: 'Get the current presentation service order with all items',
+        parameters: { type: 'object', properties: {} }
+      },
+      {
+        name: 'write_item_translation',
+        description: 'Write translated slides for a service item',
+        parameters: {
+          type: 'object',
+          properties: {
+            itemId: { type: 'string' },
+            language: { type: 'string' },
+            slides: { type: 'array', items: { type: 'string' } },
+            sourceHash: { type: 'string' }
+          },
+          required: ['itemId', 'language', 'slides']
+        }
+      }
+    ]
+  }]
+});
+```
+
+### Response structure
+
+Gemini response `candidate.content.parts` contains mixed parts:
+- `{ text: "I'll translate..." }` — text response
+- `{ functionCall: { name: "write_item_translation", args: {...} } }` — tool call
+
+Multiple function calls can appear in a single response.
+
+### Tool result format (sent back as user message)
+
+```typescript
+{
+  role: 'user',
+  parts: [{
+    functionResponse: {
+      name: 'write_item_translation',
+      response: { success: true }
+    }
+  }]
+}
+```
+
+**Gotcha**: Gemini requires tool results as role `user`, not a separate
+`tool` role like OpenAI.
+
+---
+
+## 4. Client-Side Agent Architecture
+
+### Agent loop (useSlideAgent.ts)
+
+```
+User message → POST /api/chat → Gemini response
+  ↓
+Has function calls? → Execute tools (read/write Yjs) → Send results back → Loop
+  ↓ (no)
+Done — display assistant text
+```
+
+Max 20 iterations. AbortController for cancellation.
+
+### Tool: get_service_order
+
+Reads `proclaimServiceOrder` Y.Array and `proclaimPresentations` Y.Map.
+Returns:
+```json
+{
+  "items": [
+    {
+      "id": "item-song-001",
+      "title": "Amazing Grace",
+      "kind": "SongLyrics",
+      "sourceSlides": ["Amazing Grace (My Chains Are Gone)", "Amazing grace..."],
+      "storedTranslation": ["Grâce infinie", "Grâce infinie si douce..."],
+      "sourceHash": "a1b2c3d4"
+    }
+  ]
+}
+```
+
+### Tool: write_item_translation
+
+Writes to `slideTranslations` Y.Map:
+```typescript
+const key = `${itemId}:${language}`;
+slideTranslationsMap.set(key, { slides, sourceHash, updatedAt });
+```
+
+### sourceHash for staleness
+
+djb2 hash of `sourceSlides.join('|')`. If Proclaim source changes, hash
+changes, and cached translations are stale.
+
+```typescript
+function createHash(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) & 0xffffffff;
+  }
+  return (hash >>> 0).toString(16);
+}
+```
+
+---
+
+## 5. Existing Server Endpoints (server.ts)
+
+```
+GET  /api/config              — PostHog config {posthogKey, posthogHost}
+POST /api/ys-auth             — Y-Sweet auth tokens
+POST /api/requestTranslatedBlocks — Gemini translation (existing, for notes)
+POST /api/tts                 — ElevenLabs TTS
+GET  *                        — Static file serving
+```
+
+Phase 5 adds `POST /api/chat`.
+
+---
+
+## 6. Layout System (App.tsx)
+
+URL path encodes layout: rows separated by `|`, columns by `,`.
+
+Examples:
+- `/currentSlide` — single slide viewer
+- `/slideAgent,currentSlide-French` — agent chat + French slide viewer
+- `/translatedText-French,currentSlide` — text translation + slides
+
+Components registered via a map. Phase 4 adds `currentSlide-{language}`,
+Phase 7 adds `slideAgent`.
+
+---
+
+## 7. Test Infrastructure (Phase 1 ready-to-use)
+
+### Synthetic fixture: `tests/proclaim_snapshots/2026-01-05_synthetic.json`
+
+Shape:
+```json
+{
+  "captured_at": "2026-01-05T10:00:00+00:00",
+  "presentation_id": "aabbccdd11223344",
+  "status_response": { "presentationId": "...", "status": { "itemId": "...", "slideIndex": 0 } },
+  "onair_response": {
+    "serviceItems": [
+      { "id": "item-song-001", "title": "Amazing Grace", "kind": "SongLyrics", "slides": [...] },
+      { "id": "item-content-002", "title": "Call to Worship", "kind": "Content", "slides": [...] },
+      { "id": "item-bible-003", "title": "Romans 8:1-4", "kind": "BiblePassage", "slides": [...] },
+      { "id": "item-image-004", "title": "NCF Slide", "kind": "ImageSlideshow", "slides": [] },
+      { "id": "item-blank-005", "title": "Blank", "kind": "Content", "slides": [] }
+    ]
+  },
+  "presentation_row": {
+    "id": "aabbccdd11223344",
+    "content": {
+      "VirtualScreens": "[{...JSON string...}]"  // MUST be JSON string, not parsed list
+    }
+  },
+  "service_items": {
+    "item-song-001": {
+      "ServiceItemId": "itemsong001",
+      "ServiceItemKind": "SongLyrics",
+      "Title": "Amazing Grace",
+      "Content": "{...JSON string with _richtextfield:Lyrics, slideOutput:0:RichTextXml, CustomOrderSequence, SongDisplayTitle...}"
+    }
+  }
+}
+```
+
+Key: `service_items` is keyed by dashed ID. Each `Content` field is a JSON
+string containing the rich text XML fields.
+
+### MockProclaimDB (`tests/conftest.py`)
+
+```python
+class MockProclaimDB:
+    def __init__(self, snapshot):
+        self._items = {}
+        for key, row in snapshot['service_items'].items():
+            self._items[key] = row
+            self._items[key.replace('-', '')] = row  # both forms
+        self._presentation = snapshot['presentation_row']
+
+    def get_service_item(self, item_id):
+        return self._items.get(item_id)
+
+    def get_presentation(self, presentation_id):
+        # ID matching with dash stripping
+```
+
+### Parametrized fixture
+
+```python
+SNAPSHOT_DIR = Path(__file__).parent / 'proclaim_snapshots'
+
+@pytest.fixture(params=_snapshot_files(), ids=_snapshot_ids())
+def snapshot(request):
+    return json.loads(Path(request.param).read_text())
+```
+
+All tests in `test_proclaim_pipeline.py` accept `snapshot` fixture and run
+against every `.json` file in the snapshots directory.
+
+### Capture tool (`proclaim_capture.py`)
+
+Env var `PROCLAIM_CAPTURE_DIR` enables capture in `proclaim_service.py`.
+`capture_snapshot()` gathers: API status response, onair response, all
+service item DB rows, presentation row. `save_snapshot()` writes to
+`YYYY-MM-DD_{hash8}.json` with dedup (won't overwrite if content matches).
+
+### pyproject.toml additions
+
+```toml
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+```
+
+`pythonpath = ["."]` is needed so `from conftest import MockProclaimDB`
+works (tests/ is not a package).
+
+---
+
+## 8. parse_item_slides Implementation Notes (Phase 2)
+
+The new function extracts both main and translation content. Key logic:
+
+```python
+def parse_item_slides(db, item_id, translation_idx=None):
+    service_item = db.get_service_item(item_id.replace('-', ''))
+    content = json.loads(service_item['Content'])
+    item_kind = service_item['ServiceItemKind']
+
+    # Blank items
+    if item_kind in ["ImageSlideshow"] or title.lower() in BLANK_TITLES:
+        return ServiceItemWithSlides(slides=[''], sourceSlides=[''], ...)
+
+    # Main-screen content (always)
+    main_key = MAIN_CONTENT_KEYS.get(item_kind)
+    main_xml = content.get(main_key)
+    source_slides = _xml_to_slides(main_xml, item_kind, content)
+
+    # Translation-screen content (optional)
+    stored_translation = None
+    if translation_idx is not None:
+        trans_key = f'slideOutput:{translation_idx-1}:RichTextXml'
+        if trans_key in content:
+            trans_xml = content[trans_key]
+            stored_translation = _xml_to_slides(trans_xml, item_kind, content)
+
+    # Backward compat: slides = translation if available, else source
+    slides = stored_translation if stored_translation else source_slides
+
+    return ServiceItemWithSlides(
+        itemId=item_id, title=title, slides=slides,
+        sourceSlides=source_slides, storedTranslation=stored_translation,
+        itemKind=item_kind,
+    )
+```
+
+`_xml_to_slides()` handles the item-kind-specific parsing:
+- SongLyrics: decode XML → split sections → order by CustomOrderSequence →
+  prepend SongDisplayTitle
+- Content: decode XML → split on `--` delimiter
+- BiblePassage: decode XML → single slide (or split on `--`)
+
+---
+
+## 9. Proclaim API Endpoints (local, port 52195)
+
+```
+GET /api/presentations/current          — current presentation ID
+GET /api/presentations/{id}/onair       — service order with item metadata
+GET /api/presentations/{id}/status      — current item and slide index
+```
+
+The Python service polls these every ~1 second.
+
+---
+
+## 10. Key File Locations on main
+
+```
+proclaim_lib.py              — Parsing library (ServiceItemWithSlides, parse_item_translation, etc.)
+proclaim_service.py          — Proclaim→Yjs sync service (ProclaimYjsService)
+src/CurrentSlideViewer.tsx   — Slide viewer (pure component + Yjs container)
+src/App.tsx                  — Layout system, component registry
+server.ts                    — Express backend
+src/translationUtils.ts      — Notes translation pipeline (separate from slide translation)
+src/useTTS.ts                — TTS hook
+src/strings.ts               — UI localization strings
+src/useLocale.ts             — Locale resolution
+```

--- a/dump-docs.ts
+++ b/dump-docs.ts
@@ -214,10 +214,10 @@ async function dumpDocument(docId: string): Promise<any> {
       data.notesTranslationCache = serializeMap(notesTranslationCache);
     }
 
-    // proclaimPresentations (Map)
-    const proclaimPresentations = ydoc.getMap('proclaimPresentations');
-    if (proclaimPresentations.size > 0) {
-      data.proclaimPresentations = serializeMap(proclaimPresentations);
+    // proclaimServiceItems (Map)
+    const proclaimServiceItems = ydoc.getMap('proclaimServiceItems');
+    if (proclaimServiceItems.size > 0) {
+      data.proclaimServiceItems = serializeMap(proclaimServiceItems);
     }
 
     // proclaimStatus (Map)

--- a/proclaim_capture.py
+++ b/proclaim_capture.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Capture a snapshot of the current Proclaim session for offline testing.
+
+Reads from the Proclaim local API and database, writes a JSON file compatible
+with tests/conftest.py MockProclaimDB and the proclaim_snapshots/ fixtures.
+
+Usage:
+    uv run proclaim_capture.py [--output PATH]
+"""
+
+import argparse
+import asyncio
+import json
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict
+
+import httpx
+
+from proclaim_lib import ProclaimDB, find_presentation_db
+
+PROCLAIM_BASE_URL = "http://127.0.0.1:52195"
+DEFAULT_OUTPUT_DIR = Path(__file__).parent / "tests" / "proclaim_snapshots"
+
+
+async def get_session_id(client: httpx.AsyncClient) -> str:
+    r = await client.get(f"{PROCLAIM_BASE_URL}/onair/session", timeout=5.0)
+    r.raise_for_status()
+    return r.content.decode("utf-8-sig")
+
+
+async def get_onair_presentation(client: httpx.AsyncClient, session_id: str) -> Dict[str, Any]:
+    r = await client.get(
+        f"{PROCLAIM_BASE_URL}/presentations/onair",
+        headers={"OnAirSessionId": session_id},
+        timeout=5.0,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+async def get_status(client: httpx.AsyncClient, session_id: str) -> Dict[str, Any]:
+    r = await client.get(
+        f"{PROCLAIM_BASE_URL}/onair/statusChanged",
+        headers={"OnAirSessionId": session_id},
+        timeout=5.0,
+    )
+    if r.status_code == 404:
+        return {}
+    r.raise_for_status()
+    return r.json()
+
+
+async def capture(output_path: Path) -> None:
+    db_path = find_presentation_db()
+    print(f"Using database: {db_path}")
+    db = ProclaimDB(db_path)
+
+    async with httpx.AsyncClient() as client:
+        session_id = await get_session_id(client)
+        presentation = await get_onair_presentation(client, session_id)
+        status = await get_status(client, session_id)
+
+    service_items_meta = presentation.get("serviceItems", [])
+    if not service_items_meta:
+        print("No service items found in on-air presentation.")
+        return
+
+    # VirtualScreens lives in the DB presentation, not the API response.
+    # Get it via the presentationId from the status response.
+    presentation_id = status.get("presentationId")
+    presentation_content_raw: Dict[str, Any] = {}
+    if presentation_id:
+        pres_data = db.get_presentation(presentation_id)
+        if pres_data:
+            presentation_content_raw = pres_data["content"]
+            print(f"Presentation: {presentation_id}")
+        else:
+            print(f"WARNING: presentation {presentation_id} not found in DB")
+    else:
+        print("WARNING: no presentationId in status response — VirtualScreens will be empty")
+
+    service_items = []
+    for meta in service_items_meta:
+        item_id = meta["id"]
+        row = db.get_service_item(item_id.replace("-", ""))
+        if row is None:
+            print(f"  WARNING: item {item_id} not found in DB, skipping")
+            continue
+
+        content_dict = json.loads(row.get("Content", "{}"))
+        service_items.append({
+            "ServiceItemId": row["ServiceItemId"],
+            "Title": row.get("Title", ""),
+            "ServiceItemKind": row.get("ServiceItemKind", "Unknown"),
+            "content_dict": content_dict,
+        })
+        print(f"  Captured: {row.get('Title', item_id)} ({row.get('ServiceItemKind', '?')})")
+
+    current_status = status.get("status", {})
+    print(f"Current item: {current_status.get('itemId')} slide {current_status.get('slideIndex')}")
+
+    snapshot = {
+        "date": date.today().isoformat(),
+        "note": "Captured from live Proclaim session",
+        "presentation_content": presentation_content_raw,
+        "current_status": current_status,
+        "service_items": service_items,
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(snapshot, indent=2))
+    print(f"\nSnapshot written to: {output_path}")
+    print(f"Total items: {len(service_items)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Capture Proclaim session snapshot for testing")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output JSON path (default: tests/proclaim_snapshots/YYYY-MM-DD_captured.json)",
+    )
+    args = parser.parse_args()
+
+    output = args.output or (DEFAULT_OUTPUT_DIR / f"{date.today().isoformat()}_captured.json")
+    asyncio.run(capture(output))
+
+
+if __name__ == "__main__":
+    main()

--- a/proclaim_lib.py
+++ b/proclaim_lib.py
@@ -336,7 +336,13 @@ def parse_item_translation(
     item_id: str,
     translation_screen_idx: Optional[int],
 ) -> Optional['ServiceItemWithSlides']:
-    """Extract slides for any item type, populating sourceSlides and storedTranslation."""
+    """Extract slides for any item type, populating sourceSlides and storedTranslation.
+
+    translation_screen_idx=None means no translation screen is configured for this
+    presentation. In that case storedTranslation is left as None and slides falls back
+    to sourceSlides (the untranslated main content). Returns None only if neither the
+    main content key nor the translation screen yields any content.
+    """
     service_item = db.get_service_item(item_id.replace('-', ''))
     if not service_item:
         logger.warning(f"Service item {item_id} not found")

--- a/proclaim_lib.py
+++ b/proclaim_lib.py
@@ -25,8 +25,13 @@ logger = logging.getLogger(__name__)
 class ServiceItemWithSlides:
     itemId: str
     title: str
+    # Legacy field: storedTranslation when present, else sourceSlides. Kept so
+    # CurrentSlideViewer (which reads only 'slides' from Yjs) keeps working
+    # until it's updated to prefer sourceSlides + agent translations.
     slides: List[str]
     itemKind: str
+    sourceSlides: Optional[List[str]] = None       # main-screen (untranslated)
+    storedTranslation: Optional[List[str]] = None  # translation-screen content from Proclaim
 
 
 def find_presentation_db() -> str:
@@ -269,12 +274,69 @@ def get_slides_for_song(content: dict, content_key: str = '_richtextfield:Lyrics
     return split_into_slides(text)
 
 
+_MAIN_CONTENT_KEYS = {
+    'SongLyrics': '_richtextfield:Lyrics',
+    'Content': '_richtextfield:Main Content',
+    'BiblePassage': '_richtextfield:Passage',
+}
+
+
+def _parse_screen(content: dict, item_kind: str, screen_idx: Optional[int]) -> Optional[List[str]]:
+    """Extract slides for one virtual screen.
+
+    screen_idx=None → main content key for this item kind.
+    screen_idx=n    → slideOutput:{n-1}:RichTextXml.
+    Returns None if the key is absent from content.
+    """
+    if screen_idx is None:
+        key = _MAIN_CONTENT_KEYS.get(item_kind)
+        if not key or key not in content:
+            return None
+    else:
+        key = f'slideOutput:{screen_idx - 1}:RichTextXml'
+        if key not in content:
+            return None
+
+    text = decode_richtext_xml(content[key])
+
+    if item_kind == 'SongLyrics':
+        sections = split_into_song_sections(text)
+        order_str = content.get('CustomOrderSequence', '')
+        slides = get_slides_in_order(sections, order_str)
+        if title := content.get('SongDisplayTitle'):
+            slides.insert(0, title)
+    else:
+        slides = split_into_slides(text)
+
+    return slides
+
+
+def item_to_yjs_dict(item: 'ServiceItemWithSlides') -> dict:
+    """Convert a ServiceItemWithSlides to the dict written to Yjs.
+
+    The 'slides' field is storedTranslation ?? sourceSlides — it exists only
+    for backward compatibility with CurrentSlideViewer. New consumers should
+    read sourceSlides or storedTranslation directly.
+    """
+    d: Dict[str, Any] = {
+        'title': item.title,
+        'itemId': item.itemId,
+        'slides': item.slides,
+        'itemKind': item.itemKind,
+    }
+    if item.sourceSlides is not None:
+        d['sourceSlides'] = item.sourceSlides
+    if item.storedTranslation is not None:
+        d['storedTranslation'] = item.storedTranslation
+    return d
+
+
 def parse_item_translation(
-    db: ProclaimDB,
+    db: 'ProclaimDB',
     item_id: str,
-    translation_screen_idx: int,
-) -> Optional[ServiceItemWithSlides]:
-    """Extract translated slides for any item type."""
+    translation_screen_idx: Optional[int],
+) -> Optional['ServiceItemWithSlides']:
+    """Extract slides for any item type, populating sourceSlides and storedTranslation."""
     service_item = db.get_service_item(item_id.replace('-', ''))
     if not service_item:
         logger.warning(f"Service item {item_id} not found")
@@ -292,46 +354,30 @@ def parse_item_translation(
                 title=item_title,
                 slides=[''],
                 itemKind=item_kind,
+                sourceSlides=[''],
+                storedTranslation=None,
             )
 
-        translation_key = f'slideOutput:{translation_screen_idx-1}:RichTextXml'
+        source = _parse_screen(content, item_kind, None)
+        stored = _parse_screen(content, item_kind, translation_screen_idx) if translation_screen_idx is not None else None
 
-        # Try translation first, fall back to main content
-        if translation_key in content:
-            source_xml = content[translation_key]
-        else:
-            # Fall back to main slide text
-            main_content_keys = {
-                'SongLyrics': '_richtextfield:Lyrics',
-                'Content': '_richtextfield:Main Content',
-                'BiblePassage': '_richtextfield:Passage',
-            }
-            fallback_key = main_content_keys.get(item_kind)
-            if fallback_key and fallback_key in content:
-                logger.warning(f"No translation for {item_id}, falling back to main content")
-                source_xml = content[fallback_key]
-            else:
-                logger.warning(f"No translation or main content found for {item_id}")
-                return None
+        if stored is None and source is None:
+            logger.warning(f"No content found for {item_id}")
+            return None
 
-        source_text = decode_richtext_xml(source_xml)
+        if stored is None and source is not None:
+            logger.warning(f"No translation screen content for {item_id}, using source")
 
-        if item_kind == 'SongLyrics':
-            sections = split_into_song_sections(source_text)
-            order_str = content.get('CustomOrderSequence', '')
-            slides = get_slides_in_order(sections, order_str)
-
-            if title := content.get('SongDisplayTitle'):
-                slides.insert(0, title)
-        else:
-            slides = split_into_slides(source_text)
+        slides = stored or source
 
         return ServiceItemWithSlides(
             itemId=item_id,
             title=item_title,
             slides=slides,
             itemKind=item_kind,
+            sourceSlides=source,
+            storedTranslation=stored,
         )
     except Exception as e:
-        logger.error(f"Error parsing translation for {item_id}: {e}")
+        logger.error(f"Error parsing item {item_id}: {e}")
         return None

--- a/proclaim_service.py
+++ b/proclaim_service.py
@@ -174,7 +174,7 @@ class ProclaimYjsService:
 
         # Yjs state
         self.ydoc: Doc = Doc()
-        self.presentations_map = self.ydoc.get('proclaimPresentations', type=Map)
+        self.service_items_map = self.ydoc.get('proclaimServiceItems', type=Map)
         self.status_map = self.ydoc.get('proclaimStatus', type=Map)
 
         # State tracking
@@ -212,12 +212,12 @@ class ProclaimYjsService:
             return response.json()
 
 
-    def update_presentation_item_in_yjs(self, presentation_data: ServiceItemWithSlides):
-        """Store full presentation data in Yjs"""
+    def update_service_item_in_yjs(self, presentation_data: ServiceItemWithSlides):
+        """Store full service item data in Yjs"""
         item_id = presentation_data.itemId
 
         with self.ydoc.transaction():
-            self.presentations_map[item_id] = item_to_yjs_dict(presentation_data)
+            self.service_items_map[item_id] = item_to_yjs_dict(presentation_data)
 
         logger.info(f"Stored service item {item_id} ({presentation_data.title}) with {len(presentation_data.slides)} slides")
 
@@ -245,12 +245,12 @@ class ProclaimYjsService:
             logger.warning("No presentation ID in status response")
             return False
 
-        pres_data = self.db.get_presentation(presentation_id)
-        if not pres_data:
+        item_db_data = self.db.get_presentation(presentation_id)
+        if not item_db_data:
             logger.warning(f"Presentation {presentation_id} not found in database")
             return False
 
-        translation_idx = get_translation_screen_idx(pres_data['content'])
+        translation_idx = get_translation_screen_idx(item_db_data['content'])
         if translation_idx is None:
             logger.debug(f"No translation screen found in presentation {presentation_id}")
 
@@ -258,7 +258,7 @@ class ProclaimYjsService:
         if not item_with_slides:
             return False
 
-        self.update_presentation_item_in_yjs(item_with_slides)
+        self.update_service_item_in_yjs(item_with_slides)
         self.current_item_slides = item_with_slides
         self.update_status_in_yjs(item_id, slide_index)
         self.last_item_id = item_id

--- a/proclaim_service.py
+++ b/proclaim_service.py
@@ -67,6 +67,7 @@ from proclaim_lib import (
     ProclaimDB,
     get_translation_screen_idx,
     parse_item_translation,
+    item_to_yjs_dict,
 )
 
 # Configure logging (default level, can be overridden by --debug flag)
@@ -216,11 +217,7 @@ class ProclaimYjsService:
         item_id = presentation_data.itemId
 
         with self.ydoc.transaction():
-            self.presentations_map[item_id] = {
-                'title': presentation_data.title,
-                'itemId': item_id,
-                'slides': presentation_data.slides
-            }
+            self.presentations_map[item_id] = item_to_yjs_dict(presentation_data)
 
         logger.info(f"Stored service item {item_id} ({presentation_data.title}) with {len(presentation_data.slides)} slides")
 
@@ -255,8 +252,7 @@ class ProclaimYjsService:
 
         translation_idx = get_translation_screen_idx(pres_data['content'])
         if translation_idx is None:
-            logger.warning(f"No translation screen found in presentation {presentation_id}")
-            return False
+            logger.debug(f"No translation screen found in presentation {presentation_id}")
 
         item_with_slides = parse_item_translation(self.db, item_id, translation_idx)
         if not item_with_slides:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,10 @@ dependencies = [
 [dependency-groups]
 dev = [
     "mypy>=1.20.2",
+    "pytest>=9.0.3",
     "types-lxml>=2026.2.16",
 ]
+
+[tool.pytest]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/src/CurrentSlideViewer.tsx
+++ b/src/CurrentSlideViewer.tsx
@@ -89,7 +89,7 @@ export function CurrentSlideViewer({
 export function CurrentSlideViewerContainer() {
   const s = useStrings();
   const statusMap = useMap('proclaimStatus');
-  const presentationsMap = useMap('proclaimPresentations');
+  const serviceItemsMap = useMap('proclaimServiceItems');
 
   try {
     // Read current status
@@ -99,14 +99,14 @@ export function CurrentSlideViewerContainer() {
     }
     const slideIndex = (statusMap.get('slideIndex') as number) ?? 0;
 
-    // Read presentation data
-    const presentation = presentationsMap.get(itemId) as { title: string; slides: string[] } | undefined;
-    if (!presentation) {
-      throw new Error('Presentation not found');
+    // Read service item data
+    const serviceItem = serviceItemsMap.get(itemId) as { title: string; slides: string[] } | undefined;
+    if (!serviceItem) {
+      throw new Error('Service item not found');
     }
 
-    const title = presentation.title || s.untitledPresentation;
-    const slidesArray = presentation.slides || [];
+    const title = serviceItem.title || s.untitledPresentation;
+    const slidesArray = serviceItem.slides || [];
     const slides: string[] = [];
 
     if (slidesArray.length > 0) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+from proclaim_lib import get_translation_screen_idx
+
+SNAPSHOTS_DIR = Path(__file__).parent / "proclaim_snapshots"
+
+
+class MockProclaimDB:
+    def __init__(self, data: dict):
+        self._items: Dict[str, dict] = {
+            item["ServiceItemId"].replace("-", ""): item
+            for item in data["service_items"]
+        }
+
+    def get_service_item(self, item_id: str) -> Optional[Dict[str, Any]]:
+        item = self._items.get(item_id.replace("-", ""))
+        if item is None:
+            return None
+        result = dict(item)
+        if "content_dict" in result:
+            result["Content"] = json.dumps(result.pop("content_dict"))
+        return result
+
+
+@pytest.fixture(
+    params=sorted(p for p in SNAPSHOTS_DIR.glob("*.json") if not p.stem.endswith(".expected")),
+    ids=lambda p: p.stem,
+)
+def snapshot(request: pytest.FixtureRequest) -> dict:
+    return json.loads(request.param.read_text())
+
+
+@pytest.fixture
+def db(snapshot: dict) -> MockProclaimDB:
+    return MockProclaimDB(snapshot)
+
+
+@pytest.fixture
+def translation_idx(snapshot: dict) -> Optional[int]:
+    return get_translation_screen_idx(snapshot["presentation_content"])
+
+
+@pytest.fixture
+def expected(request: pytest.FixtureRequest, snapshot: dict) -> Optional[dict]:  # noqa: ARG001
+    """Load the .expected.json file for this snapshot, or None if absent."""
+    param_path: Path = request.node.callspec.params["snapshot"]  # type: ignore[attr-defined]
+    expected_path = param_path.with_suffix("").with_suffix(".expected.json")
+    if not expected_path.exists():
+        return None
+    return json.loads(expected_path.read_text())

--- a/tests/proclaim_snapshots/2026-01-05_synthetic.expected.json
+++ b/tests/proclaim_snapshots/2026-01-05_synthetic.expected.json
@@ -1,0 +1,54 @@
+{
+  "status": {
+    "itemId": "song001",
+    "slideIndex": 2
+  },
+  "presentations": [
+    {
+      "itemId": "song001",
+      "title": "Beautiful Savior",
+      "itemKind": "SongLyrics",
+      "slides": [
+        "Beautiful Savior",
+        "Ligne un du verset un\nLigne deux du verset un",
+        "Refrain ligne un\nRefrain ligne deux",
+        "Ligne un du verset deux\nLigne deux du verset deux"
+      ]
+    },
+    {
+      "itemId": "content001",
+      "title": "Call to Worship",
+      "itemKind": "Content",
+      "slides": [
+        "Premier texte d appel au culte",
+        "Deuxieme texte d appel au culte",
+        "Troisieme texte d appel au culte"
+      ]
+    },
+    {
+      "itemId": "bible001",
+      "title": "Scripture Reading",
+      "itemKind": "BiblePassage",
+      "slides": [
+        "John 3 16 \nFor God so loved the world",
+        "John 3 17 \nGod did not send his Son to condemn the world"
+      ]
+    },
+    {
+      "itemId": "image001",
+      "title": "Welcome Slides",
+      "itemKind": "ImageSlideshow",
+      "slides": [
+        ""
+      ]
+    },
+    {
+      "itemId": "blank001",
+      "title": "Blank",
+      "itemKind": "Content",
+      "slides": [
+        ""
+      ]
+    }
+  ]
+}

--- a/tests/proclaim_snapshots/2026-01-05_synthetic.expected.json
+++ b/tests/proclaim_snapshots/2026-01-05_synthetic.expected.json
@@ -5,10 +5,21 @@
   },
   "presentations": [
     {
-      "itemId": "song001",
       "title": "Beautiful Savior",
-      "itemKind": "SongLyrics",
+      "itemId": "song001",
       "slides": [
+        "Beautiful Savior",
+        "Ligne un du verset un\nLigne deux du verset un",
+        "Refrain ligne un\nRefrain ligne deux",
+        "Ligne un du verset deux\nLigne deux du verset deux"
+      ],
+      "itemKind": "SongLyrics",
+      "sourceSlides": [
+        "Beautiful Savior",
+        "Line one of verse one\nLine two of verse one",
+        "Line one of verse two\nLine two of verse two"
+      ],
+      "storedTranslation": [
         "Beautiful Savior",
         "Ligne un du verset un\nLigne deux du verset un",
         "Refrain ligne un\nRefrain ligne deux",
@@ -16,37 +27,57 @@
       ]
     },
     {
-      "itemId": "content001",
       "title": "Call to Worship",
-      "itemKind": "Content",
+      "itemId": "content001",
       "slides": [
+        "Premier texte d appel au culte",
+        "Deuxieme texte d appel au culte",
+        "Troisieme texte d appel au culte"
+      ],
+      "itemKind": "Content",
+      "sourceSlides": [
+        "First slide of call to worship",
+        "Second slide of call to worship",
+        "Third slide of call to worship"
+      ],
+      "storedTranslation": [
         "Premier texte d appel au culte",
         "Deuxieme texte d appel au culte",
         "Troisieme texte d appel au culte"
       ]
     },
     {
-      "itemId": "bible001",
       "title": "Scripture Reading",
-      "itemKind": "BiblePassage",
+      "itemId": "bible001",
       "slides": [
+        "John 3 16 \nFor God so loved the world",
+        "John 3 17 \nGod did not send his Son to condemn the world"
+      ],
+      "itemKind": "BiblePassage",
+      "sourceSlides": [
         "John 3 16 \nFor God so loved the world",
         "John 3 17 \nGod did not send his Son to condemn the world"
       ]
     },
     {
-      "itemId": "image001",
       "title": "Welcome Slides",
-      "itemKind": "ImageSlideshow",
+      "itemId": "image001",
       "slides": [
+        ""
+      ],
+      "itemKind": "ImageSlideshow",
+      "sourceSlides": [
         ""
       ]
     },
     {
-      "itemId": "blank001",
       "title": "Blank",
-      "itemKind": "Content",
+      "itemId": "blank001",
       "slides": [
+        ""
+      ],
+      "itemKind": "Content",
+      "sourceSlides": [
         ""
       ]
     }

--- a/tests/proclaim_snapshots/2026-01-05_synthetic.json
+++ b/tests/proclaim_snapshots/2026-01-05_synthetic.json
@@ -1,0 +1,53 @@
+{
+  "date": "2026-01-05",
+  "note": "Synthetic fixture: SongLyrics, Content, BiblePassage, ImageSlideshow, Blank",
+  "current_status": {
+    "itemId": "song001",
+    "slideIndex": 2
+  },
+  "presentation_content": {
+    "VirtualScreens": "[{\"outputKind\": \"Slides\", \"name\": \"Main\"}, {\"outputKind\": \"SlidesAlternateContent\", \"name\": \"French Translation\"}]"
+  },
+  "service_items": [
+    {
+      "ServiceItemId": "song001",
+      "Title": "Beautiful Savior",
+      "ServiceItemKind": "SongLyrics",
+      "content_dict": {
+        "_richtextfield:Lyrics": "<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Verse 1\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Line one of verse one\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Line two of verse one\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Chorus 1\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Chorus line one\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Chorus line two\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Verse 2\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Line one of verse two\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Line two of verse two\" /></Paragraph>",
+        "slideOutput:0:RichTextXml": "<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Verse 1\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Ligne un du verset un\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Ligne deux du verset un\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Chorus 1\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Refrain ligne un\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Refrain ligne deux\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Verse 2\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Ligne un du verset deux\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Ligne deux du verset deux\" /></Paragraph>",
+        "CustomOrderSequence": "v1,c,v2",
+        "SongDisplayTitle": "Beautiful Savior"
+      }
+    },
+    {
+      "ServiceItemId": "content001",
+      "Title": "Call to Worship",
+      "ServiceItemKind": "Content",
+      "content_dict": {
+        "_richtextfield:Main Content": "<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"First slide of call to worship\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"--\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Second slide of call to worship\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"--\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Third slide of call to worship\" /></Paragraph>",
+        "slideOutput:0:RichTextXml": "<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Premier texte d appel au culte\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"--\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Deuxieme texte d appel au culte\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"--\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"Troisieme texte d appel au culte\" /></Paragraph>"
+      }
+    },
+    {
+      "ServiceItemId": "bible001",
+      "Title": "Scripture Reading",
+      "ServiceItemKind": "BiblePassage",
+      "content_dict": {
+        "_richtextfield:Passage": "<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"John 3 16\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"For God so loved the world\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"John 3 17\" /></Paragraph>\n<Paragraph Language=\"en-US\" Margin=\"0,0,0,0\"><Run Text=\"God did not send his Son to condemn the world\" /></Paragraph>"
+      }
+    },
+    {
+      "ServiceItemId": "image001",
+      "Title": "Welcome Slides",
+      "ServiceItemKind": "ImageSlideshow",
+      "content_dict": {}
+    },
+    {
+      "ServiceItemId": "blank001",
+      "Title": "Blank",
+      "ServiceItemKind": "Content",
+      "content_dict": {}
+    }
+  ]
+}

--- a/tests/test_proclaim_pipeline.py
+++ b/tests/test_proclaim_pipeline.py
@@ -11,6 +11,7 @@ import pytest
 
 from proclaim_lib import (
     get_translation_screen_idx,
+    item_to_yjs_dict,
     parse_item_translation,
 )
 from tests.conftest import MockProclaimDB
@@ -80,22 +81,24 @@ def test_non_blank_items_have_nonempty_slides(snapshot: dict, db: MockProclaimDB
 
 
 def test_yjs_dict_has_required_keys(snapshot: dict, db: MockProclaimDB, translation_idx: Optional[int]):
-    """The dict written to Yjs must have title, itemId, and slides."""
+    """The dict written to Yjs must have the expected shape."""
     assert translation_idx is not None
     for item in snapshot["service_items"]:
         if item["ServiceItemKind"] in SKIPPED_KINDS:
             continue
         result = parse_item_translation(db, item["ServiceItemId"], translation_idx)
         assert result is not None, f"parse returned None for {item['ServiceItemId']} ({item['Title']})"
-        yjs_dict = {
-            "title": result.title,
-            "itemId": result.itemId,
-            "slides": result.slides,
-        }
-        assert isinstance(yjs_dict["title"], str)
-        assert isinstance(yjs_dict["itemId"], str)
-        assert isinstance(yjs_dict["slides"], list)
-        assert all(isinstance(s, str) for s in yjs_dict["slides"])
+        d = item_to_yjs_dict(result)
+        assert isinstance(d["title"], str)
+        assert isinstance(d["itemId"], str)
+        assert isinstance(d["itemKind"], str)
+        assert isinstance(d["slides"], list)
+        assert all(isinstance(s, str) for s in d["slides"])
+        assert isinstance(d["sourceSlides"], list)
+        assert all(isinstance(s, str) for s in d["sourceSlides"])
+        if "storedTranslation" in d:
+            assert isinstance(d["storedTranslation"], list)
+            assert all(isinstance(s, str) for s in d["storedTranslation"])
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +180,48 @@ def test_blank_title_item_is_blank(syn):
     result = parse_item_translation(db, "blank001", idx)
     assert result is not None
     assert result.slides == [""]
+
+
+def test_source_slides_are_english(syn):
+    db, idx = syn
+    result = parse_item_translation(db, "song001", idx)
+    assert result is not None
+    assert result.sourceSlides is not None
+    assert any("verse one" in s.lower() for s in result.sourceSlides), result.sourceSlides
+
+
+def test_stored_translation_is_french(syn):
+    db, idx = syn
+    result = parse_item_translation(db, "song001", idx)
+    assert result is not None
+    assert result.storedTranslation is not None
+    assert any("Ligne" in s or "Refrain" in s for s in result.storedTranslation), result.storedTranslation
+
+
+def test_slides_equals_stored_translation_when_present(syn):
+    db, idx = syn
+    result = parse_item_translation(db, "song001", idx)
+    assert result is not None
+    assert result.slides == result.storedTranslation
+
+
+def test_bible_has_source_slides_no_stored_translation(syn):
+    db, idx = syn
+    result = parse_item_translation(db, "bible001", idx)
+    assert result is not None
+    assert result.sourceSlides is not None
+    assert result.storedTranslation is None
+    assert result.slides == result.sourceSlides
+
+
+def test_no_translation_screen_returns_source(syn):
+    """parse_item_translation with translation_idx=None populates only sourceSlides."""
+    db, _ = syn
+    result = parse_item_translation(db, "content001", None)
+    assert result is not None
+    assert result.storedTranslation is None
+    assert result.sourceSlides is not None
+    assert result.slides == result.sourceSlides
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_proclaim_pipeline.py
+++ b/tests/test_proclaim_pipeline.py
@@ -1,0 +1,208 @@
+"""Integration tests for the Proclaim parsing pipeline.
+
+These tests run against all snapshots in proclaim_snapshots/ (parametrized via conftest).
+"""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from proclaim_lib import (
+    get_translation_screen_idx,
+    parse_item_translation,
+)
+from tests.conftest import MockProclaimDB
+
+SYNTHETIC = Path(__file__).parent / "proclaim_snapshots" / "2026-01-05_synthetic.json"
+
+
+# ---------------------------------------------------------------------------
+# Generic tests — run against every snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_translation_screen_detected(snapshot: dict, translation_idx: Optional[int]):
+    """Every snapshot must have exactly one translation screen."""
+    assert translation_idx is not None, "Expected a translation screen in VirtualScreens"
+
+
+SKIPPED_KINDS = {"Grouping"}  # organizational items with no slide content
+
+
+def test_all_items_parse_without_error(snapshot: dict, db: MockProclaimDB, translation_idx: Optional[int]):
+    """Parsing must not raise for any item (may return None for structural items)."""
+    assert translation_idx is not None
+    for item in snapshot["service_items"]:
+        if item["ServiceItemKind"] in SKIPPED_KINDS:
+            continue
+        result = parse_item_translation(db, item["ServiceItemId"], translation_idx)
+        assert result is not None, f"parse_item_translation returned None for {item['ServiceItemId']} ({item['Title']})"
+
+
+def test_blank_items_produce_single_blank_slide(snapshot: dict, db: MockProclaimDB, translation_idx: Optional[int]):
+    assert translation_idx is not None
+    blank_kinds = {"ImageSlideshow"}
+    blank_titles = {"blank", "ncf slide", "offering slide"}
+    for item in snapshot["service_items"]:
+        if item["ServiceItemKind"] in SKIPPED_KINDS:
+            continue
+        is_blank = (
+            item["ServiceItemKind"] in blank_kinds
+            or item["Title"].lower() in blank_titles
+        )
+        if is_blank:
+            result = parse_item_translation(db, item["ServiceItemId"], translation_idx)
+            assert result is not None
+            assert result.slides == [""], (
+                f"Blank item {item['ServiceItemId']} should have slides=[''], got {result.slides}"
+            )
+
+
+def test_non_blank_items_have_nonempty_slides(snapshot: dict, db: MockProclaimDB, translation_idx: Optional[int]):
+    assert translation_idx is not None
+    blank_kinds = {"ImageSlideshow"}
+    blank_titles = {"blank", "ncf slide", "offering slide"}
+    for item in snapshot["service_items"]:
+        if item["ServiceItemKind"] in SKIPPED_KINDS:
+            continue
+        is_blank = (
+            item["ServiceItemKind"] in blank_kinds
+            or item["Title"].lower() in blank_titles
+        )
+        if not is_blank:
+            result = parse_item_translation(db, item["ServiceItemId"], translation_idx)
+            assert result is not None, f"parse returned None for {item['ServiceItemId']} ({item['Title']})"
+            assert any(s.strip() for s in result.slides), (
+                f"Non-blank item {item['ServiceItemId']} has no non-empty slides: {result.slides}"
+            )
+
+
+def test_yjs_dict_has_required_keys(snapshot: dict, db: MockProclaimDB, translation_idx: Optional[int]):
+    """The dict written to Yjs must have title, itemId, and slides."""
+    assert translation_idx is not None
+    for item in snapshot["service_items"]:
+        if item["ServiceItemKind"] in SKIPPED_KINDS:
+            continue
+        result = parse_item_translation(db, item["ServiceItemId"], translation_idx)
+        assert result is not None, f"parse returned None for {item['ServiceItemId']} ({item['Title']})"
+        yjs_dict = {
+            "title": result.title,
+            "itemId": result.itemId,
+            "slides": result.slides,
+        }
+        assert isinstance(yjs_dict["title"], str)
+        assert isinstance(yjs_dict["itemId"], str)
+        assert isinstance(yjs_dict["slides"], list)
+        assert all(isinstance(s, str) for s in yjs_dict["slides"])
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-fixture-specific tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def syn():
+    data = json.loads(SYNTHETIC.read_text())
+    db = MockProclaimDB(data)
+    idx = get_translation_screen_idx(data["presentation_content"])
+    return db, idx
+
+
+def test_translation_screen_is_index_1(syn):
+    _, idx = syn
+    assert idx == 1
+
+
+def test_song_title_is_first_slide(syn):
+    db, idx = syn
+    result = parse_item_translation(db, "song001", idx)
+    assert result is not None
+    assert result.slides[0] == "Beautiful Savior"
+
+
+def test_song_custom_order_v1_c_v2(syn):
+    db, idx = syn
+    result = parse_item_translation(db, "song001", idx)
+    assert result is not None
+    # Title + 3 sections (v1, chorus, v2) from custom order "v1,c,v2"
+    assert len(result.slides) == 4
+
+
+def test_song_uses_french_translation_screen(syn):
+    db, idx = syn
+    result = parse_item_translation(db, "song001", idx)
+    assert result is not None
+    # French content should appear somewhere in slides
+    french_content = any("Ligne" in slide or "Refrain" in slide for slide in result.slides)
+    assert french_content, f"Expected French content in slides: {result.slides}"
+
+
+def test_content_delimiter_splitting(syn):
+    db, idx = syn
+    result = parse_item_translation(db, "content001", idx)
+    assert result is not None
+    # Content uses '--' delimiter → 3 slides
+    assert len(result.slides) == 3
+
+
+def test_content_uses_french_translation(syn):
+    db, idx = syn
+    result = parse_item_translation(db, "content001", idx)
+    assert result is not None
+    assert any("texte" in slide.lower() for slide in result.slides), (
+        f"Expected French content in slides: {result.slides}"
+    )
+
+
+def test_bible_falls_back_to_source(syn):
+    db, idx = syn
+    result = parse_item_translation(db, "bible001", idx)
+    assert result is not None
+    # No translation screen for Bible → falls back to Passage
+    assert any("John" in slide for slide in result.slides)
+
+
+def test_image_slideshow_is_blank(syn):
+    db, idx = syn
+    result = parse_item_translation(db, "image001", idx)
+    assert result is not None
+    assert result.slides == [""]
+
+
+def test_blank_title_item_is_blank(syn):
+    db, idx = syn
+    result = parse_item_translation(db, "blank001", idx)
+    assert result is not None
+    assert result.slides == [""]
+
+
+# ---------------------------------------------------------------------------
+# Expected-output comparison — run on any snapshot that has an .expected.json
+# ---------------------------------------------------------------------------
+
+
+def test_matches_expected(
+    snapshot: dict,
+    db: MockProclaimDB,
+    translation_idx: Optional[int],
+    expected: Optional[dict],
+) -> None:
+    """Full parse output must match the approved .expected.json file.
+
+    Run ``uv run tests/update_expected.py --force`` to regenerate expected files
+    after an intentional change.
+    """
+    if expected is None:
+        pytest.skip("no .expected.json for this snapshot")
+    assert translation_idx is not None
+
+    from tests.update_expected import build_expected
+
+    actual = build_expected(snapshot)
+    assert actual == expected, (
+        "Parse output differs from expected. "
+        "If this is intentional, run: uv run tests/update_expected.py --force"
+    )

--- a/tests/update_expected.py
+++ b/tests/update_expected.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Regenerate .expected.json files from .json snapshot files.
+
+Run after capturing a new snapshot or when parse output intentionally changes:
+    uv run tests/update_expected.py [snapshot_stem ...]
+
+With no arguments, updates all snapshots that lack an expected file.
+Pass snapshot stems to update specific ones:
+    uv run tests/update_expected.py 2026-05-02_captured
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from proclaim_lib import get_translation_screen_idx, parse_item_translation
+from tests.conftest import MockProclaimDB
+
+SNAPSHOTS_DIR = Path(__file__).parent / "proclaim_snapshots"
+SKIPPED_KINDS = {"Grouping"}
+
+
+def build_expected(snapshot: dict) -> dict:
+    db = MockProclaimDB(snapshot)
+    translation_idx = get_translation_screen_idx(snapshot["presentation_content"])
+
+    presentations = []
+    for item in snapshot["service_items"]:
+        if item["ServiceItemKind"] in SKIPPED_KINDS:
+            continue
+        result = parse_item_translation(db, item["ServiceItemId"], translation_idx)
+        if result is None:
+            continue
+        presentations.append({
+            "itemId": result.itemId,
+            "title": result.title,
+            "itemKind": result.itemKind,
+            "slides": result.slides,
+        })
+
+    return {
+        "status": snapshot.get("current_status"),
+        "presentations": presentations,
+    }
+
+
+def update(path: Path, force: bool = False) -> None:
+    expected_path = path.with_suffix("").with_suffix(".expected.json")
+    if expected_path.exists() and not force:
+        print(f"  skipping (already exists): {expected_path.name}")
+        return
+
+    snapshot = json.loads(path.read_text())
+    expected = build_expected(snapshot)
+    expected_path.write_text(json.dumps(expected, indent=2, ensure_ascii=False))
+    print(f"  wrote: {expected_path.name}")
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    force = "--force" in args
+    stems = [a for a in args if not a.startswith("--")]
+
+    if stems:
+        paths = [SNAPSHOTS_DIR / f"{stem}.json" for stem in stems]
+    else:
+        paths = sorted(SNAPSHOTS_DIR.glob("*.json"))
+
+    for path in paths:
+        update(path, force=force)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/update_expected.py
+++ b/tests/update_expected.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from proclaim_lib import get_translation_screen_idx, parse_item_translation
+from proclaim_lib import get_translation_screen_idx, item_to_yjs_dict, parse_item_translation
 from tests.conftest import MockProclaimDB
 
 SNAPSHOTS_DIR = Path(__file__).parent / "proclaim_snapshots"
@@ -34,12 +34,7 @@ def build_expected(snapshot: dict) -> dict:
         result = parse_item_translation(db, item["ServiceItemId"], translation_idx)
         if result is None:
             continue
-        presentations.append({
-            "itemId": result.itemId,
-            "title": result.title,
-            "itemKind": result.itemKind,
-            "slides": result.slides,
-        })
+        presentations.append(item_to_yjs_dict(result))
 
     return {
         "status": snapshot.get("current_status"),
@@ -53,6 +48,7 @@ def update(path: Path, force: bool = False) -> None:
         print(f"  skipping (already exists): {expected_path.name}")
         return
 
+    print(f"Updating expected for: {path.name}")
     snapshot = json.loads(path.read_text())
     expected = build_expected(snapshot)
     expected_path.write_text(json.dumps(expected, indent=2, ensure_ascii=False))
@@ -67,7 +63,7 @@ def main() -> None:
     if stems:
         paths = [SNAPSHOTS_DIR / f"{stem}.json" for stem in stems]
     else:
-        paths = sorted(SNAPSHOTS_DIR.glob("*.json"))
+        paths = sorted(p for p in SNAPSHOTS_DIR.glob("*.json") if not p.stem.endswith(".expected"))
 
     for path in paths:
         update(path, force=force)

--- a/uv.lock
+++ b/uv.lock
@@ -190,6 +190,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "cssselect"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -397,6 +406,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -463,6 +481,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pytest" },
     { name = "types-lxml" },
 ]
 
@@ -483,6 +502,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.20.2" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "types-lxml", specifier = ">=2026.2.16" },
 ]
 
@@ -788,12 +808,30 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -951,6 +989,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4f/91/a412af8792af22e7e67a7424e7b6c64baada4897777fed885a2cb825155d/pycrdt_websocket-0.16.0.tar.gz", hash = "sha256:89d4d830f41028c55cc9877635f73f94f49131ca73ffac7353d0be421150d0fd", size = 23152, upload-time = "2025-06-11T07:15:54.298Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/b7/a1dd4d149fa6279f321bd7dacab66ac31e728fbae175a7d75cf8211b1f30/pycrdt_websocket-0.16.0-py3-none-any.whl", hash = "sha256:4b9ffe47c40867b7e637922680e93471fd801b6e8d6c9f6aa688fd2a17351141", size = 14568, upload-time = "2025-06-11T07:15:52.364Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Incremental plan (7 phases) to replace storing translations in Proclaim
with a conversational agent. Each phase is independently mergeable and
demoable. Starts with test infrastructure, ends with chat UI.

https://claude.ai/code/session_01Bju9RHq8uqNVNcR9bQxdGh