### PR TITLE
Switch to continuous delta-based transcription streaming

### DIFF
--- a/live-audio/transcript-writer.test.ts
+++ b/live-audio/transcript-writer.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { endsSentence } from "./transcript-writer.ts";
+
+// Gemini Live Translate streams transcription as a continuous flow of deltas with
+// no turnComplete, so the writer starts a fresh paragraph after a delta that ends
+// a sentence. `endsSentence` is that decision.
+describe("endsSentence", () => {
+  it("is true for deltas ending in sentence punctuation", () => {
+    expect(endsSentence("Hello world.")).toBe(true);
+    expect(endsSentence("Really?")).toBe(true);
+    expect(endsSentence("Stop!")).toBe(true);
+  });
+
+  it("tolerates trailing whitespace after the punctuation", () => {
+    expect(endsSentence("Done. ")).toBe(true);
+    expect(endsSentence("Done.\n")).toBe(true);
+  });
+
+  it("allows a closing quote or bracket after the punctuation", () => {
+    expect(endsSentence('He said "go."')).toBe(true);
+    expect(endsSentence("(an aside.)")).toBe(true);
+  });
+
+  it("handles non-Latin sentence punctuation", () => {
+    expect(endsSentence("结束。")).toBe(true);
+    expect(endsSentence("本当に？")).toBe(true);
+  });
+
+  it("is false for mid-sentence deltas", () => {
+    expect(endsSentence("Hello")).toBe(false);
+    expect(endsSentence("and then we")).toBe(false);
+    expect(endsSentence("a comma,")).toBe(false);
+  });
+
+  it("is false for empty or whitespace-only text", () => {
+    expect(endsSentence("")).toBe(false);
+    expect(endsSentence("   ")).toBe(false);
+  });
+});

--- a/live-audio/transcript-writer.ts
+++ b/live-audio/transcript-writer.ts
@@ -1,13 +1,14 @@
 /**
  * TranscriptWriter: a server-side Yjs writer that persists live translation
  * transcripts into the session's shared Y-Sweet doc, so any viewer — including
- * late joiners — can read the full, stable transcript history.
+ * late joiners — can read the full transcript history.
  *
  * One writer per session (doc), shared by all of that session's TranslationBridges.
- * Each language's finalized segments accumulate in a `liveTranscript-{code}`
- * Y.Text; the client renders those as stable, chunked paragraphs. In-progress
- * (interim) lines are NOT written here — they stay ephemeral on the LiveKit data
- * channel to avoid bloating the persisted doc.
+ * Each language's transcript accumulates in a `liveTranscript-{code}` Y.Text:
+ * Gemini Live Translate streams a continuous flow of transcription deltas (it has
+ * no "turns", so no turnComplete to flush on), so we append each delta verbatim
+ * and start a fresh paragraph after sentence-ending punctuation. The Y.Text is the
+ * single source of truth — there is no separate ephemeral interim stream.
  *
  * Mirrors the Proclaim service's "external process writes into Yjs" pattern, but
  * in-process on the Node server using the same Y-Sweet DocumentManager that issues
@@ -20,11 +21,20 @@ import type { DocumentManager } from "@y-sweet/sdk";
 
 const KEY_PREFIX = "liveTranscript-";
 
+/**
+ * Whether a transcription delta ends an utterance, used to start a new paragraph.
+ * Cheap heuristic: the trimmed text ends with sentence-ending punctuation,
+ * optionally followed by a closing quote or bracket. Abbreviations ("Dr.") may
+ * split a paragraph early — acceptable for a live transcript.
+ */
+export function endsSentence(text: string): boolean {
+  return /[.!?…。！？][")'\]]?\s*$/.test(text);
+}
+
 export class TranscriptWriter {
   public readonly docId: string;
   private doc = new Y.Doc();
   private provider: YSweetProvider;
-  private ready: Promise<void>;
 
   constructor(docId: string, documentManager: DocumentManager) {
     this.docId = docId;
@@ -34,42 +44,22 @@ export class TranscriptWriter {
       () => documentManager.getClientToken(docId),
       { connect: true }
     );
-
-    this.ready = new Promise<void>((resolve) => {
-      if (this.provider.synced) {
-        resolve();
-        return;
-      }
-      this.provider.once("synced", () => resolve());
-    });
-  }
-
-  /** Resolve once the initial sync with Y-Sweet is complete. */
-  whenReady(): Promise<void> {
-    return this.ready;
-  }
-
-  /** Append a finalized transcript segment for a language, separated by a blank line. */
-  appendSegment(code: string, text: string): void {
-    const trimmed = text.trim();
-    if (!trimmed) return;
-    const ytext = this.doc.getText(`${KEY_PREFIX}${code}`);
-    const separator = ytext.length > 0 ? "\n\n" : "";
-    ytext.insert(ytext.length, separator + trimmed);
   }
 
   /**
-   * Clear every language's transcript. Called when a fresh talk begins so the
-   * day-scoped doc doesn't show a previous service's transcript to late joiners.
-   * Waits for the initial sync first, otherwise server state would re-populate
-   * the texts right after we clear them.
+   * Append a streamed transcription delta for a language. The delta is inserted
+   * verbatim (no trimming — inter-delta spacing is significant), and a paragraph
+   * break is added once a sentence finishes so the client renders readable
+   * paragraphs. Edits made before the initial sync are merged by Yjs.
    */
-  async clearAll(): Promise<void> {
-    await this.ready;
-    for (const key of this.doc.share.keys()) {
-      if (!key.startsWith(KEY_PREFIX)) continue;
-      const ytext = this.doc.getText(key);
-      if (ytext.length > 0) ytext.delete(0, ytext.length);
+  appendDelta(code: string, text: string): void {
+    if (!text) return;
+    const ytext = this.doc.getText(`${KEY_PREFIX}${code}`);
+    ytext.insert(ytext.length, text);
+    // Start a new paragraph after a completed sentence, unless the delta already
+    // ended with a newline (so we don't stack blank lines).
+    if (endsSentence(text) && !ytext.toString().endsWith("\n")) {
+      ytext.insert(ytext.length, "\n\n");
     }
   }
 

--- a/live-audio/translation-bridge.ts
+++ b/live-audio/translation-bridge.ts
@@ -66,9 +66,6 @@ export class TranslationBridge {
   // via Gemini input transcription. Only the primary bridge does, so the same
   // English text isn't appended once per running language.
   private readonly writesSourceTranscript: boolean;
-  // Accumulators for the current turn's transcription, flushed on turnComplete.
-  private outputTurnBuffer: string = "";
-  private inputTurnBuffer: string = "";
 
   // The source (input) transcript is published under this language code.
   static readonly SOURCE_CODE = "en";
@@ -413,32 +410,16 @@ export class TranslationBridge {
         }
       }
 
-      // Output transcription (target language): accumulate the turn, stream it as
-      // an ephemeral interim line, and persist the finalized segment on turn end.
+      // Transcription (target language): Gemini Live Translate streams a continuous
+      // flow of deltas with no turnComplete, so persist each delta straight into the
+      // shared Yjs transcript, which is the single source of truth for viewers.
       if (serverContent?.outputTranscription?.text) {
-        this.outputTurnBuffer += serverContent.outputTranscription.text;
-        this.publishInterim(this.targetLanguage, this.outputTurnBuffer);
+        this.writer?.appendDelta(this.targetLanguage, serverContent.outputTranscription.text);
       }
 
       // Input transcription (source language / English) — only on the primary bridge.
       if (this.writesSourceTranscript && serverContent?.inputTranscription?.text) {
-        this.inputTurnBuffer += serverContent.inputTranscription.text;
-        this.publishInterim(TranslationBridge.SOURCE_CODE, this.inputTurnBuffer);
-      }
-
-      // On turn completion, flush finalized segments into Yjs and clear the interim
-      // lines (the finalized text now arrives via Yjs).
-      if (serverContent?.turnComplete) {
-        if (this.outputTurnBuffer.trim()) {
-          this.writer?.appendSegment(this.targetLanguage, this.outputTurnBuffer);
-          this.publishInterim(this.targetLanguage, "");
-          this.outputTurnBuffer = "";
-        }
-        if (this.inputTurnBuffer.trim()) {
-          this.writer?.appendSegment(TranslationBridge.SOURCE_CODE, this.inputTurnBuffer);
-          this.publishInterim(TranslationBridge.SOURCE_CODE, "");
-          this.inputTurnBuffer = "";
-        }
+        this.writer?.appendDelta(TranslationBridge.SOURCE_CODE, serverContent.inputTranscription.text);
       }
     } catch (error) {
       console.error(
@@ -642,35 +623,6 @@ export class TranslationBridge {
     } catch (error) {
       console.error(
         `[TranslationBridge:${this.targetLanguage}] Error sending audio to Gemini:`,
-        error
-      );
-    }
-  }
-
-  /**
-   * Publish the current in-progress (interim) transcript line for a language over
-   * the LiveKit data channel. Interim text is ephemeral — finalized segments live
-   * in Yjs — so passing an empty string clears the interim line on turn completion.
-   */
-  private publishInterim(code: string, text: string): void {
-    if (!this.room?.localParticipant) return;
-
-    try {
-      const payload = JSON.stringify({
-        type: "transcription",
-        language: code,
-        text,
-        interim: true,
-        timestamp: Date.now(),
-      });
-
-      void this.room.localParticipant.publishData(
-        new TextEncoder().encode(payload),
-        { reliable: true, topic: "transcription" }
-      );
-    } catch (error) {
-      console.error(
-        `[TranslationBridge:${this.targetLanguage}] Error publishing interim transcript:`,
         error
       );
     }

--- a/live-audio/translation-session-manager.ts
+++ b/live-audio/translation-session-manager.ts
@@ -114,11 +114,11 @@ class TranslationSessionManager {
   /**
    * Ensure translation is running for a language and return its bridge.
    *
-   * Side effects that keep the English transcript available cheaply:
-   *  - ensures the default/primary bridge (DEFAULT_LANGUAGE) is running while
-   *    anyone is listening — it is the sole writer of the source transcript;
-   *  - on the first bridge for a session (a fresh talk), clears any stale
-   *    transcript left in the day-scoped doc by a previous service.
+   * Always keeps the English transcript available cheaply by ensuring the
+   * default/primary bridge (DEFAULT_LANGUAGE) runs while anyone is listening —
+   * it is the sole writer of the source transcript. The transcript is never
+   * cleared here: it accumulates in the day-scoped doc for accountability, so a
+   * transient drop-to-zero-listeners and rejoin can't wipe a live talk.
    */
   async getOrCreate(
     sessionId: string,
@@ -129,14 +129,7 @@ class TranslationSessionManager {
     // has finished joining the LiveKit room.
     this.lastHealthyAt.set(sessionId, Date.now());
 
-    const existingMap = this.translations.get(sessionId);
-    const isFirstBridge = !existingMap || existingMap.size === 0;
-
     const writer = this.getOrCreateWriter(sessionId);
-    if (writer && isFirstBridge) {
-      // Clear before any bridge can append, so a new talk starts clean.
-      await writer.clearAll();
-    }
 
     // Always keep the default bridge alive (the source-transcript writer).
     const defaultBridge = await this.ensureBridge(

--- a/src/ListenViewer.tsx
+++ b/src/ListenViewer.tsx
@@ -5,9 +5,9 @@
 // to this pane and never disturbs the outline / slide views.
 //
 // The transcript is read from the shared Yjs doc (`liveTranscript-{code}`), which
-// the server-side translator bridge writes. That gives late joiners the full
-// history and keeps the text visually stable; only the in-progress (interim) line
-// arrives ephemerally over the LiveKit data channel.
+// the server-side translator bridge writes (one delta at a time, as a continuous
+// stream). That gives late joiners the full history and is the single source of
+// truth — there is no separate ephemeral interim line.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   LiveKitRoom,
@@ -16,7 +16,7 @@ import {
   useRemoteParticipants,
 } from "@livekit/components-react";
 import "@livekit/components-styles";
-import { Track, RoomEvent } from "livekit-client";
+import { Track } from "livekit-client";
 import { LANGUAGE_BCP47, useStrings } from "./useLocale";
 import { useAsPlainText } from "./yjsUtils";
 import { LISTEN_ORIGINAL_CODE, DEFAULT_LISTEN_CODE } from "./listenLanguages";
@@ -41,12 +41,6 @@ interface TokenResp {
   token?: string;
   serverUrl?: string;
   error?: string;
-}
-interface TranscriptionMsg {
-  type?: string;
-  language?: string;
-  text?: string;
-  interim?: boolean;
 }
 
 // One finalized transcript paragraph. Mounting fresh (only appended segments do)
@@ -78,7 +72,6 @@ function ListenInner({
   const room = useRoomContext();
   const remoteParticipants = useRemoteParticipants();
   const [finalized] = useAsPlainText(`liveTranscript-${langCode}`);
-  const [interim, setInterim] = useState("");
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const atBottomRef = useRef(true);
 
@@ -101,31 +94,6 @@ function ListenInner({
       }
     }
   }, [room, translatorIdentity, isOriginal, remoteParticipants]);
-
-  // The in-progress line is ephemeral: replace (don't append) on each message,
-  // and clear when the bridge sends an empty interim at turn completion.
-  useEffect(() => {
-    if (!room) return;
-    const handleData = (
-      payload: Uint8Array,
-      _participant: unknown,
-      _kind: unknown,
-      topic: string | undefined
-    ) => {
-      if (topic !== "transcription") return;
-      try {
-        const data = JSON.parse(new TextDecoder().decode(payload)) as TranscriptionMsg;
-        if (data.type !== "transcription" || data.language !== langCode) return;
-        setInterim(data.text ?? "");
-      } catch {
-        // ignore non-transcription payloads
-      }
-    };
-    room.on(RoomEvent.DataReceived, handleData);
-    return () => {
-      room.off(RoomEvent.DataReceived, handleData);
-    };
-  }, [room, langCode]);
 
   const segments = useMemo(
     () => finalized.split("\n\n").map((t) => t.trim()).filter(Boolean),
@@ -167,7 +135,7 @@ function ListenInner({
     };
   }, [docId, releaseTarget]);
 
-  const hasContent = segments.length > 0 || interim;
+  const hasContent = segments.length > 0;
 
   return (
     <>
@@ -196,9 +164,6 @@ function ListenInner({
                 isNew={i >= baselineCount}
               />
             ))}
-            {interim && (
-              <p className="my-2 italic text-gray-400 dark:text-gray-500">{interim}</p>
-            )}
           </div>
         ) : (
           <span className="italic text-gray-400">{s.waitingForSpeech}</span>


### PR DESCRIPTION
## Summary

Refactors the live transcription system to handle Gemini Live Translate's continuous delta stream directly, eliminating the turn-based buffering model and ephemeral interim lines. The transcript is now the single source of truth in Yjs, with deltas persisted immediately as they arrive.

## Key Changes

**TranscriptWriter** (`live-audio/transcript-writer.ts`):
- Replaced `appendSegment()` (turn-based, trimmed) with `appendDelta()` (streaming, verbatim)
- Added `endsSentence()` utility to detect sentence completion and start new paragraphs
- Removed `whenReady()` and `clearAll()` methods (no longer needed for turn-based flushing or session cleanup)
- Deltas are inserted as-is without trimming; paragraph breaks are added after sentence-ending punctuation
- Added comprehensive unit tests for `endsSentence()` covering Latin, CJK punctuation, quotes, and edge cases

**TranslationBridge** (`live-audio/translation-bridge.ts`):
- Removed turn-based accumulators (`outputTurnBuffer`, `inputTurnBuffer`)
- Removed `turnComplete` handling and turn-end flushing logic
- Removed `publishInterim()` method (no more ephemeral interim lines over LiveKit data channel)
- Transcription deltas now flow directly to `writer.appendDelta()` as they arrive
- Simplified message handling: each delta is persisted immediately to Yjs

**ListenViewer** (`src/ListenViewer.tsx`):
- Removed interim transcript state and LiveKit `DataReceived` event listener
- Removed rendering of ephemeral interim line (italic gray text)
- Removed unused `TranscriptionMsg` interface and `RoomEvent` import
- Transcript now reads exclusively from Yjs (`liveTranscript-{code}`), which is the single source of truth

**TranslationSessionManager** (`live-audio/translation-session-manager.ts`):
- Removed `clearAll()` call on first bridge creation
- Transcript now accumulates indefinitely in the day-scoped doc for accountability
- Transient listener drops can no longer wipe a live talk's transcript

## Implementation Details

- The `endsSentence()` regex (`/[.!?…。！？][")'\]]?\s*$/.test(text)`) handles sentence-ending punctuation in multiple languages (Latin, CJK) with optional trailing quotes/brackets and whitespace
- Paragraph breaks are only added if the delta doesn't already end with a newline, preventing stacked blank lines
- Yjs automatically merges edits made before initial sync, so the system is resilient to timing issues
- This aligns with Gemini Live Translate's architecture, which has no turn boundaries and streams a continuous flow of transcription deltas

https://claude.ai/code/session_01LLa67ZvjVSWhk2sGJy7vKQ