### PR TITLE
Show listen transcript immediately; gate audio behind a play button

### DIFF
--- a/src/BroadcastControl.tsx
+++ b/src/BroadcastControl.tsx
@@ -15,7 +15,13 @@ import "@livekit/components-styles";
 import { LocalAudioTrack, Track } from "livekit-client";
 import { isEditorAtom } from "./configAtoms";
 import { useStrings } from "./useLocale";
+import { LiveTranscript } from "./LiveTranscript";
 import { getDocId } from "./getDocId";
+
+// The default/primary translator bridge transcribes the speaker's own audio and
+// writes it to the shared Yjs doc under this code, so the broadcaster can read
+// back exactly what's being captured.
+const SOURCE_TRANSCRIPT_CODE = "en";
 
 interface TranslationInfo {
   language: string;
@@ -103,7 +109,11 @@ function BroadcastDashboard({ docId }: { docId: string }) {
         </span>
       </div>
       <MicLevelMeter />
-      <div className="flex-1 overflow-auto">
+      <h3 className="text-xs font-semibold text-gray-500 dark:text-gray-300">
+        {s.englishTranscript}
+      </h3>
+      <LiveTranscript langCode={SOURCE_TRANSCRIPT_CODE} />
+      <div className="overflow-auto max-h-40">
         <h3 className="text-xs font-semibold text-gray-500 dark:text-gray-300 mb-1">
           {s.activeTranslations}
         </h3>

--- a/src/ListenViewer.tsx
+++ b/src/ListenViewer.tsx
@@ -1,14 +1,15 @@
-// ListenViewer: a self-contained pane that lets a viewer hear live
-// speech-to-speech translated audio for a single language, produced by a Gemini
-// Live translator bot in the session's LiveKit room. Kept deliberately isolated
-// (lazy LiveKit import, own error/empty states) so any failure here is contained
-// to this pane and never disturbs the outline / slide views.
+// ListenViewer: a self-contained pane that lets a viewer follow a live, AI
+// speech-to-speech translation for a single language, produced by a Gemini Live
+// translator bot in the session's LiveKit room. Kept deliberately isolated (lazy
+// LiveKit import, own error/empty states) so any failure here is contained to
+// this pane and never disturbs the outline / slide views.
 //
-// The transcript is read from the shared Yjs doc (`liveTranscript-{code}`), which
-// the server-side translator bridge writes (one delta at a time, as a continuous
-// stream). That gives late joiners the full history and is the single source of
-// truth — there is no separate ephemeral interim line.
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+// The transcript shows immediately and unconditionally (it reads the shared Yjs
+// doc, no LiveKit needed). To keep that transcript flowing this pane joins the
+// LiveKit room on mount — that both spins up the translator bot and keeps the
+// session healthy — but the translated *audio* stays muted until the listener
+// presses the play button. In other words: read for free, opt in to hear.
+import { useEffect, useState } from "react";
 import {
   LiveKitRoom,
   RoomAudioRenderer,
@@ -18,8 +19,8 @@ import {
 import "@livekit/components-styles";
 import { Track } from "livekit-client";
 import { LANGUAGE_BCP47, useStrings } from "./useLocale";
-import { useAsPlainText } from "./yjsUtils";
 import { LISTEN_ORIGINAL_CODE, DEFAULT_LISTEN_CODE } from "./listenLanguages";
+import { LiveTranscript } from "./LiveTranscript";
 import { getDocId } from "./getDocId";
 
 const ORGANIZER_PREFIX = "organizer-";
@@ -43,79 +44,51 @@ interface TokenResp {
   error?: string;
 }
 
-// One finalized transcript paragraph. Mounting fresh (only appended segments do)
-// plays a one-shot highlight animation, so new text is gently emphasized without
-// any diffing — the Yjs text is append-only.
-function TranscriptSegment({ text, isNew }: { text: string; isNew: boolean }) {
-  return (
-    <p className={`my-2 ${isNew ? "transcript-new" : ""}`}>{text}</p>
-  );
-}
-
-// Runs inside <LiveKitRoom>: subscribe only to the chosen audio (translator bot,
-// or the speaker's original mic), render the stable transcript, and report whether
-// the speaker is present.
-function ListenInner({
+// Runs inside <LiveKitRoom>: report whether the speaker is present, and — only
+// while the listener has audio enabled — subscribe to and play the chosen audio
+// (the translator bot, or the speaker's original mic). The transcript itself is
+// rendered by the parent, outside the room.
+function ListenAudio({
   docId,
-  langCode,
   releaseTarget,
   translatorIdentity,
   isOriginal,
+  audioOn,
+  onToggleAudio,
 }: {
   docId: string;
-  langCode: string;
   releaseTarget: string;
   translatorIdentity: string | null;
   isOriginal: boolean;
+  audioOn: boolean;
+  onToggleAudio: () => void;
 }) {
   const s = useStrings();
   const room = useRoomContext();
   const remoteParticipants = useRemoteParticipants();
-  const [finalized] = useAsPlainText(`liveTranscript-${langCode}`);
-  const scrollRef = useRef<HTMLDivElement | null>(null);
-  const atBottomRef = useRef(true);
 
   const speakerPresent = remoteParticipants.some((p) =>
     p.identity.startsWith(ORGANIZER_PREFIX)
   );
 
-  // Subscribe to the audio we want: the translator bot for a translation, or the
-  // speaker's raw mic for "Original / English". autoSubscribe is off, so we drive
-  // this explicitly. Re-running on participant changes is essential for late
-  // joiners — the track is already published, so no per-track event fires for us.
+  // Subscribe to the audio we want only while audio is enabled: the translator
+  // bot for a translation, or the speaker's raw mic for "Original / English".
+  // autoSubscribe is off, so we drive this explicitly. Re-running on participant
+  // changes is essential for late joiners — the track is already published, so no
+  // per-track event fires for us.
   useEffect(() => {
     if (!room) return;
     for (const participant of remoteParticipants) {
-      const wanted = isOriginal
-        ? participant.identity.startsWith(ORGANIZER_PREFIX)
-        : participant.identity === translatorIdentity;
+      const wanted =
+        audioOn &&
+        (isOriginal
+          ? participant.identity.startsWith(ORGANIZER_PREFIX)
+          : participant.identity === translatorIdentity);
       for (const [, pub] of participant.trackPublications) {
         if (pub.kind === Track.Kind.Audio) pub.setSubscribed(wanted);
       }
     }
-  }, [room, translatorIdentity, isOriginal, remoteParticipants]);
-
-  const segments = useMemo(
-    () => finalized.split("\n\n").map((t) => t.trim()).filter(Boolean),
-    [finalized]
-  );
-
-  // Segments present at first render aren't animated; only later-appended ones are.
-  // Captured once via a lazy initializer (reading a ref during render is unsafe).
-  const [baselineCount] = useState(() => segments.length);
-
-  // Auto-scroll only when the reader is already near the bottom, so reading older
-  // text isn't yanked away when new text arrives. Runs after every render (cheap);
-  // it only moves the scroll position when already pinned to the bottom.
-  const onScroll = () => {
-    const el = scrollRef.current;
-    if (!el) return;
-    atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
-  };
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el && atBottomRef.current) el.scrollTop = el.scrollHeight;
-  });
+  }, [room, translatorIdentity, isOriginal, remoteParticipants, audioOn]);
 
   // Decrement the listener count when this pane goes away (unmount or tab close)
   // so idle translator bots tear down. (Best-effort; the server's presence reaper
@@ -135,8 +108,6 @@ function ListenInner({
     };
   }, [docId, releaseTarget]);
 
-  const hasContent = segments.length > 0;
-
   return (
     <>
       <RoomAudioRenderer />
@@ -149,25 +120,17 @@ function ListenInner({
         <span className="text-gray-600 dark:text-gray-300">
           {speakerPresent ? s.liveListening : s.waitingForSpeaker}
         </span>
-      </div>
-      <div
-        ref={scrollRef}
-        onScroll={onScroll}
-        className="flex-1 overflow-auto text-gray-800 dark:text-gray-100"
-      >
-        {hasContent ? (
-          <div className="mx-auto max-w-[60ch] text-lg leading-relaxed">
-            {segments.map((seg, i) => (
-              <TranscriptSegment
-                key={`${i}-${seg.slice(0, 16)}`}
-                text={seg}
-                isNew={i >= baselineCount}
-              />
-            ))}
-          </div>
-        ) : (
-          <span className="italic text-gray-400">{s.waitingForSpeech}</span>
-        )}
+        <div className="flex-1" />
+        <button
+          type="button"
+          aria-pressed={audioOn}
+          className={`px-3 py-1 rounded-full text-white shadow ${
+            audioOn ? "bg-gray-500 hover:bg-gray-600" : "bg-blue-500 hover:bg-blue-600"
+          }`}
+          onClick={onToggleAudio}
+        >
+          {audioOn ? `🔇 ${s.stopAudio}` : `🔊 ${s.listenLive}`}
+        </button>
       </div>
     </>
   );
@@ -184,95 +147,109 @@ export function ListenViewer({ language }: { language: string }) {
   const docId = getDocId();
   const [conn, setConn] = useState<ConnectInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [connecting, setConnecting] = useState(false);
+  // Audio is opt-in: the transcript flows without it, the button toggles sound.
+  const [audioOn, setAudioOn] = useState(false);
+  // Bumped by the retry button to re-run the connect effect.
+  const [attempt, setAttempt] = useState(0);
 
-  const start = useCallback(async () => {
-    setError(null);
-    setConnecting(true);
-    try {
-      // Ask the server to spin up (or reuse) the translator bot. For original
-      // audio this just ensures the default bridge (and its transcript) is running.
-      const tr = (await fetch("/api/livekit/translate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId: docId, targetLanguage: translateTarget }),
-      }).then((r) => r.json())) as TranslateResp;
-      if (tr.error) throw new Error(tr.error);
+  // Connect on mount (no button): joining the room spins up the bot and keeps the
+  // session healthy, so the transcript starts (and keeps) flowing right away. The
+  // audio itself stays muted until the listener presses play.
+  useEffect(() => {
+    let cancelled = false;
+    const connect = async () => {
+      try {
+        // Ask the server to spin up (or reuse) the translator bot. For original
+        // audio this just ensures the default bridge (and its transcript) runs.
+        const tr = (await fetch("/api/livekit/translate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionId: docId, targetLanguage: translateTarget }),
+        }).then((r) => r.json())) as TranslateResp;
+        if (tr.error) throw new Error(tr.error);
 
-      const identity = `attendee-${Math.random().toString(36).slice(2, 8)}`;
-      const tk = (await fetch("/api/livekit/token", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ room: docId, identity, role: "attendee" }),
-      }).then((r) => r.json())) as TokenResp;
-      if (tk.error) throw new Error(tk.error);
-      if (!tk.token || !tk.serverUrl) {
-        throw new Error("Incomplete response from server");
+        const identity = `attendee-${Math.random().toString(36).slice(2, 8)}`;
+        const tk = (await fetch("/api/livekit/token", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ room: docId, identity, role: "attendee" }),
+        }).then((r) => r.json())) as TokenResp;
+        if (tk.error) throw new Error(tk.error);
+        if (!tk.token || !tk.serverUrl) {
+          throw new Error("Incomplete response from server");
+        }
+        if (!isOriginal && !tr.translatorIdentity) {
+          throw new Error("Incomplete response from server");
+        }
+
+        if (cancelled) return;
+        setConn({
+          token: tk.token,
+          serverUrl: tk.serverUrl,
+          translatorIdentity: isOriginal ? null : tr.translatorIdentity ?? null,
+        });
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       }
-      if (!isOriginal && !tr.translatorIdentity) {
-        throw new Error("Incomplete response from server");
-      }
+    };
+    void connect();
+    return () => {
+      cancelled = true;
+    };
+  }, [docId, translateTarget, isOriginal, attempt]);
 
-      setConn({
-        token: tk.token,
-        serverUrl: tk.serverUrl,
-        translatorIdentity: isOriginal ? null : tr.translatorIdentity ?? null,
-      });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setConnecting(false);
-    }
-  }, [docId, translateTarget, isOriginal]);
-
+  // The control bar reflects the connection: error (with retry), the live audio
+  // controls once connected, or a connecting hint. The transcript is always shown
+  // below it, since it reads Yjs and needs no LiveKit connection.
+  let controls: React.ReactElement;
   if (error) {
-    return (
-      <div className="flex flex-col gap-2 items-start text-sm">
+    controls = (
+      <div className="flex flex-col gap-1 items-start text-sm">
         <p className="text-red-600 dark:text-red-400">{s.liveAudioError}</p>
         <p className="text-xs text-gray-500">{error}</p>
         <button
           type="button"
           className="px-3 py-1 rounded bg-blue-500 text-white text-xs hover:bg-blue-600"
-          onClick={() => void start()}
+          onClick={() => {
+            setError(null);
+            setConn(null);
+            setAttempt((a) => a + 1);
+          }}
         >
           {s.retry}
         </button>
       </div>
     );
-  }
-
-  if (!conn) {
-    return (
-      <div className="flex-1 flex flex-col items-center justify-center gap-3">
-        <button
-          type="button"
-          disabled={connecting}
-          className="px-4 py-2 rounded-full bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-60 shadow"
-          onClick={() => void start()}
-        >
-          {connecting ? s.connecting : `🔊 ${s.listenLive}`}
-        </button>
-      </div>
+  } else if (conn) {
+    controls = (
+      <LiveKitRoom
+        video={false}
+        audio={false}
+        token={conn.token}
+        serverUrl={conn.serverUrl}
+        connectOptions={{ autoSubscribe: false }}
+        onError={(e) => setError(e.message)}
+      >
+        <ListenAudio
+          docId={docId}
+          releaseTarget={translateTarget}
+          translatorIdentity={conn.translatorIdentity}
+          isOriginal={isOriginal}
+          audioOn={audioOn}
+          onToggleAudio={() => setAudioOn((v) => !v)}
+        />
+      </LiveKitRoom>
+    );
+  } else {
+    controls = (
+      <div className="flex items-center gap-2 text-xs text-gray-500">{s.connecting}</div>
     );
   }
 
   return (
-    <LiveKitRoom
-      video={false}
-      audio={false}
-      token={conn.token}
-      serverUrl={conn.serverUrl}
-      connectOptions={{ autoSubscribe: false }}
-      onError={(e) => setError(e.message)}
-      className="flex flex-col gap-2 flex-1 min-h-0"
-    >
-      <ListenInner
-        docId={docId}
-        langCode={langCode}
-        releaseTarget={translateTarget}
-        translatorIdentity={conn.translatorIdentity}
-        isOriginal={isOriginal}
-      />
-    </LiveKitRoom>
+    <div className="flex flex-col gap-2 flex-1 min-h-0">
+      {controls}
+      <LiveTranscript langCode={langCode} />
+    </div>
   );
 }

--- a/src/LiveTranscript.tsx
+++ b/src/LiveTranscript.tsx
@@ -1,0 +1,73 @@
+// LiveTranscript: renders the live transcript for one language code, read
+// straight from the shared Yjs doc (`liveTranscript-{code}`). The server-side
+// translator bridge writes that text one delta at a time as a continuous,
+// append-only stream, so this is the single source of truth and gives late
+// joiners the full history.
+//
+// Deliberately free of any LiveKit dependency: the transcript shows immediately
+// for any viewer — a listener (whether or not they've started audio) or the
+// broadcaster — because reading it needs only the Yjs connection, not the audio
+// room.
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useStrings } from "./useLocale";
+import { useAsPlainText } from "./yjsUtils";
+
+// One finalized transcript paragraph. Mounting fresh (only appended segments do)
+// plays a one-shot highlight animation, so new text is gently emphasized without
+// any diffing — the Yjs text is append-only.
+function TranscriptSegment({ text, isNew }: { text: string; isNew: boolean }) {
+  return <p className={`my-2 ${isNew ? "transcript-new" : ""}`}>{text}</p>;
+}
+
+export function LiveTranscript({ langCode }: { langCode: string }) {
+  const s = useStrings();
+  const [finalized] = useAsPlainText(`liveTranscript-${langCode}`);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const atBottomRef = useRef(true);
+
+  const segments = useMemo(
+    () => finalized.split("\n\n").map((t) => t.trim()).filter(Boolean),
+    [finalized]
+  );
+
+  // Segments present at first render aren't animated; only later-appended ones are.
+  // Captured once via a lazy initializer (reading a ref during render is unsafe).
+  const [baselineCount] = useState(() => segments.length);
+
+  // Auto-scroll only when the reader is already near the bottom, so reading older
+  // text isn't yanked away when new text arrives. Runs after every render (cheap);
+  // it only moves the scroll position when already pinned to the bottom.
+  const onScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  };
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && atBottomRef.current) el.scrollTop = el.scrollHeight;
+  });
+
+  const hasContent = segments.length > 0;
+
+  return (
+    <div
+      ref={scrollRef}
+      onScroll={onScroll}
+      className="flex-1 overflow-auto text-gray-800 dark:text-gray-100"
+    >
+      {hasContent ? (
+        <div className="mx-auto max-w-[60ch] text-lg leading-relaxed">
+          {segments.map((seg, i) => (
+            <TranscriptSegment
+              key={`${i}-${seg.slice(0, 16)}`}
+              text={seg}
+              isNew={i >= baselineCount}
+            />
+          ))}
+        </div>
+      ) : (
+        <span className="italic text-gray-400">{s.waitingForSpeech}</span>
+      )}
+    </div>
+  );
+}

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -51,6 +51,8 @@ export interface AppStrings {
 
   // Live audio translation (Gemini Live + LiveKit)
   listenLive: string;
+  stopAudio: string;
+  englishTranscript: string;
   liveListening: string;
   waitingForSpeaker: string;
   waitingForSpeech: string;
@@ -98,6 +100,8 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     noContent: 'No content yet',
     notTranslated: '(not translated)',
     listenLive: 'Listen live',
+    stopAudio: 'Stop audio',
+    englishTranscript: 'English transcript',
     liveListening: 'Listening live',
     waitingForSpeaker: 'Waiting for the speaker…',
     waitingForSpeech: 'Waiting for translated speech…',
@@ -145,6 +149,8 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     noContent: 'Aucun contenu pour l\u2019instant',
     notTranslated: '(non traduit)',
     listenLive: 'Écouter en direct',
+    stopAudio: 'Couper le son',
+    englishTranscript: 'Transcription anglaise',
     liveListening: 'Écoute en direct',
     waitingForSpeaker: 'En attente de l’orateur…',
     waitingForSpeech: 'En attente de la traduction vocale…',
@@ -192,6 +198,8 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     noContent: 'Sin contenido a\u00fan',
     notTranslated: '(no traducido)',
     listenLive: 'Escuchar en vivo',
+    stopAudio: 'Detener audio',
+    englishTranscript: 'Transcripción en inglés',
     liveListening: 'Escuchando en vivo',
     waitingForSpeaker: 'Esperando al orador…',
     waitingForSpeech: 'Esperando la traducción hablada…',
@@ -239,6 +247,8 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     noContent: 'Pa gen kontni pou kounye a',
     notTranslated: '(pa tradui)',
     listenLive: 'Koute an dirèk',
+    stopAudio: 'Sispann odyo',
+    englishTranscript: 'Transkripsyon anglè',
     liveListening: 'Ap koute an dirèk',
     waitingForSpeaker: 'N ap tann moun k ap pale a…',
     waitingForSpeech: 'N ap tann tradiksyon vokal la…',


### PR DESCRIPTION
The listen pane now connects to the LiveKit room on mount so the translator
bot spins up and the transcript starts flowing right away. The transcript is
read straight from the shared Yjs doc and rendered unconditionally — audio
output is opt-in via a play/stop toggle that only controls track subscription.

Extract the transcript view into a LiveKit-free LiveTranscript component and
reuse it on the broadcaster, which now shows the English source transcript.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013uUW4CRrDw1M9acri1NiQt