### PR TITLE
Anchor Proclaim doc id to the show's scheduled date

### DIFF
--- a/PROCLAIM_INTEGRATION.md
+++ b/PROCLAIM_INTEGRATION.md
@@ -39,10 +39,13 @@ uv sync
 
 ```bash
 # Make sure Proclaim is running
-# Start the service (default doc: doc-YYYY-MM-DD)
+# Start the service. By default it targets doc-YYYY-MM-DD using the on-air show's
+# scheduled date (Proclaim's DateGiven), falling back to today's date if the show
+# has no date. This means you can pre-stage a future-dated show: bring it on air in
+# Proclaim and the service syncs to that date's doc automatically.
 uv run proclaim_service.py
 
-# Or specify a custom doc ID
+# Or specify a custom doc ID (disables date-based selection entirely)
 uv run proclaim_service.py my-custom-doc
 ```
 
@@ -77,8 +80,11 @@ reconnects:
 - **Active health checks.** The service pings the websocket each poll so a silently
   dropped connection is detected promptly and triggers a reconnect (the underlying
   library otherwise swallows the disconnect).
-- **Date rollover.** Across midnight the service rolls to the new date-based document
-  with a fresh doc, without needing an external restart.
+- **Show-dated documents.** When using the default date-based doc, the service anchors
+  the doc to the on-air show's scheduled date (Proclaim's `DateGiven`), so a show
+  prepared the night before still syncs to its own date's doc. When a show has no usable
+  date it falls back to today's date and rolls over at midnight (with a fresh doc) without
+  needing an external restart.
 
 ### 3. View Current Slide in Browser
 

--- a/proclaim_lib.py
+++ b/proclaim_lib.py
@@ -228,7 +228,7 @@ class ProclaimDB:
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT PresentationId, Content FROM Presentations WHERE PresentationId = ?",
+                "SELECT PresentationId, DateGiven, Content FROM Presentations WHERE PresentationId = ?",
                 (presentation_id,)
             )
             row = cursor.fetchone()
@@ -236,7 +236,8 @@ class ProclaimDB:
                 return None
             return {
                 'id': row[0],
-                'content': json.loads(row[1])
+                'date_given': row[1],
+                'content': json.loads(row[2])
             }
 
     def get_presentations(self, limit: int = 10) -> List[Dict[str, Any]]:

--- a/proclaim_service.py
+++ b/proclaim_service.py
@@ -189,6 +189,13 @@ class ProclaimYjsService:
             self.doc_id = doc_id
             self.current_doc_date = None
 
+        # Whether current_doc_date came from the on-air show's DateGiven (authoritative,
+        # set per session) rather than wall-clock today. When the date is anchored to a
+        # show we don't roll the doc at midnight - the show's date is the source of truth,
+        # so a service started the night before for a future-dated show targets the right
+        # doc. Only the wall-clock fallback rolls over at midnight.
+        self.doc_date_from_show = False
+
         # Yjs state
         self.ydoc: Doc = Doc()
         self.presentations_map = self.ydoc.get('proclaimPresentations', type=Map)
@@ -200,13 +207,68 @@ class ProclaimYjsService:
         self.current_item_slides: Optional[ServiceItemWithSlides] = None
 
     @staticmethod
-    def _get_date_based_doc_id() -> str:
-        """Generate doc ID based on current date"""
-        return f'doc-{date.today().isoformat()}'
+    def _get_date_based_doc_id(d: Optional[date] = None) -> str:
+        """Generate doc ID based on a date (defaults to today)."""
+        return f'doc-{(d or date.today()).isoformat()}'
+
+    @staticmethod
+    def _parse_date_given(raw: Any) -> Optional[date]:
+        """Parse a Proclaim ``DateGiven`` value (e.g. ``"2025-03-02"``) into a date.
+
+        Returns None when the value is missing or not a parseable ISO date, so the
+        caller can fall back to wall-clock today.
+        """
+        if not isinstance(raw, str):
+            return None
+        # DateGiven is a date string but tolerate an accidental time component.
+        token = raw.strip().replace('T', ' ').split(' ')[0]
+        try:
+            return date.fromisoformat(token)
+        except ValueError:
+            return None
+
+    def _read_show_date(self, presentation_id: Optional[str]) -> Optional[date]:
+        """Read the on-air presentation's DateGiven as a date, or None if unavailable.
+
+        Tolerates a missing row (DB trailing the live API) or any DB/parse problem by
+        returning None; the caller then falls back to today's date.
+        """
+        if not presentation_id:
+            return None
+        try:
+            pres = self.db.get_presentation(presentation_id)
+        except Exception as e:
+            logger.warning(f"Could not read date for presentation {presentation_id}: {e}")
+            return None
+        if not pres:
+            return None
+        return self._parse_date_given(pres.get('date_given'))
+
+    def _resolve_doc_for_session(self, presentation_id: Optional[str]) -> None:
+        """Point the (date-based) doc id at the on-air show's date before connecting.
+
+        Uses the presentation's ``DateGiven`` when available, otherwise wall-clock today.
+        Recreates the Doc when the id changes so a new target doesn't inherit the prior
+        session's slides. No-op when an explicit doc_id override is in effect.
+        """
+        if not self.use_date_based_doc_id:
+            return
+
+        show_date = self._read_show_date(presentation_id)
+        new_date = show_date if show_date is not None else date.today()
+        self.doc_date_from_show = show_date is not None
+        new_doc_id = self._get_date_based_doc_id(new_date)
+
+        if new_doc_id != self.doc_id:
+            source = "show DateGiven" if show_date is not None else "today"
+            logger.info(f"Resolved doc from {source}: {self.doc_id} → {new_doc_id}")
+            self.doc_id = new_doc_id
+            self._recreate_doc()
+        self.current_doc_date = new_date
 
     def _check_doc_id_change(self) -> bool:
         """Check if date-based doc ID has changed. Returns True if changed."""
-        if not self.use_date_based_doc_id:
+        if not self.use_date_based_doc_id or self.doc_date_from_show:
             return False
 
         today = date.today()
@@ -224,7 +286,11 @@ class ProclaimYjsService:
         Used inside a live session (where we must not swap the Doc out from under an
         active Provider) to decide we should end the session and roll over.
         """
-        return self.use_date_based_doc_id and date.today() != self.current_doc_date
+        return (
+            self.use_date_based_doc_id
+            and not self.doc_date_from_show
+            and date.today() != self.current_doc_date
+        )
 
     def _recreate_doc(self) -> None:
         """Start a fresh Y.Doc so a new day's document doesn't inherit yesterday's slides."""
@@ -373,11 +439,13 @@ class ProclaimYjsService:
             self.update_status_in_yjs(item_id, slide_index)
             self.last_slide_index = slide_index
 
-    async def _wait_until_on_air(self) -> None:
+    async def _wait_until_on_air(self) -> Dict[str, Any]:
         """Poll Proclaim until it reports on air, holding NO Y-Sweet connection.
 
-        We don't open (or keep) a Y-Sweet connection while nothing is happening, so
-        we never depend on a connection that was established long before it was needed.
+        Returns the first on-air status (so the caller can resolve the doc from the
+        show before connecting). We don't open (or keep) a Y-Sweet connection while
+        nothing is happening, so we never depend on a connection that was established
+        long before it was needed.
         """
         announced = False
         while True:
@@ -385,7 +453,7 @@ class ProclaimYjsService:
             status = await self._fetch_status()
             if status is not None:
                 logger.info("Proclaim is on air - connecting to Y-Sweet")
-                return
+                return status
             if not announced:
                 logger.info("Waiting for Proclaim to go on air (no Y-Sweet connection held)")
                 announced = True
@@ -466,7 +534,9 @@ class ProclaimYjsService:
         while True:
             try:
                 # Phase 1: no connection held until Proclaim is actually on air.
-                await self._wait_until_on_air()
+                on_air_status = await self._wait_until_on_air()
+                # Anchor the date-based doc to the on-air show's date before connecting.
+                self._resolve_doc_for_session(on_air_status.get('presentationId'))
                 # Phase 2: connect and sync until off air / date roll / disconnect.
                 await self._run_session()
                 # Clean end of a session - reset backoff for the next connect.
@@ -497,7 +567,12 @@ async def main():
     """Entry point with signal handling"""
     # Parse command line arguments
     parser = argparse.ArgumentParser(description='Proclaim Service - Syncs Proclaim to Yjs')
-    parser.add_argument('doc_id', nargs='?', help='Document ID (default: date-based doc-YYYY-MM-DD)')
+    parser.add_argument(
+        'doc_id',
+        nargs='?',
+        help="Document ID override. Default: doc-YYYY-MM-DD from the on-air show's "
+             "DateGiven (falling back to today's date).",
+    )
     parser.add_argument('--debug', action='store_true', help='Enable debug logging')
     args = parser.parse_args()
 

--- a/tests/test_proclaim_service.py
+++ b/tests/test_proclaim_service.py
@@ -14,6 +14,7 @@ Covered behaviors:
 """
 
 import contextlib
+from datetime import date
 from unittest import mock
 
 import anyio
@@ -73,6 +74,14 @@ def make_service():
     service.get_ysweet_token = mock.AsyncMock(return_value={"url": "ws://test"})
     # Item-change parsing hits the DB; stub it so _apply_status just records state.
     service._handle_item_change = mock.MagicMock(return_value=True)
+    return service
+
+
+def make_date_based_service():
+    """Build a date-based service (no explicit doc_id) with the Proclaim DB mocked."""
+    with mock.patch.object(ps, "ProclaimDB"):
+        service = ps.ProclaimYjsService("http://localhost:8000")
+    service.get_ysweet_token = mock.AsyncMock(return_value={"url": "ws://test"})
     return service
 
 
@@ -138,7 +147,7 @@ async def test_reconnects_after_websocket_drop(fast_timing):
     """A silently dropped websocket triggers reconnect-with-backoff, not death."""
     service = make_service()
     service._fetch_status = mock.AsyncMock(return_value=status())
-    service._wait_until_on_air = mock.AsyncMock()
+    service._wait_until_on_air = mock.AsyncMock(return_value=status())
 
     # Each session connects with a websocket that dies on its 2nd ping.
     websockets = [FakeWebSocket(fail_ping_after=2) for _ in range(5)]
@@ -176,7 +185,7 @@ async def test_reconnects_after_websocket_drop(fast_timing):
 async def test_reconnects_after_failed_token_fetch(fast_timing):
     """A cold/slow Y-Sweet (token fetch fails) is retried, not fatal."""
     service = make_service()
-    service._wait_until_on_air = mock.AsyncMock()
+    service._wait_until_on_air = mock.AsyncMock(return_value=status())
 
     calls = {"n": 0}
 
@@ -209,6 +218,84 @@ async def test_fresh_connection_repushes_current_state(fast_timing):
     # last_item_id was reset to None on connect, so the first poll counts as an
     # item change and re-pushes via _handle_item_change.
     service._handle_item_change.assert_called_with("item-9", 4, "pres-1")
+
+
+def test_parse_date_given_variants():
+    """DateGiven parsing accepts plain dates (and a stray time), rejects junk."""
+    parse = ps.ProclaimYjsService._parse_date_given
+    assert parse("2025-03-02") == date(2025, 3, 2)
+    assert parse("2025-03-02T10:30:00") == date(2025, 3, 2)
+    assert parse("2025-03-02 10:30") == date(2025, 3, 2)
+    assert parse("") is None
+    assert parse("not-a-date") is None
+    assert parse(None) is None
+
+
+def test_resolve_doc_uses_show_date():
+    """Date-based doc is anchored to the on-air show's DateGiven, with a fresh Doc."""
+    service = make_date_based_service()
+    service.db.get_presentation = mock.MagicMock(
+        return_value={"date_given": "2030-01-15", "content": {}}
+    )
+    old_doc = service.ydoc
+
+    service._resolve_doc_for_session("pres-1")
+
+    assert service.doc_id == "doc-2030-01-15"
+    assert service.doc_date_from_show is True
+    assert service.current_doc_date == date(2030, 1, 15)
+    assert service.ydoc is not old_doc  # doc recreated for the new target
+    # Anchored to a show date => never rolls over at wall-clock midnight.
+    assert service._date_rolled_over() is False
+
+
+def test_resolve_doc_falls_back_to_today_without_show_date():
+    """A show with no usable date falls back to today and stays midnight-rollable."""
+    service = make_date_based_service()
+    service.db.get_presentation = mock.MagicMock(
+        return_value={"date_given": None, "content": {}}
+    )
+
+    service._resolve_doc_for_session("pres-1")
+
+    assert service.doc_id == ps.ProclaimYjsService._get_date_based_doc_id(date.today())
+    assert service.doc_date_from_show is False
+    assert service.current_doc_date == date.today()
+
+
+def test_resolve_doc_falls_back_when_presentation_missing():
+    """A missing presentation row (DB trailing the API) falls back to today."""
+    service = make_date_based_service()
+    service.db.get_presentation = mock.MagicMock(return_value=None)
+
+    service._resolve_doc_for_session("pres-x")
+
+    assert service.doc_date_from_show is False
+    assert service.current_doc_date == date.today()
+
+
+def test_resolve_doc_noop_with_explicit_doc_id():
+    """An explicit doc_id override is left untouched (no DB read, no Doc swap)."""
+    service = make_service()  # explicit doc_id="doc-test"
+    old_doc = service.ydoc
+
+    service._resolve_doc_for_session("pres-1")
+
+    assert service.doc_id == "doc-test"
+    assert service.ydoc is old_doc
+    assert service.doc_date_from_show is False
+
+
+async def test_wait_until_on_air_returns_status(fast_timing):
+    """_wait_until_on_air hands the on-air status back so the caller can resolve the doc."""
+    service = make_service()
+    service._fetch_status = mock.AsyncMock(return_value=status(item_id="item-7"))
+
+    with anyio.fail_after(2):
+        result = await service._wait_until_on_air()
+
+    assert result["status"]["itemId"] == "item-7"
+    assert result["presentationId"] == "pres-1"
 
 
 def test_recreate_doc_resets_state():


### PR DESCRIPTION
The Proclaim service derived its date-based doc id from wall-clock today,
so a slideshow prepared the night before synced to the wrong day's doc
and only landed on the right one after midnight rollover.

When using the default date-based doc, resolve the doc id from the on-air
show's DateGiven (Proclaim's scheduled date) at the start of each session,
falling back to today's date when a show has no usable date. A show-dated
doc is authoritative and does not roll over at midnight; the wall-clock
fallback keeps its existing midnight-rollover behavior. An explicit doc_id
override still wins and skips date resolution entirely.

- proclaim_lib: expose DateGiven from get_presentation
- proclaim_service: parse DateGiven, resolve doc per session, recreate the
  Doc when the target changes; _wait_until_on_air now returns the status
- tests: cover date parsing, show-date resolution, fallbacks, and override

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PpcqUn5piuT9UzaBasW3rV