### PR TITLE
Fix straightforward ESLint errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,9 @@ npm test -- path/to/test.ts --run
 # Lint code
 npm run lint
 
+# Type-check without a full production build
+npm run typecheck
+
 # Build for production (requires npm install first)
 npm run build
 
@@ -75,6 +78,7 @@ npm start
 **Important**:
 - Always run `npm install` before building or testing, especially in fresh environments. The build will fail with module resolution errors if dependencies aren't installed.
 - When running tests via tools/agents, use `--no-color` flag to disable ANSI color codes in output.
+- The root `tsconfig.json` is a solution-style config (`files: []` + `references`), so plain `tsc --noEmit -p .` silently checks nothing. Use `npm run typecheck` (or `tsc -b`) to actually type-check.
 
 ### Python (Proclaim service)
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -b && vite build",
+    "typecheck": "tsc -b",
     "start": "env PORT=5008 node server.ts",
     "dev": "vite --host 127.0.0.1",
     "lint": "eslint .",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -173,7 +173,7 @@ function HomePage() {
 function PagePart({ componentStr, onReplace }: { componentStr: string; onReplace: (newName: string) => void }) {
   const [fontSize, setFontSize] = useAtom(fontSizeAtom);
   const ydoc = useYDoc();
-  // eslint-disable-next-line react-hooks/immutability, @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line react-hooks/immutability, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
   (window as any).ydoc = ydoc; // Expose YDoc on window for debugging
   const s = useStrings();
   const locale = resolveLocale();

--- a/src/BilingualBlockViewerContainer.tsx
+++ b/src/BilingualBlockViewerContainer.tsx
@@ -1,8 +1,7 @@
 import type React from 'react';
 import { useEffect, useState, useMemo } from 'react';
 import { useYDoc, useMap } from '@y-sweet/react';
-import type * as Y from 'yjs';
-import { type Block, yMapToBlock, compareBlockPositions } from './blockTypes';
+import { type Block, type BlockYMap, yMapToBlock, compareBlockPositions } from './blockTypes';
 import { BilingualBlockViewer } from './BilingualBlockViewer';
 
 interface BilingualBlockViewerContainerProps {
@@ -34,7 +33,7 @@ export function BilingualBlockViewerContainer({
 
   // Get the sourceBlocks array
   const sourceBlocks = useMemo(
-    () => ydoc.getArray<Y.Map<any>>('sourceBlocks'),
+    () => ydoc.getArray<BlockYMap>('sourceBlocks'),
     [ydoc]
   );
 

--- a/src/BlockEditor.test.tsx
+++ b/src/BlockEditor.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import * as Y from 'yjs';
 import { BlockEditor } from './BlockEditor';
 import { createBlock, getPosition, addBlockToYArray, createSequentialPositions, type BlockYMap } from './blockTypes';
+import { yTextToString } from './yjsUtils';
 
 const positions = createSequentialPositions(10);
 
@@ -112,8 +113,7 @@ describe('BlockEditor', () => {
       await waitFor(() => {
         const yMap = yArray.get(0);
         const yText = yMap.get('content') as Y.Text;
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        expect(yText.toString()).toBe('Updated text');
+        expect(yTextToString(yText)).toBe('Updated text');
       });
     });
 
@@ -179,10 +179,8 @@ describe('BlockEditor', () => {
         expect(yArray.length).toBe(2);
         const block1 = yArray.get(0);
         const block2 = yArray.get(1);
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        expect((block1.get('content') as Y.Text).toString()).toBe('Hello ');
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        expect((block2.get('content') as Y.Text).toString()).toBe('World');
+        expect(yTextToString(block1.get('content') as Y.Text)).toBe('Hello ');
+        expect(yTextToString(block2.get('content') as Y.Text)).toBe('World');
       });
     });
 
@@ -357,8 +355,7 @@ describe('BlockEditor', () => {
         expect(yMap.get('type')).toBe('heading');
         expect(yMap.get('level')).toBe(0);
         // Content should not include the #
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        expect((yMap.get('content') as Y.Text).toString()).toBe('Test');
+        expect(yTextToString(yMap.get('content') as Y.Text)).toBe('Test');
       });
     });
 
@@ -397,8 +394,7 @@ describe('BlockEditor', () => {
         const yMap = yArray.get(0);
         expect(yMap.get('level')).toBe(5);
         // Content should not include the #
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        expect((yMap.get('content') as Y.Text).toString()).toBe('Test');
+        expect(yTextToString(yMap.get('content') as Y.Text)).toBe('Test');
       });
     });
 
@@ -419,8 +415,7 @@ describe('BlockEditor', () => {
         const yMap = yArray.get(0);
         expect(yMap.get('type')).toBe('bullet');
         // Content should include the #
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        expect((yMap.get('content') as Y.Text).toString()).toBe('Test#');
+        expect(yTextToString(yMap.get('content') as Y.Text)).toBe('Test#');
       });
     });
   });
@@ -555,8 +550,7 @@ describe('BlockEditor', () => {
       await waitFor(() => {
         // Check that second block now has a position before first
         const blocks = yArray.toArray().map(yMap => ({
-          // eslint-disable-next-line @typescript-eslint/no-base-to-string
-          content: (yMap.get('content') as Y.Text).toString(),
+          content: yTextToString(yMap.get('content') as Y.Text),
           position: yMap.get('position') as string
         }));
         blocks.sort((a, b) => a.position < b.position ? -1 : 1);
@@ -582,8 +576,7 @@ describe('BlockEditor', () => {
 
       await waitFor(() => {
         const blocks = yArray.toArray().map(yMap => ({
-          // eslint-disable-next-line @typescript-eslint/no-base-to-string
-          content: (yMap.get('content') as Y.Text).toString(),
+          content: yTextToString(yMap.get('content') as Y.Text),
           position: yMap.get('position') as string
         }));
         blocks.sort((a, b) => a.position < b.position ? -1 : 1);
@@ -723,8 +716,7 @@ describe('BlockEditor', () => {
 
       await waitFor(() => {
         const blocks = yArray.toArray().map(yMap => ({
-          // eslint-disable-next-line @typescript-eslint/no-base-to-string
-          content: (yMap.get('content') as Y.Text).toString(),
+          content: yTextToString(yMap.get('content') as Y.Text),
           position: yMap.get('position') as string
         }));
         blocks.sort((a, b) => a.position < b.position ? -1 : 1);
@@ -749,8 +741,7 @@ describe('BlockEditor', () => {
 
       await waitFor(() => {
         const blocks = yArray.toArray().map(yMap => ({
-          // eslint-disable-next-line @typescript-eslint/no-base-to-string
-          content: (yMap.get('content') as Y.Text).toString(),
+          content: yTextToString(yMap.get('content') as Y.Text),
           position: yMap.get('position') as string
         }));
         blocks.sort((a, b) => a.position < b.position ? -1 : 1);

--- a/src/BlockEditor.test.tsx
+++ b/src/BlockEditor.test.tsx
@@ -3,13 +3,13 @@ import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as Y from 'yjs';
 import { BlockEditor } from './BlockEditor';
-import { createBlock, getPosition, addBlockToYArray, createSequentialPositions } from './blockTypes';
+import { createBlock, getPosition, addBlockToYArray, createSequentialPositions, type BlockYMap } from './blockTypes';
 
 const positions = createSequentialPositions(10);
 
 describe('BlockEditor', () => {
   let ydoc: Y.Doc;
-  let yArray: Y.Array<Y.Map<any>>;
+  let yArray: Y.Array<BlockYMap>;
 
   beforeEach(() => {
     ydoc = new Y.Doc();
@@ -112,13 +112,14 @@ describe('BlockEditor', () => {
       await waitFor(() => {
         const yMap = yArray.get(0);
         const yText = yMap.get('content') as Y.Text;
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
         expect(yText.toString()).toBe('Updated text');
       });
     });
 
     it('calls onTextChanged callback when content changes', async () => {
       const user = userEvent.setup();
-      const onTextChanged = vi.fn();
+      const onTextChanged = vi.fn<(markdown: string) => void>();
       const positions = createSequentialPositions(1);
       const block = createBlock('Test', 'bullet', 0, positions[0]);
       addBlockToYArray(yArray, block);
@@ -178,7 +179,9 @@ describe('BlockEditor', () => {
         expect(yArray.length).toBe(2);
         const block1 = yArray.get(0);
         const block2 = yArray.get(1);
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
         expect((block1.get('content') as Y.Text).toString()).toBe('Hello ');
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
         expect((block2.get('content') as Y.Text).toString()).toBe('World');
       });
     });
@@ -354,6 +357,7 @@ describe('BlockEditor', () => {
         expect(yMap.get('type')).toBe('heading');
         expect(yMap.get('level')).toBe(0);
         // Content should not include the #
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
         expect((yMap.get('content') as Y.Text).toString()).toBe('Test');
       });
     });
@@ -393,6 +397,7 @@ describe('BlockEditor', () => {
         const yMap = yArray.get(0);
         expect(yMap.get('level')).toBe(5);
         // Content should not include the #
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
         expect((yMap.get('content') as Y.Text).toString()).toBe('Test');
       });
     });
@@ -414,6 +419,7 @@ describe('BlockEditor', () => {
         const yMap = yArray.get(0);
         expect(yMap.get('type')).toBe('bullet');
         // Content should include the #
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
         expect((yMap.get('content') as Y.Text).toString()).toBe('Test#');
       });
     });
@@ -549,6 +555,7 @@ describe('BlockEditor', () => {
       await waitFor(() => {
         // Check that second block now has a position before first
         const blocks = yArray.toArray().map(yMap => ({
+          // eslint-disable-next-line @typescript-eslint/no-base-to-string
           content: (yMap.get('content') as Y.Text).toString(),
           position: yMap.get('position') as string
         }));
@@ -575,6 +582,7 @@ describe('BlockEditor', () => {
 
       await waitFor(() => {
         const blocks = yArray.toArray().map(yMap => ({
+          // eslint-disable-next-line @typescript-eslint/no-base-to-string
           content: (yMap.get('content') as Y.Text).toString(),
           position: yMap.get('position') as string
         }));
@@ -641,7 +649,7 @@ describe('BlockEditor', () => {
       render(<BlockEditor yArray={yArray} />);
 
       await user.click(screen.getByText('Second'));
-      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+      const textarea: HTMLTextAreaElement = screen.getByRole('textbox');
 
       // Move cursor to start
       textarea.setSelectionRange(0, 0);
@@ -649,7 +657,7 @@ describe('BlockEditor', () => {
 
       // Should focus first block
       await waitFor(() => {
-        const activeTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+        const activeTextarea: HTMLTextAreaElement = screen.getByRole('textbox');
         expect(activeTextarea.value).toBe('First');
       });
     });
@@ -664,7 +672,7 @@ describe('BlockEditor', () => {
       render(<BlockEditor yArray={yArray} />);
 
       await user.click(screen.getByText('First'));
-      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+      const textarea: HTMLTextAreaElement = screen.getByRole('textbox');
 
       // Move cursor to end
       textarea.setSelectionRange(textarea.value.length, textarea.value.length);
@@ -672,7 +680,7 @@ describe('BlockEditor', () => {
 
       // Should focus second block
       await waitFor(() => {
-        const activeTextarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+        const activeTextarea: HTMLTextAreaElement = screen.getByRole('textbox');
         expect(activeTextarea.value).toBe('Second');
       });
     });
@@ -715,6 +723,7 @@ describe('BlockEditor', () => {
 
       await waitFor(() => {
         const blocks = yArray.toArray().map(yMap => ({
+          // eslint-disable-next-line @typescript-eslint/no-base-to-string
           content: (yMap.get('content') as Y.Text).toString(),
           position: yMap.get('position') as string
         }));
@@ -740,6 +749,7 @@ describe('BlockEditor', () => {
 
       await waitFor(() => {
         const blocks = yArray.toArray().map(yMap => ({
+          // eslint-disable-next-line @typescript-eslint/no-base-to-string
           content: (yMap.get('content') as Y.Text).toString(),
           position: yMap.get('position') as string
         }));
@@ -847,7 +857,7 @@ describe('BlockEditor', () => {
 
   describe('Markdown Serialization', () => {
     it('generates correct markdown through onTextChanged', async () => {
-      const onTextChanged = vi.fn();
+      const onTextChanged = vi.fn<(markdown: string) => void>();
 
       const block1 = createBlock('Title', 'heading', 0, positions[0]);
       const block2 = createBlock('First point', 'bullet', 0, positions[1]);
@@ -868,7 +878,7 @@ describe('BlockEditor', () => {
     });
 
     it('skips empty blocks when serializing', async () => {
-      const onTextChanged = vi.fn();
+      const onTextChanged = vi.fn<(markdown: string) => void>();
 
       const block1 = createBlock('Title', 'heading', 0, positions[0]);
       const block2 = createBlock('', 'bullet', 0, positions[1]); // empty
@@ -962,7 +972,7 @@ describe('BlockEditor', () => {
   });
 
   describe('Yjs Integration', () => {
-    it('maintains block order using fractional indices', async () => {
+    it('maintains block order using fractional indices', () => {
       // Create blocks with explicit fractional index positions
       const block1 = createBlock('First', 'bullet', 0, 'a0');
       const block2 = createBlock('Second', 'bullet', 0, 'a1');

--- a/src/BlockEditor.tsx
+++ b/src/BlockEditor.tsx
@@ -5,6 +5,7 @@ import { generateKeyBetween } from 'fractional-indexing';
 import {
   Block,
   BlockType,
+  BlockYMap,
   createBlock,
   yMapToBlock,
   updateYMap,
@@ -19,7 +20,7 @@ import {
 const SHOW_BUTTONS = true;
 
 interface BlockEditorProps {
-  yArray: Y.Array<Y.Map<any>>;
+  yArray: Y.Array<BlockYMap>;
   onTextChanged?: (markdown: string) => void;
   onBlocksChanged?: (blocks: Block[]) => void;
   editable?: boolean;
@@ -28,7 +29,7 @@ interface BlockEditorProps {
 
 interface BlockItemProps {
   blockId: string;
-  yArray: Y.Array<Y.Map<any>>;
+  yArray: Y.Array<BlockYMap>;
   isFocused: boolean;
   isFirst: boolean;
   isLast: boolean;
@@ -63,7 +64,10 @@ const BlockItem = memo(function BlockItem({
   // Find the Y.Map for this specific block
   const yMap = useMemo(() => {
     return yArray.toArray().find(map => map.get('id') === blockId);
-  }, [yArray, blockId, version]); // Include version to refresh when array changes
+    // version isn't read here, but must stay a dependency to force re-lookup
+    // when the underlying Yjs map mutates.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [yArray, blockId, version]);
 
   // Observe only this block's Y.Map
   useEffect(() => {
@@ -335,7 +339,7 @@ export function BlockEditor({ yArray, onTextChanged, onBlocksChanged, editable =
       const nextPos = currentIndex < sortedBlocks.length - 1
         ? sortedBlocks[currentIndex + 1].position
         : null;
-      const newPosition = generateKeyBetween(currentPos, nextPos) as string;
+      const newPosition = generateKeyBetween(currentPos, nextPos);
 
       const newBlock = createBlock(
         content,

--- a/src/SourceTextTranslationManager.tsx
+++ b/src/SourceTextTranslationManager.tsx
@@ -3,7 +3,7 @@ import { useCallback, useRef } from "react";
 import * as Y from "yjs";
 import { isEditorAtom, languages } from "./configAtoms";
 import { BlockEditor } from "./BlockEditor";
-import type { Block } from "./blockTypes";
+import type { Block, BlockYMap } from "./blockTypes";
 import type { TranslationBlock } from "./translationUtils";
 import { useTranslationManager } from "./useTranslationManager";
 
@@ -16,7 +16,7 @@ const modifierKeyPrefix =
 export function SourceTextTranslationManager({ ydoc }: { ydoc: Y.Doc }) {
   const sourceBlocksRef = useRef<TranslationBlock[]>([]);
   const isEditor = useAtomValue(isEditorAtom);
-  const sourceBlocks = ydoc.getArray<Y.Map<string | number>>("sourceBlocks");
+  const sourceBlocks = ydoc.getArray<BlockYMap>("sourceBlocks");
   const {
     isTranslating,
     translationError,

--- a/src/blockTypes.ts
+++ b/src/blockTypes.ts
@@ -1,6 +1,6 @@
 import * as Y from 'yjs';
 import { v4 as uuidv4 } from 'uuid';
-import { setYTextFromString } from './yjsUtils';
+import { setYTextFromString, yTextToString } from './yjsUtils';
 import { generateKeyBetween } from 'fractional-indexing';
 
 export type BlockType = 'heading' | 'bullet';
@@ -71,8 +71,7 @@ export function yMapToBlock(yMap: BlockYMap): Block {
 
   return {
     id: id || uuidv4(),
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    content: yText ? yText.toString() : '',
+    content: yText ? yTextToString(yText) : '',
     type: type || 'bullet',
     level: level ?? 0,
     position: position || getPosition(null, null),
@@ -108,8 +107,7 @@ export function updateYMap(yMap: BlockYMap, block: Partial<Block>): void {
         }
       } else {
         // Existing Y.Text - update it using diff-based approach
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        const currentText = yText.toString();
+        const currentText = yTextToString(yText);
         if (currentText !== block.content) {
           setYTextFromString(yText, block.content);
         }

--- a/src/blockTypes.ts
+++ b/src/blockTypes.ts
@@ -13,6 +13,10 @@ export interface Block {
   position: string; // Fractional index for stable ordering
 }
 
+// The Y.Map backing a block holds a mix of these value types (id/type/position
+// are strings, level is a number, content is a Y.Text).
+export type BlockYMap = Y.Map<string | number | Y.Text>;
+
 export const MAX_INDENT_LEVEL = 5;
 
 /**
@@ -48,7 +52,7 @@ export function getPosition(prevBlock: Block | null, nextBlock: Block | null): s
  *
  * Logs warnings if expected fields are missing - indicates incorrect state.
  */
-export function yMapToBlock(yMap: Y.Map<any>): Block {
+export function yMapToBlock(yMap: BlockYMap): Block {
   const yText = yMap.get('content') as Y.Text | undefined;
   const id = yMap.get('id') as string | undefined;
   const type = yMap.get('type') as BlockType | undefined;
@@ -82,7 +86,7 @@ export function yMapToBlock(yMap: Y.Map<any>): Block {
  * All updates are wrapped in a transaction to ensure atomicity when multiple
  * fields are updated simultaneously.
  */
-export function updateYMap(yMap: Y.Map<any>, block: Partial<Block>): void {
+export function updateYMap(yMap: BlockYMap, block: Partial<Block>): void {
   const doc = yMap.doc;
 
   const performUpdates = () => {
@@ -133,8 +137,8 @@ export function updateYMap(yMap: Y.Map<any>, block: Partial<Block>): void {
  * 
  * This avoids warnings from Yjs about modifying a Y.Map before it's attached to a document.
  */
-export function addBlockToYArray(yArray: Y.Array<Y.Map<any>>, block: Block): void {
-  const yMap = new Y.Map();
+export function addBlockToYArray(yArray: Y.Array<BlockYMap>, block: Block): void {
+  const yMap: BlockYMap = new Y.Map();
   yArray.push([yMap]);
   if (yArray.doc == null) {
     updateYMap(yMap, block);
@@ -169,7 +173,7 @@ export function serializeBlocksToMarkdown(blocks: Block[]): string {
 /**
  * Ensure there's always at least one block
  */
-export function ensureMinimumBlocks(yArray: Y.Array<Y.Map<any>>): void {
+export function ensureMinimumBlocks(yArray: Y.Array<BlockYMap>): void {
   if (yArray.length > 0) {
     return;
   }
@@ -180,7 +184,7 @@ export function ensureMinimumBlocks(yArray: Y.Array<Y.Map<any>>): void {
 /**
  * Get the Y.Text for a block's content
  */
-export function getBlockYText(yMap: Y.Map<any>): Y.Text {
+export function getBlockYText(yMap: BlockYMap): Y.Text {
   let yText = yMap.get('content') as Y.Text | undefined;
   if (!yText) {
     yText = new Y.Text();
@@ -220,7 +224,7 @@ export function createSequentialPositions(count: number): string[] {
   let prevPos: string | null = null;
 
   for (let i = 0; i < count; i++) {
-    const pos = generateKeyBetween(prevPos, null) as string;
+    const pos = generateKeyBetween(prevPos, null);
     positions.push(pos);
     prevPos = pos;
   }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -14,4 +14,4 @@ global.Audio = vi.fn().mockImplementation(() => ({
   addEventListener: vi.fn(),
   removeEventListener: vi.fn(),
   load: vi.fn(),
-})) as unknown as typeof Audio;
+}));

--- a/src/translationUtils.ts
+++ b/src/translationUtils.ts
@@ -1,5 +1,5 @@
 
-export function findContiguousBlocks(arr: any[]) {
+export function findContiguousBlocks(arr: unknown[]) {
     const blocks = [];
     let start = -1;
 
@@ -37,12 +37,6 @@ export interface TranslationCache {
     has(key: string): boolean;
 }
 
-export interface GenericMap {
-    get(key: string): any;
-    set(key: string, value: any): void;
-    has(key: string): boolean;
-}
-
 type ChunkStatus = 0 | 1 | 2; // 0: skip, 1: translate, 2: context
 
 export function translationCacheKey(language: string, chunkText: string) {
@@ -51,10 +45,21 @@ export function translationCacheKey(language: string, chunkText: string) {
     return `${language}:${chunkText}`;
 }
 
-export function updateTranslationCache(serverResponse: any, translationCache: TranslationCache) {
+interface TranslationApiResult {
+    sourceText: string;
+    translatedText: string;
+    language: string;
+}
+
+export interface TranslationApiResponse {
+    ok: boolean;
+    error?: string;
+    results: TranslationApiResult[][];
+}
+
+export function updateTranslationCache(serverResponse: TranslationApiResponse, translationCache: TranslationCache) {
     // For each block, the server gave us a list of updated chunks, which we can use to update the translation cache.
-    const translationResults = serverResponse.results as { sourceText: string; translatedText: string; language: string}[][];
-    for (const block of translationResults) {
+    for (const block of serverResponse.results) {
     for (const result of block) {
         const { sourceText, translatedText, language } = result;
         // There shouldn't be anything to trim, but just in case, trim the source and translated text.
@@ -189,7 +194,7 @@ export async function fetchAndCacheTranslations(
             body: JSON.stringify({ translationTodos, language }),
         });
 
-        const result = await response.json().catch(() => null);
+        const result = await response.json().catch(() => null) as TranslationApiResponse | null;
         if (!response.ok || !result?.ok) {
             if (result?.error) {
                 throw new Error(`Translation error (${response.status}): ${result.error}`);

--- a/src/useTTS.test.ts
+++ b/src/useTTS.test.ts
@@ -58,7 +58,7 @@ describe('useTTS', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({ audioUrl: 'http://example.com/audio.mp3' }),
-    } as unknown as Response);
+    });
   });
 
   afterEach(() => {
@@ -312,7 +312,7 @@ describe('useTTS', () => {
       global.fetch = vi.fn().mockResolvedValue({
         ok: true,
         json: vi.fn().mockResolvedValue({ audioUrl: 'http://example.com/audio.mp3' }),
-      } as unknown as Response);
+      });
 
       // Second attempt should work
       act(() => {

--- a/src/useTranslationManager.ts
+++ b/src/useTranslationManager.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useMap } from '@y-sweet/react';
-import type { GenericMap, TranslationBlock, TranslationCache } from './translationUtils';
+import type { TranslationBlock } from './translationUtils';
 import { fetchAndCacheTranslations } from './translationUtils';
 
 export function useTranslationManager({
@@ -12,7 +12,7 @@ export function useTranslationManager({
   sourceBlocksRef: React.RefObject<TranslationBlock[]>;
   translationCacheName: string;
 }) {
-  const translationCache = useMap(translationCacheName);
+  const translationCache = useMap<string>(translationCacheName);
   const [isTranslating, setIsTranslating] = useState(false);
   const [translationError, setTranslationError] = useState("");
 
@@ -29,7 +29,7 @@ export function useTranslationManager({
       await fetchAndCacheTranslations(
         language,
         blocks,
-        translationCache as GenericMap as TranslationCache,
+        translationCache,
       );
     }
 

--- a/src/yjsUtils.ts
+++ b/src/yjsUtils.ts
@@ -3,22 +3,27 @@ import diff from 'fast-diff';
 import { useText } from '@y-sweet/react';
 import * as Y from 'yjs';
 
+// Yjs's Y.Text.d.ts doesn't declare its (working) toString() override, so TypeScript
+// falls back to Object.prototype.toString and flags direct calls as unsafe. Centralize
+// the disable here instead of scattering it at every call site.
+export function yTextToString(yText: Y.Text): string {
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string
+  return yText.toString();
+}
+
 // Hook based on implementation here https://discuss.yjs.dev/t/plain-text-input-component-with-y-text/2358/2
 export const useAsPlainText = (name: string): [string, (newText: string) => void] => {
   const sharedText = useText(name);
-  // eslint-disable-next-line @typescript-eslint/no-base-to-string
-  const [text, setText] = useState(() => sharedText.toString());
-  
+  const [text, setText] = useState(() => yTextToString(sharedText));
+
   // Reset text state when name changes
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    setText(sharedText.toString());
+    setText(yTextToString(sharedText));
   }, [sharedText, name]);
 
   useEffect(() => {
     const observer = () => {
-      // eslint-disable-next-line @typescript-eslint/no-base-to-string
-      setText(sharedText.toString());
+      setText(yTextToString(sharedText));
     };
 
     sharedText.observe(observer);
@@ -43,8 +48,7 @@ export const usePlainTextSetter = (name: string): ((newText: string) => void) =>
 
 
 export function setYTextFromString(yText: Y.Text, text: string) {
-  // eslint-disable-next-line @typescript-eslint/no-base-to-string
-  const currentText = yText.toString();
+  const currentText = yTextToString(yText);
   if (currentText === text) return;
   const delta = diffToDelta(diff(currentText, text));
   yText.applyDelta(delta);


### PR DESCRIPTION
## Summary
- Removed unnecessary/unsafe `any` usage: replaced the scattered `Y.Map<any>` block type with a shared `BlockYMap = Y.Map<string | number | Y.Text>` alias (`blockTypes.ts` and 4 call sites), and gave the translation API response a real `TranslationApiResponse` interface instead of `any` in `translationUtils.ts` (this also surfaced and fixed a genuine pre-existing type hole in `useTranslationManager.ts`, where a `GenericMap` cast was silently masking a mismatch with `TranslationCache`).
- Added `no-base-to-string` disable comments for `Y.Text.toString()` calls in `BlockEditor.test.tsx`, matching the existing pattern already used in `yjsUtils.ts` (Yjs's `.d.ts` doesn't declare `toString()` even though it exists at runtime).
- Fixed a handful of smaller issues: unused `TranslationCache` import, unnecessary type assertions, an `async` test function with no `await`, and an intentional-but-unlabeled `useMemo` dependency in `BlockEditor.tsx` (now has an explanatory disable comment instead of being silently non-compliant).
- Verified all of the above against `npx tsc -b` (the actual build command) and `npm test`, not just `eslint`.

## A note on why some of this needed care
`eslint --fix` initially removed several `getByRole('textbox') as HTMLTextAreaElement` casts in `BlockEditor.test.tsx`, and ESLint's `no-unnecessary-type-assertion` rule agreed they were removable. But the real build (`tsc -p tsconfig.app.json`) fails without them (`Property 'setSelectionRange' does not exist on type 'HTMLElement'`).

Root cause: `getByRole<T extends HTMLElement = HTMLElement>()` is generic. When the call result is written as `expr as HTMLTextAreaElement`, TypeScript uses that assertion as a contextual type hint and infers `T = HTMLTextAreaElement` for the call itself — so the assertion is genuinely a no-op *in that context*. But naively deleting the assertion text changes the very context used for generic inference, so `T` silently falls back to the declared default `HTMLElement` post-fix, and the build breaks. ESLint's local, per-node analysis has no way to see that its own fix invalidates its own premise.

I converted those two spots to typed variable declarations (`const textarea: HTMLTextAreaElement = screen.getByRole('textbox');`) instead, which supplies the same contextual type hint through a different, ESLint-invisible-to-this-rule mechanism, satisfying both ESLint and `tsc`.

Separately: `tsc --noEmit -p .` (no `-b`) silently checks **nothing**, because the root `tsconfig.json` has `files: []` and only references sub-projects — you have to use `-b` (build mode) or point directly at `tsconfig.app.json`/`tsconfig.node.json` to catch real errors. This is an easy trap for any future lint-fixing pass to fall into, and is plausibly what caused a prior attempt at this task to get stuck and commit a build-breaking change.

## Left unfixed (3 errors)
`CurrentSlideViewer.tsx` (JSX-in-try/catch), `reactUtils.tsx` (ref write during render), and `yjsUtils.ts` (setState in effect) all trip newer React-Compiler-oriented `eslint-plugin-react-hooks` rules. These flag real architectural patterns, not typos, and none of the three affected files/hooks have test coverage to verify a refactor preserves behavior — left for a follow-up with explicit test coverage first.

## Test plan
- [x] `npm run lint` — down from 47 problems to 3 (all pre-existing architectural patterns, documented above)
- [x] `npx tsc -b` (real build-mode typecheck) — passes
- [x] `npm run build` — succeeds
- [x] `npm test -- --no-color --run` — 181/181 tests pass
- [x] `uv run pytest` — 36/36 tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01Po25LdbJAk878BfHKrgDKs)_