### PR TITLE
Add tests for lint-flagged modules and fix two latent bugs

### DIFF
--- a/src/CurrentSlideViewer.test.tsx
+++ b/src/CurrentSlideViewer.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CurrentSlideViewer, CurrentSlideViewerContainer } from './CurrentSlideViewer';
+
+// ── Container Yjs seam ──────────────────────────────────────────────────────
+// The container reads two Y.Maps via @y-sweet/react's useMap. A plain JS Map is
+// get-compatible with the code under test, so we back each hook with one we
+// control per test.
+const maps = new Map<string, Map<string, unknown>>();
+vi.mock('@y-sweet/react', () => ({
+  useMap: (name: string) => {
+    let m = maps.get(name);
+    if (!m) {
+      m = new Map<string, unknown>();
+      maps.set(name, m);
+    }
+    return m;
+  },
+}));
+
+function setStatus(fields: Record<string, unknown>) {
+  const m = new Map<string, unknown>(Object.entries(fields));
+  maps.set('proclaimStatus', m);
+}
+
+function setPresentation(itemId: string, presentation: unknown) {
+  let m = maps.get('proclaimPresentations');
+  if (!m) {
+    m = new Map<string, unknown>();
+    maps.set('proclaimPresentations', m);
+  }
+  m.set(itemId, presentation);
+}
+
+// ── Pure component ──────────────────────────────────────────────────────────
+
+describe('CurrentSlideViewer (pure)', () => {
+  it('renders the empty state when there are no slides', () => {
+    render(<CurrentSlideViewer title="T" slides={[]} currentIndex={0} />);
+    expect(screen.getByText('No slides available')).toBeInTheDocument();
+  });
+
+  it('shows only the current slide when context is 0', () => {
+    render(<CurrentSlideViewer title="T" slides={['a', 'b', 'c']} currentIndex={1} context={0} />);
+    expect(screen.getByText('b')).toBeInTheDocument();
+    expect(screen.queryByText('a')).not.toBeInTheDocument();
+    expect(screen.queryByText('c')).not.toBeInTheDocument();
+  });
+
+  it('shows previous/next context slides with labels', () => {
+    render(<CurrentSlideViewer title="T" slides={['a', 'b', 'c']} currentIndex={1} context={1} />);
+    expect(screen.getByText('a')).toBeInTheDocument();
+    expect(screen.getByText('b')).toBeInTheDocument();
+    expect(screen.getByText('c')).toBeInTheDocument();
+    expect(screen.getByText('Previous')).toBeInTheDocument();
+    expect(screen.getByText('Next')).toBeInTheDocument();
+  });
+
+  it('clamps the window at the start (no Previous label at index 0)', () => {
+    render(<CurrentSlideViewer title="T" slides={['a', 'b', 'c']} currentIndex={0} context={1} />);
+    expect(screen.getByText('a')).toBeInTheDocument();
+    expect(screen.getByText('b')).toBeInTheDocument();
+    expect(screen.queryByText('Previous')).not.toBeInTheDocument();
+    expect(screen.getByText('Next')).toBeInTheDocument();
+  });
+
+  it('splits multi-line slide text and renders blank lines as a non-breaking space', () => {
+    render(<CurrentSlideViewer title="T" slides={['line1\n\nline3']} currentIndex={0} />);
+    expect(screen.getByText('line1')).toBeInTheDocument();
+    expect(screen.getByText('line3')).toBeInTheDocument();
+    // The blank middle line renders as a non-breaking space (identity normalizer
+    // so testing-library doesn't collapse it away).
+    expect(screen.getByText('\u00A0', { normalizer: (s) => s })).toBeInTheDocument();
+  });
+
+  // Regression: Proclaim publishes status and presentation as two separate writes,
+  // so currentIndex can transiently point past the known slides. The viewer must
+  // show a real slide, not a blank container.
+  it('clamps an out-of-range currentIndex to the last slide', () => {
+    render(<CurrentSlideViewer title="T" slides={['a', 'b', 'c']} currentIndex={5} context={0} />);
+    expect(screen.getByText('c')).toBeInTheDocument();
+    expect(screen.queryByText('a')).not.toBeInTheDocument();
+    expect(screen.queryByText('b')).not.toBeInTheDocument();
+  });
+
+  it('clamps a negative currentIndex to the first slide', () => {
+    render(<CurrentSlideViewer title="T" slides={['a', 'b', 'c']} currentIndex={-1} context={0} />);
+    expect(screen.getByText('a')).toBeInTheDocument();
+    expect(screen.queryByText('c')).not.toBeInTheDocument();
+  });
+});
+
+// ── Container ───────────────────────────────────────────────────────────────
+
+describe('CurrentSlideViewerContainer', () => {
+  beforeEach(() => {
+    maps.clear();
+  });
+
+  it('renders the waiting state when there is no itemId', () => {
+    setStatus({});
+    render(<CurrentSlideViewerContainer />);
+    expect(screen.getByText('Waiting for Proclaim data...')).toBeInTheDocument();
+  });
+
+  it('renders the waiting state when the presentation is missing', () => {
+    setStatus({ itemId: 'item-1', slideIndex: 0 });
+    // no presentation registered for item-1
+    render(<CurrentSlideViewerContainer />);
+    expect(screen.getByText('Waiting for Proclaim data...')).toBeInTheDocument();
+  });
+
+  it('renders the current slide on the happy path', () => {
+    setStatus({ itemId: 'item-1', slideIndex: 1 });
+    setPresentation('item-1', { title: 'Sermon', slides: ['first', 'second', 'third'] });
+    render(<CurrentSlideViewerContainer />);
+    expect(screen.getByText('second')).toBeInTheDocument();
+  });
+
+  it('defaults slideIndex to 0 when absent', () => {
+    setStatus({ itemId: 'item-1' });
+    setPresentation('item-1', { title: 'Sermon', slides: ['first', 'second'] });
+    render(<CurrentSlideViewerContainer />);
+    expect(screen.getByText('first')).toBeInTheDocument();
+  });
+
+  it('filters out non-string slide entries', () => {
+    setStatus({ itemId: 'item-1', slideIndex: 0 });
+    setPresentation('item-1', { title: 'Sermon', slides: ['ok', null, 42, 'also-ok'] });
+    render(<CurrentSlideViewerContainer />);
+    // With the bad entries dropped, index 0 is 'ok' and there is no throw/blank.
+    expect(screen.getByText('ok')).toBeInTheDocument();
+  });
+});

--- a/src/CurrentSlideViewer.tsx
+++ b/src/CurrentSlideViewer.tsx
@@ -22,17 +22,6 @@ export function CurrentSlideViewer({
   context = 0
 }: CurrentSlideViewerProps) {
   const s = useStrings();
-  // Build array of slides to display with context
-  const startIdx = Math.max(0, currentIndex - context);
-  const endIdx = Math.min(slides.length - 1, currentIndex + context);
-
-  const visibleSlides: Slide[] = [];
-  for (let i = startIdx; i <= endIdx; i++) {
-    visibleSlides.push({
-      text: slides[i],
-      isActive: i === currentIndex,
-    });
-  }
 
   if (slides.length === 0) {
     return (
@@ -40,6 +29,22 @@ export function CurrentSlideViewer({
         <div className="text-gray-500 dark:text-gray-400">{s.noSlides}</div>
       </div>
     );
+  }
+
+  // Clamp the index into range: Proclaim publishes status and presentation as
+  // separate writes, so currentIndex can transiently point past the slides.
+  const clampedIndex = Math.min(Math.max(currentIndex, 0), slides.length - 1);
+
+  // Build array of slides to display with context
+  const startIdx = Math.max(0, clampedIndex - context);
+  const endIdx = Math.min(slides.length - 1, clampedIndex + context);
+
+  const visibleSlides: Slide[] = [];
+  for (let i = startIdx; i <= endIdx; i++) {
+    visibleSlides.push({
+      text: slides[i],
+      isActive: i === clampedIndex,
+    });
   }
 
   return (
@@ -73,7 +78,7 @@ export function CurrentSlideViewer({
             </div>
             {!slide.isActive && (
               <div className="text-xs text-gray-500 dark:text-gray-600 mt-1 text-center">
-                {startIdx + idx < currentIndex ? s.previous : s.next}
+                {startIdx + idx < clampedIndex ? s.previous : s.next}
               </div>
             )}
           </div>
@@ -91,49 +96,36 @@ export function CurrentSlideViewerContainer() {
   const statusMap = useMap('proclaimStatus');
   const presentationsMap = useMap('proclaimPresentations');
 
-  try {
-    // Read current status
-    const itemId = statusMap.get('itemId') as string | undefined;
-    if (!itemId) {
-      throw new Error('No itemId in statusMap');
-    }
-    const slideIndex = (statusMap.get('slideIndex') as number) ?? 0;
+  // Read current status and presentation data.
+  const itemId = statusMap.get('itemId') as string | undefined;
+  const presentation = itemId
+    ? (presentationsMap.get(itemId) as { title: string; slides: string[] } | undefined)
+    : undefined;
 
-    // Read presentation data
-    const presentation = presentationsMap.get(itemId) as { title: string; slides: string[] } | undefined;
-    if (!presentation) {
-      throw new Error('Presentation not found');
-    }
-
-    const title = presentation.title || s.untitledPresentation;
-    const slidesArray = presentation.slides || [];
-    const slides: string[] = [];
-
-    if (slidesArray.length > 0) {
-      for (let i = 0; i < slidesArray.length; i++) {
-        const slide = slidesArray[i];
-        if (typeof slide === 'string') {
-          slides.push(slide);
-        }
-      }
-    }
-
+  // Without a current item or its presentation, we have nothing to show yet.
+  if (!itemId || !presentation) {
     return (
-      <CurrentSlideViewer
-        title={title}
-        slides={slides}
-        currentIndex={slideIndex}
-        context={0}
-      />
-    );
-  } catch {
-      return (
-        <div className="flex items-center justify-center bg-gray-50 dark:bg-gray-900">
-          <div className="text-gray-500 dark:text-gray-400">
-            {s.waitingForProclaim}
-            <div className="text-xs mt-2">{s.isProclaimRunning}</div>
-          </div>
+      <div className="flex items-center justify-center bg-gray-50 dark:bg-gray-900">
+        <div className="text-gray-500 dark:text-gray-400">
+          {s.waitingForProclaim}
+          <div className="text-xs mt-2">{s.isProclaimRunning}</div>
         </div>
-      );
+      </div>
+    );
   }
+
+  const slideIndex = (statusMap.get('slideIndex') as number) ?? 0;
+  const title = presentation.title || s.untitledPresentation;
+  const slides = (presentation.slides || []).filter(
+    (slide): slide is string => typeof slide === 'string',
+  );
+
+  return (
+    <CurrentSlideViewer
+      title={title}
+      slides={slides}
+      currentIndex={slideIndex}
+      context={0}
+    />
+  );
 }

--- a/src/reactUtils.test.tsx
+++ b/src/reactUtils.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { useScrollToBottom } from './reactUtils';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * A fake scroll-parent element that tracks scrollTo calls and reports a fixed
+ * rect. Returns the mock separately so assertions target a plain mock (not an
+ * HTMLElement method, which trips @typescript-eslint/unbound-method).
+ */
+function makeParent(bottom = 100, scrollTop = 50) {
+  const scrollTo = vi.fn();
+  const el = {
+    scrollTop,
+    scrollTo,
+    getBoundingClientRect: () => ({ bottom }) as DOMRect,
+  } as unknown as HTMLElement;
+  return { el, scrollTo };
+}
+
+/** A fake target element that reports a fixed rect. */
+function makeTarget(bottom = 200) {
+  return {
+    getBoundingClientRect: () => ({ bottom }) as DOMRect,
+  } as unknown as HTMLElement;
+}
+
+describe('useScrollToBottom', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('scrolls the parent so the target sits at the bottom after the debounce', () => {
+    const { el, scrollTo } = makeParent(100, 50);
+    const parentRef = { current: el };
+    const targetRef = { current: makeTarget(200) };
+
+    renderHook(({ deps }) => useScrollToBottom(parentRef, targetRef, deps, true), {
+      initialProps: { deps: [0] as unknown[] },
+    });
+
+    // Debounced: nothing fires immediately.
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    // scrollTop (50) + (targetBottom 200 - parentBottom 100) = 150
+    expect(scrollTo).toHaveBeenCalledWith({ top: 150, behavior: 'smooth' });
+  });
+
+  it('does not scroll when disabled', () => {
+    const { el, scrollTo } = makeParent();
+    const parentRef = { current: el };
+    const targetRef = { current: makeTarget() };
+
+    renderHook(({ deps }) => useScrollToBottom(parentRef, targetRef, deps, false), {
+      initialProps: { deps: [0] as unknown[] },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('coalesces rapid dependency changes into a single scroll', () => {
+    const { el, scrollTo } = makeParent();
+    const parentRef = { current: el };
+    const targetRef = { current: makeTarget() };
+
+    const { rerender } = renderHook(
+      ({ deps }) => useScrollToBottom(parentRef, targetRef, deps, true),
+      { initialProps: { deps: [0] as unknown[] } },
+    );
+
+    // Several dependency changes land inside the 100ms debounce window.
+    rerender({ deps: [1] });
+    rerender({ deps: [2] });
+    rerender({ deps: [3] });
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing (and does not throw) when refs are missing', () => {
+    const parentRef = { current: null as HTMLElement | null };
+    const targetRef = { current: null as HTMLElement | null };
+
+    renderHook(({ deps }) => useScrollToBottom(parentRef, targetRef, deps, true), {
+      initialProps: { deps: [0] as unknown[] },
+    });
+
+    expect(() =>
+      act(() => {
+        vi.advanceTimersByTime(100);
+      }),
+    ).not.toThrow();
+  });
+
+  // Regression: if the pending timeout fires while a ref is transiently null, the
+  // callback must not leave the internal timeout handle stuck non-null — otherwise
+  // every subsequent scroll is permanently blocked for the component's lifetime.
+  it('recovers after a timeout fires with a missing ref (does not wedge)', () => {
+    const { el, scrollTo } = makeParent();
+    const parentRef = { current: el };
+    const targetRef = { current: makeTarget() as HTMLElement | null };
+
+    const { rerender } = renderHook(
+      ({ deps }) => useScrollToBottom(parentRef, targetRef, deps, true),
+      { initialProps: { deps: [0] as unknown[] } },
+    );
+
+    // Target detaches right before the scheduled timeout fires.
+    targetRef.current = null;
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    // Target reattaches and new content arrives.
+    targetRef.current = makeTarget();
+    rerender({ deps: [1] });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    // Auto-scroll must resume, not stay wedged.
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/reactUtils.tsx
+++ b/src/reactUtils.tsx
@@ -8,7 +8,9 @@ export function useScrollToBottom(
 ) {
   const timeoutRef = React.useRef<NodeJS.Timeout | null>(null);
   const enabledRef = React.useRef(enabled);
-  enabledRef.current = enabled;
+  React.useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
   React.useEffect(() => {
     if (timeoutRef.current || !enabledRef.current) {
       return;
@@ -18,6 +20,10 @@ export function useScrollToBottom(
     if (!scrollParent || !target) return;
 
     timeoutRef.current = setTimeout(() => {
+      // Clear the handle first so a bailout below can't leave it stuck non-null,
+      // which would permanently block every future scroll for this component.
+      timeoutRef.current = null;
+
       const scrollParent = scrollParentRef.current;
       const target = targetRef.current;
       if (!scrollParent || !target || !enabledRef.current) return;
@@ -31,7 +37,6 @@ export function useScrollToBottom(
         top: scrollTop,
         behavior: 'smooth',
       });
-      timeoutRef.current = null;
     }, 100);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);

--- a/src/yjsUtils.test.ts
+++ b/src/yjsUtils.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import * as Y from 'yjs';
+import { yTextToString, setYTextFromString, useAsPlainText } from './yjsUtils';
+
+// ── useText seam ────────────────────────────────────────────────────────────
+// useAsPlainText subscribes to a Y.Text obtained from @y-sweet/react's useText.
+// Back it with a real Y.Doc we control; doc.getText(name) is stable per name, so
+// the hook sees a new Y.Text only when `name` changes.
+let doc: Y.Doc;
+vi.mock('@y-sweet/react', () => ({
+  useText: (name: string) => doc.getText(name),
+}));
+
+beforeEach(() => {
+  doc = new Y.Doc();
+});
+
+// ── Pure helpers ────────────────────────────────────────────────────────────
+
+describe('setYTextFromString', () => {
+  it('sets the text from empty', () => {
+    const t = doc.getText('a');
+    setYTextFromString(t, 'hello');
+    expect(yTextToString(t)).toBe('hello');
+  });
+
+  it('is a no-op when the text is unchanged (emits no update)', () => {
+    const t = doc.getText('a');
+    setYTextFromString(t, 'hello');
+
+    const onUpdate = vi.fn();
+    doc.on('update', onUpdate);
+    setYTextFromString(t, 'hello');
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('applies a minimal delta rather than clearing and reinserting', () => {
+    const t = doc.getText('a');
+    setYTextFromString(t, 'hello world');
+
+    // Capture the delta produced by editing the middle of the string.
+    const deltas: unknown[] = [];
+    t.observe((event) => deltas.push(event.changes.delta));
+    setYTextFromString(t, 'hello brave world');
+
+    expect(yTextToString(t)).toBe('hello brave world');
+    // Minimal edit: retain the shared prefix, insert only the new word — no delete.
+    expect(deltas).toEqual([[{ retain: 6 }, { insert: 'brave ' }]]);
+  });
+
+  it('handles deletion in the middle', () => {
+    const t = doc.getText('a');
+    setYTextFromString(t, 'hello brave world');
+    setYTextFromString(t, 'hello world');
+    expect(yTextToString(t)).toBe('hello world');
+  });
+
+  it('round-trips unicode / multi-line content', () => {
+    const t = doc.getText('a');
+    setYTextFromString(t, 'café\n\n😀 line');
+    expect(yTextToString(t)).toBe('café\n\n😀 line');
+    setYTextFromString(t, 'café\n\n😀 lines!');
+    expect(yTextToString(t)).toBe('café\n\n😀 lines!');
+  });
+});
+
+// ── useAsPlainText hook ─────────────────────────────────────────────────────
+// These pin the observable behavior so the setState-in-effect lint fix (or an
+// eslint-disable) can be verified to preserve it.
+
+describe('useAsPlainText', () => {
+  it('returns the current Y.Text contents on mount', () => {
+    doc.getText('note').insert(0, 'initial');
+    const { result } = renderHook(() => useAsPlainText('note'));
+    expect(result.current[0]).toBe('initial');
+  });
+
+  it('updates when the Y.Text changes externally', () => {
+    const { result } = renderHook(() => useAsPlainText('note'));
+    expect(result.current[0]).toBe('');
+
+    act(() => {
+      doc.getText('note').insert(0, 'typed by a peer');
+    });
+    expect(result.current[0]).toBe('typed by a peer');
+  });
+
+  it('setter writes through to the Y.Text and state converges via the observer', () => {
+    const { result } = renderHook(() => useAsPlainText('note'));
+
+    act(() => {
+      result.current[1]('written locally');
+    });
+
+    expect(yTextToString(doc.getText('note'))).toBe('written locally');
+    expect(result.current[0]).toBe('written locally');
+  });
+
+  it('re-syncs state when the name changes', () => {
+    doc.getText('a').insert(0, 'text A');
+    doc.getText('b').insert(0, 'text B');
+
+    const { result, rerender } = renderHook(({ name }) => useAsPlainText(name), {
+      initialProps: { name: 'a' },
+    });
+    expect(result.current[0]).toBe('text A');
+
+    rerender({ name: 'b' });
+    expect(result.current[0]).toBe('text B');
+  });
+
+  it('unobserves on unmount (no updates after teardown)', () => {
+    const yText = doc.getText('note');
+    const unobserveSpy = vi.spyOn(yText, 'unobserve');
+
+    const { result, unmount } = renderHook(() => useAsPlainText('note'));
+    unmount();
+    expect(unobserveSpy).toHaveBeenCalled();
+
+    // Mutating after unmount must not throw or affect the last-rendered value.
+    expect(() =>
+      act(() => {
+        yText.insert(0, 'late');
+      }),
+    ).not.toThrow();
+    expect(result.current[0]).toBe('');
+  });
+});

--- a/src/yjsUtils.ts
+++ b/src/yjsUtils.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import diff from 'fast-diff';
 import { useText } from '@y-sweet/react';
 import * as Y from 'yjs';
@@ -14,25 +14,22 @@ export function yTextToString(yText: Y.Text): string {
 // Hook based on implementation here https://discuss.yjs.dev/t/plain-text-input-component-with-y-text/2358/2
 export const useAsPlainText = (name: string): [string, (newText: string) => void] => {
   const sharedText = useText(name);
-  const [text, setText] = useState(() => yTextToString(sharedText));
 
-  // Reset text state when name changes
-  useEffect(() => {
-    setText(yTextToString(sharedText));
-  }, [sharedText, name]);
-
-  useEffect(() => {
-    const observer = () => {
-      setText(yTextToString(sharedText));
-    };
-
-    sharedText.observe(observer);
-    return () => { sharedText.unobserve(observer); };
-  }, [sharedText]);
+  // Subscribe to the shared Y.Text as an external store. useSyncExternalStore
+  // re-reads the snapshot on every change and whenever `subscribe` changes (i.e.
+  // when `name` yields a different Y.Text), so no manual reset effect is needed.
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      sharedText.observe(onStoreChange);
+      return () => { sharedText.unobserve(onStoreChange); };
+    },
+    [sharedText],
+  );
+  const text = useSyncExternalStore(subscribe, () => yTextToString(sharedText));
 
   const setPlainText = (newText: string) => {
     setYTextFromString(sharedText, newText);
-    // Don't set the state here, as it will be set by the observer
+    // Don't set state here; the snapshot updates via the observer.
   };
 
   return [text, setPlainText];


### PR DESCRIPTION
The React-Compiler-oriented eslint rules flagged CurrentSlideViewer (JSX-in-try/catch), reactUtils (ref write during render), and yjsUtils (setState in effect). None had test coverage, so the refactors were deferred. Add characterization tests, then apply the fixes:

- yjsUtils: cover useAsPlainText (initial value, observer updates, setter write-through, name re-sync, unobserve on unmount) and the pure setYTextFromString/diff logic; refactor useAsPlainText to useSyncExternalStore (removes the setState-in-effect).
- reactUtils: cover useScrollToBottom (debounce, disabled gate, missing refs). Fix a latent wedge bug where a timeout that bailed out left the handle stuck non-null, permanently blocking future scrolls; move the enabled ref write into an effect.
- CurrentSlideViewer: cover the pure component (windowing, context labels, multi-line split) and the container branches (no itemId / no presentation / happy path / defaults / non-string filtering). Clamp an out-of-range currentIndex to a valid slide instead of rendering a blank container; replace the JSX-in-try/catch container with explicit conditional returns.


Claude-Session: https://claude.ai/code/session_011eX3XFjujS5CEpUGstGe7R