### PR TITLE
Dedup repeated slides before whole-item translation

### DIFF
--- a/src/slideItemTranslation.test.ts
+++ b/src/slideItemTranslation.test.ts
@@ -122,6 +122,86 @@ describe('translateItem', () => {
     expect(targets.map((t) => t.language)).toEqual(['Haitian Creole']);
   });
 
+  it('translates a repeated slide once but resolves it at every occurrence', async () => {
+    const translate = vi.fn(fakeTranslate);
+    const result = await translateItem({
+      slides: ['V1', 'Chorus', 'V2', 'Chorus', 'Chorus'],
+      languages: ['French'],
+      lookup: makeLookup({}),
+      translate,
+    });
+
+    // Only the first 'Chorus' is flagged for the model; later copies are skipped.
+    const target = translate.mock.calls[0][0].targets[0];
+    expect(target.isTranslationNeeded).toEqual([true, true, true, false, false]);
+
+    // ...yet every chorus index resolves to the same translation.
+    expect(result.French.map((r) => r.text)).toEqual([
+      '[French] V1',
+      '[French] Chorus',
+      '[French] V2',
+      '[French] Chorus',
+      '[French] Chorus',
+    ]);
+  });
+
+  it('never sends duplicates of an already-reviewed slide to the model', async () => {
+    const translate = vi.fn(fakeTranslate);
+    const lookup = makeLookup({
+      [slideTranslationKey('French', 'Chorus')]: {
+        text: 'Refrain',
+        status: 'reviewed',
+        provenance: 'human',
+        reviewedAt: 1,
+      },
+    });
+
+    const result = await translateItem({
+      slides: ['Chorus', 'V1', 'Chorus'],
+      languages: ['French'],
+      lookup,
+      translate,
+    });
+
+    const target = translate.mock.calls[0][0].targets[0];
+    expect(target.isTranslationNeeded).toEqual([false, true, false]);
+    expect(result.French.map((r) => r.text)).toEqual(['Refrain', '[French] V1', 'Refrain']);
+    expect(result.French[0].status).toBe('reviewed');
+    expect(result.French[2].status).toBe('reviewed');
+  });
+
+  it('dedups duplicates per language independently', async () => {
+    const translate = vi.fn(fakeTranslate);
+    const lookup = makeLookup({
+      // Reviewed in French only; Haitian Creole still needs it.
+      [slideTranslationKey('French', 'Chorus')]: {
+        text: 'Refrain',
+        status: 'reviewed',
+        provenance: 'human',
+        reviewedAt: 1,
+      },
+    });
+
+    const result = await translateItem({
+      slides: ['Chorus', 'Chorus'],
+      languages: ['French', 'Haitian Creole'],
+      lookup,
+      translate,
+    });
+
+    const targets = translate.mock.calls[0][0].targets;
+    // French is fully reviewed, so it drops out of the model call entirely.
+    expect(targets.map((t) => t.language)).toEqual(['Haitian Creole']);
+    const htTarget = targets[0];
+    expect(htTarget.isTranslationNeeded).toEqual([true, false]);
+
+    expect(result.French.map((r) => r.text)).toEqual(['Refrain', 'Refrain']);
+    expect(result['Haitian Creole'].map((r) => r.text)).toEqual([
+      '[Haitian Creole] Chorus',
+      '[Haitian Creole] Chorus',
+    ]);
+  });
+
   it('resolves empty slides to empty auto text without translating them', async () => {
     const translate = vi.fn(fakeTranslate);
     const result = await translateItem({

--- a/src/slideItemTranslation.ts
+++ b/src/slideItemTranslation.ts
@@ -72,9 +72,17 @@ export async function translateItem(params: {
       slide.trim() === '' ? undefined : lookup(language, slide),
     );
     reviewedByLang[language] = reviewed;
-    const isTranslationNeeded = slides.map(
-      (slide, i) => slide.trim() !== '' && !reviewed[i],
-    );
+    // Duplicate slides (e.g. a chorus repeated via CustomOrderSequence) share a
+    // normalized text and the same read-back key, so we only ask the model to
+    // translate the first occurrence — later copies resolve from that one result.
+    const seen = new Set<string>();
+    const isTranslationNeeded = slides.map((slide, i) => {
+      if (slide.trim() === '' || reviewed[i]) return false;
+      const key = normalizeSlideText(slide);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
     // Reviewed slides are already in-language, so they feed the model as context.
     const context = slides
       .map((_, i) => reviewed[i]?.text)


### PR DESCRIPTION
Song items often repeat a slide (e.g. a chorus sung several times), which
Proclaim's CustomOrderSequence materializes as byte-for-byte identical strings
in the item's slide list. Both the Proclaim service's background translation
worker and the review page's Suggest button POST that full list to
/api/translateItem, where the orchestrator flagged every duplicate index for
translation — so the model paid to translate each copy separately.

Dedup by normalized slide text when building isTranslationNeeded, flagging only
the first occurrence of each unique un-reviewed text per language. Read-back is
already content-addressed, so later duplicate indices resolve from the single
result; the displayed slide order and every slide's translation are unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KYQXyc6HdUKyCu75wZ1YHy