### PR TITLE
Stage 0: CI workflow, architecture map, docs index, smoke-test checklist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run lint
+      - run: npm test -- --no-color --run
+
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv run pytest -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,9 @@ This is a **live translation application** for presentations/talks. It provides 
 - **Proclaim integration**: Python service syncing Proclaim presentation slides to Yjs
 - **Frontend**: React + TypeScript + Vite + Tailwind CSS
 - **Backend**: Express server
+- **Live speech translation**: LiveKit rooms + Gemini Live ([live-audio/](live-audio/)) — a broadcaster publishes mic audio; per-language translator bots stream it through Gemini Live and publish translated audio + live transcripts
+
+**Start with [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** for the component map (what runs where, who writes what into the shared Yjs doc). [docs/README.md](docs/README.md) is the docs index; [docs/SMOKE_TEST.md](docs/SMOKE_TEST.md) is the manual pre-service smoke checklist — PR descriptions should declare which of its sections they touch.
 
 ## Development Commands
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,85 @@
+# Architecture map
+
+One page: what runs where, how data flows, and — most importantly — **who writes what into
+the shared Yjs doc and what each writer's true input is**. That distinction (stimulus vs.
+derived data) drives the testing/replay strategy.
+
+## Components
+
+```
+ sound booth / stage                      server (docker compose)              external SaaS
+┌────────────────────┐                  ┌──────────────────────────┐
+│ Broadcaster        │── mic (WebRTC) ─▶│ LiveKit room             │
+│ (BroadcastControl, │                  │   ▲            │         │
+│  future macOS      │                  │   │ translated │ source  │
+│  ingest service)   │                  │   │ audio      ▼ audio   │
+└────────────────────┘                  │ translation-bridge ──────┼──▶ Gemini Live
+┌────────────────────┐                  │  (per language, spawned  │    (translate speech)
+│ Proclaim Mac       │                  │   on listener demand by  │
+│ proclaim_service.py│─┐                │   translation-session-   │
+└────────────────────┘ │                │   manager)               │
+                       │ Y-Sweet WS     ├──────────────────────────┤
+┌────────────────────┐ │                │ Express server           │──▶ Gemini (block +
+│ Browser clients    │ ├───────────────▶│  - Y-Sweet token auth    │     slide translation)
+│  editor / viewers /│ │                │  - /api/translate        │──▶ ElevenLabs (TTS)
+│  listeners         │─┘                │  - /api/translateItem    │──▶ PostHog (telemetry)
+└────────────────────┘                  │  - TTS + audio cache     │
+                                        ├──────────────────────────┤
+                                        │ Y-Sweet (doc persistence)│
+                                        └──────────────────────────┘
+```
+
+- **Browser app** (`src/`): block editor, translated/bilingual viewers, current-slide viewer,
+  slide review UI, listen viewer (translated audio), live transcript, broadcast control.
+  Layouts are URL-encoded (see `App.tsx`); `#editor` gates write access.
+- **Express server** (`server.ts`): Y-Sweet token issuing (the auth chokepoint), translation
+  endpoints, TTS with disk cache, `/api/config`; hosts the live-audio subsystem in-process.
+- **live-audio** (`live-audio/`): `translation-session-manager` spawns one
+  `translation-bridge` per (session, language) when a listener wants it and reaps idle ones;
+  each bridge subscribes to the organizer's LiveKit track (16 kHz in), streams to Gemini
+  Live, publishes translated audio (24 kHz out), and writes the transcript into Yjs via
+  `transcript-writer`.
+- **proclaim_service.py**: polls Proclaim's local HTTP API (~1 s) and reads its SQLite DB,
+  pushes presentations + slide status into Yjs. Installed as a macOS LaunchAgent.
+- **Y-Sweet**: persistence and fan-out for the per-service Y.Doc (`doc-YYYY-MM-DD`).
+
+## The Yjs doc is stimulus + response mixed together
+
+Every writer below shares one Y.Doc per service. When recording or replaying, record each
+component at its **true input boundary** — never the Yjs doc wholesale, because most of the
+doc is *derived* data that the system under test will regenerate.
+
+| Writer | Writes into Yjs | True input boundary |
+|---|---|---|
+| Human editor (browser) | `sourceTextBlocks` edits | Keystrokes — these *are* Yjs deltas; Yjs-level recording is correct **only** for this writer |
+| `proclaim_service.py` | `proclaimPresentations`, `proclaimStatus` | Proclaim local HTTP API responses + `PresentationManager.db` |
+| translation-bridge / transcript-writer | live transcript | Organizer audio track + Gemini Live responses |
+| Block translation manager | per-language translations, `notesTranslationCache` | Source blocks + `/api/translate` (Gemini) |
+| Slide translation agent | slide translations, conversations, library | Slide texts + Gemini |
+
+Recorded *outputs* of a component have exactly two legitimate uses: as a **stand-in** when
+that component is out of the loop (simulated mode), or as a **golden reference** when it is
+in the loop. Never both at once — replaying a component's output while the real component
+also runs produces double-writes.
+
+Yjs updates carry the author's `clientID`, so a recorder can partition the delta stream by
+writer once each component announces its clientID (planned: via the status heartbeat map).
+
+## Lifecycle notes that surprise people
+
+- **Bridges are demand-driven**: a translation bridge exists only while the session has at
+  least one human listener AND a broadcaster (`translation-session-manager.ts`). Connecting
+  clients therefore *changes* system behavior — preflight checks must include a synthetic
+  listener, and "nothing is translating" is often just "nobody is listening yet."
+- **Doc IDs are date-anchored** (`getDocId.ts`, and the Proclaim service anchors to the
+  show's scheduled date), so a service's state lives in one doc per date.
+- **Editor vs viewer** is enforced server-side via Y-Sweet token scope, keyed off the
+  `#editor` request — there is currently no other auth.
+
+## Testing seams
+
+- Pure component / Yjs-container split on the frontend (see CLAUDE.md).
+- Python tests fake the Proclaim DB, Y-Sweet websocket, and provider, and scale timing
+  constants via the `fast_timing` fixture (`tests/`) — the model for the TS side.
+- The replay harness (tracking issue supersedes #69) extends these seams into recorded,
+  shareable fixtures with per-component real/simulated switches.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# Docs index
+
+Short, surfaced-not-comprehensive documentation. Coding agents can grep; humans start here.
+
+## Orientation
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — component map: what runs where, who writes what into
+  the shared Yjs doc, and what each component's true input boundary is. **Start here.**
+- [../CLAUDE.md](../CLAUDE.md) — agent-facing project guide (commands, conventions, patterns).
+
+## Operations
+
+- [SMOKE_TEST.md](SMOKE_TEST.md) — the pre-service manual smoke-test checklist, and how PRs
+  declare which sections they touch.
+
+## Design docs
+
+- [slide-translations-plan.md](slide-translations-plan.md) — slide translation agent design.
+- Replay harness design: see the tracking issue
+  ([#70 area](https://github.com/kcarnold/live-notes/issues)) — record-at-the-boundary
+  replay of full services for testing and accountability.
+
+## Subsystem references (repo root)
+
+- [PROCLAIM_INTEGRATION.md](../PROCLAIM_INTEGRATION.md), [PROCLAIM_DATA_FORMAT.md](../PROCLAIM_DATA_FORMAT.md),
+  [PROCLAIM_SERVICE_SETUP.md](../PROCLAIM_SERVICE_SETUP.md) — Proclaim sync service.
+- [DUMP_DOCS_README.md](../DUMP_DOCS_README.md) — Yjs doc dumper (end-state JSON extraction;
+  known to be stale relative to current doc structure — do not treat as source of truth).

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,8 @@ Short, surfaced-not-comprehensive documentation. Coding agents can grep; humans 
 ## Design docs
 
 - [slide-translations-plan.md](slide-translations-plan.md) — slide translation agent design.
-- Replay harness design: see the tracking issue
-  ([#70 area](https://github.com/kcarnold/live-notes/issues)) — record-at-the-boundary
-  replay of full services for testing and accountability.
+- Replay harness design: [#70](https://github.com/kcarnold/live-notes/issues/70) —
+  record-at-the-boundary replay of full services for testing and accountability.
 
 ## Subsystem references (repo root)
 

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -1,0 +1,54 @@
+# Pre-service smoke test
+
+A ~10-minute manual checklist covering the critical Sunday path. Two purposes:
+
+1. **Before a service** (or after deploying): run the whole thing.
+2. **Merge-queue batching**: merge everything CI-green, then run this checklist **once over
+   the batch** instead of once per PR. Each PR should say in its description which sections
+   below it touches ("Blast radius: §3, §5"); if a PR touches none, it can merge on green CI
+   alone.
+
+Until the replay harness lands, this checklist is the integration test. Keep it current: if
+an incident happens that this list would not have caught, add a line.
+
+## Setup
+
+- [ ] Deployed build is the intended SHA (`docker compose logs` banner / deploy script output).
+- [ ] Open the editor URL (`/...#editor`) on one device, a viewer URL on a second device
+      (ideally a phone on cellular, not the LAN).
+
+## 1. Collaboration & editor
+
+- [ ] Type in the block editor; text appears on the second device within ~1 s.
+- [ ] Enter/Backspace/Tab block operations behave; no duplicate or orphaned blocks.
+- [ ] Viewer device has no edit affordances (read-only token).
+
+## 2. Block translation
+
+- [ ] Trigger translation for at least one language; translated text appears on the viewer.
+- [ ] Edit one line, retranslate: only the changed line churns (cache hit on the rest).
+
+## 3. Proclaim sync
+
+- [ ] Proclaim service running (LaunchAgent) and pointed at today's doc.
+- [ ] Advance a slide in Proclaim; current-slide view updates on both devices within ~2 s.
+- [ ] Slide translations show for the on-air item; review screen loads its conversation.
+
+## 4. Live audio translation
+
+- [ ] Start broadcasting (mic level meter moves).
+- [ ] On the viewer device, join Listen for one language **after** broadcast started:
+      transcript deltas appear, translated audio plays after tapping play.
+- [ ] **The #69 race**: start the Listen client *first*, then start broadcasting — bridge
+      must still pick up the source audio (transcript flows).
+- [ ] Stop and restart the broadcaster mid-session; transcript resumes without a reload.
+
+## 5. TTS (text-to-speech on translated notes)
+
+- [ ] Tap a translated line: audio plays. Tap again: cancels.
+- [ ] Auto-speak advances line to line.
+
+## 6. Teardown sanity
+
+- [ ] Close all listener tabs; confirm translator bots get reaped (server logs) — no
+      orphaned Gemini sessions burning quota.


### PR DESCRIPTION
Stage 0 of the dev-process plan discussed in session: make the merge queue cheaper to drain and surface the system's shape for humans and agents.

## Changes

- **`.github/workflows/ci.yml`** — first CI for the repo: `typecheck`, `lint`, `vitest` (node job) and `uv run pytest` (python job) on every PR and push to main. All four checks verified green locally on this branch (208 JS tests, 36 Python tests).
- **`docs/ARCHITECTURE.md`** — one-page component map: what runs where, and the writer table (who writes what into the shared Yjs doc vs. what each writer's *true input boundary* is). This table is the foundation of the replay-harness design (#70).
- **`docs/SMOKE_TEST.md`** — the manual pre-service checklist, with a merge-batching convention: PRs declare which sections they touch ("Blast radius: §3, §5"); CI-green PRs touching no section can merge without a manual pass, and batches get one checklist run instead of one per PR.
- **`docs/README.md`** — thin docs index (surfacing, not comprehensiveness).
- **`CLAUDE.md`** — mentions the live-audio subsystem in the overview and points at the docs index.

## Blast radius (per docs/SMOKE_TEST.md)

None — docs and CI config only, no runtime code.

## Related

Filed alongside: #70 (replay harness, supersedes #69), #71 (Gemini session recorder), #72 (status map + canary), #73 (Proclaim service auto-update), #74 (decode-once fan-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGa7R4nBeC2DTuN2NNxkxb

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGa7R4nBeC2DTuN2NNxkxb)_