### PR TITLE
Track token usage and PostHog observability for agent conversations

### DIFF
--- a/nlp.test.ts
+++ b/nlp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { draftItemTranslations, buildSeedConversationPrompt, GeminiProvider } from './nlp.ts';
+import { draftItemTranslations, buildSeedConversationPrompt, GeminiProvider, emptyUsage, addUsage, mergeUsage } from './nlp.ts';
 
 /**
  * A provider whose model calls `set_translations` with the given args, then ends its turn.
@@ -172,6 +172,86 @@ describe('draftItemTranslations', () => {
     expect(captured?.map((c) => c.role)).toEqual(['user', 'model', 'user', 'model']);
     expect(captured?.[1].parts?.[0].functionCall?.name).toBe('set_translations');
     expect(captured?.[2].parts?.[0].functionResponse?.name).toBe('set_translations');
+  });
+});
+
+describe('token usage accounting', () => {
+  it('sums usageMetadata across rounds, tolerating missing fields', () => {
+    let usage = emptyUsage();
+    usage = addUsage(usage, {
+      promptTokenCount: 1000,
+      cachedContentTokenCount: 0,
+      candidatesTokenCount: 50,
+      totalTokenCount: 1050,
+    });
+    // Round 2: prefix now served from cache; thoughtsTokenCount present, no explicit total.
+    usage = addUsage(usage, {
+      promptTokenCount: 1200,
+      cachedContentTokenCount: 900,
+      candidatesTokenCount: 40,
+      thoughtsTokenCount: 30,
+    });
+    // A tool-only response with no usageMetadata still counts as a call.
+    usage = addUsage(usage, undefined);
+
+    expect(usage.promptTokenCount).toBe(2200);
+    expect(usage.cachedContentTokenCount).toBe(900);
+    expect(usage.candidatesTokenCount).toBe(90);
+    expect(usage.thoughtsTokenCount).toBe(30);
+    expect(usage.totalTokenCount).toBe(1050);
+    expect(usage.callCount).toBe(3);
+  });
+
+  it('mergeUsage adds two running totals field-by-field', () => {
+    const a = { ...emptyUsage(), promptTokenCount: 100, cachedContentTokenCount: 40, callCount: 1 };
+    const b = { ...emptyUsage(), promptTokenCount: 200, cachedContentTokenCount: 150, callCount: 2 };
+    const merged = mergeUsage(a, b);
+    expect(merged.promptTokenCount).toBe(300);
+    expect(merged.cachedContentTokenCount).toBe(190);
+    expect(merged.callCount).toBe(3);
+  });
+
+  it('surfaces accumulated usage and tags generations for PostHog grouping', async () => {
+    const args = {
+      languages: [{ language: 'French', segments: [{ segmentId: 0, translation: 'Bonjour' }] }],
+    };
+    const callPart = { functionCall: { name: 'set_translations', args } };
+    const generateContent = vi
+      .fn()
+      .mockResolvedValueOnce({
+        functionCalls: [{ name: 'set_translations', args }],
+        candidates: [{ content: { role: 'model', parts: [callPart] } }],
+        usageMetadata: { promptTokenCount: 1000, cachedContentTokenCount: 0, candidatesTokenCount: 20, totalTokenCount: 1020 },
+      })
+      .mockResolvedValueOnce({
+        functionCalls: [],
+        candidates: [{ content: { role: 'model', parts: [{ text: 'Done.' }] } }],
+        usageMetadata: { promptTokenCount: 1100, cachedContentTokenCount: 950, candidatesTokenCount: 10, totalTokenCount: 1110 },
+      });
+    const provider = {
+      apiClient: { models: { generateContent } },
+      defaultModel: 'fake-model',
+      maxTokens: 1000,
+    } as unknown as GeminiProvider;
+
+    let usage: import('./nlp.ts').TokenUsage | undefined;
+    await draftItemTranslations(provider, {
+      sourceSlides: ['Hello'],
+      targets: [{ language: 'French', isTranslationNeeded: [true], context: '' }],
+      observability: { distinctId: 'doc-2026-07-12', traceId: 'conv-abc', properties: { source: 'test' } },
+      onUsage: (u) => { usage = u; },
+    });
+
+    expect(usage?.promptTokenCount).toBe(2100);
+    expect(usage?.cachedContentTokenCount).toBe(950);
+    expect(usage?.callCount).toBe(2);
+
+    // Every generation carries the trace/distinct-id tags so the conversation groups in PostHog.
+    for (const call of generateContent.mock.calls) {
+      expect(call[0].posthogTraceId).toBe('conv-abc');
+      expect(call[0].posthogDistinctId).toBe('doc-2026-07-12');
+      expect(call[0].posthogProperties).toEqual({ source: 'test' });
+    }
   });
 });
 

--- a/nlp.ts
+++ b/nlp.ts
@@ -31,6 +31,83 @@ export type TranslationBlockResult = {
     translatedText: string;
 }
 
+/**
+ * PostHog LLM-observability tags for a run. Passed straight through the `@posthog/ai`
+ * GoogleGenAI wrapper, which turns each `generateContent` call into an `$ai_generation`
+ * event. `traceId` is the important one: it groups every generation from one conversation
+ * (initial draft + every follow-up round) into a single PostHog trace. Without it the
+ * wrapper emits ungrouped events under a random distinct id — which is exactly why agent
+ * messages from the same conversation weren't grouping.
+ */
+export interface AgentObservability {
+    /** Stable id for whoever/whatever is driving the conversation (we use the day's docId). */
+    distinctId?: string;
+    /** Groups all generations from one conversation into a single trace (the conversation id). */
+    traceId?: string;
+    /** Extra properties attached to every generation event in this run. */
+    properties?: Record<string, unknown>;
+}
+
+/** The subset of `usageMetadata` fields we sum; missing on faked/tool-only responses. */
+type ResponseUsage = {
+    promptTokenCount?: number;
+    cachedContentTokenCount?: number;
+    candidatesTokenCount?: number;
+    thoughtsTokenCount?: number;
+    totalTokenCount?: number;
+};
+
+/**
+ * Token usage summed across the model calls in an agent run (and across runs, when a
+ * conversation is resumed). Surfaced so cost is visible and — via `cachedContentTokenCount`
+ * — so we can tell whether Gemini's context cache is actually serving the re-sent prefix.
+ * A run of several rounds with `cachedContentTokenCount` stuck at 0 means we're paying full
+ * price for the whole prompt every round.
+ */
+export interface TokenUsage {
+    promptTokenCount: number;
+    /** Portion of `promptTokenCount` served from the context cache (implicit or explicit). */
+    cachedContentTokenCount: number;
+    candidatesTokenCount: number;
+    thoughtsTokenCount: number;
+    totalTokenCount: number;
+    /** How many model calls contributed to these totals. */
+    callCount: number;
+}
+
+export const emptyUsage = (): TokenUsage => ({
+    promptTokenCount: 0,
+    cachedContentTokenCount: 0,
+    candidatesTokenCount: 0,
+    thoughtsTokenCount: 0,
+    totalTokenCount: 0,
+    callCount: 0,
+});
+
+/** Fold one response's `usageMetadata` into a running total (tolerant of missing fields). */
+export const addUsage = (total: TokenUsage, meta: ResponseUsage | undefined): TokenUsage => ({
+    promptTokenCount: total.promptTokenCount + (meta?.promptTokenCount ?? 0),
+    cachedContentTokenCount: total.cachedContentTokenCount + (meta?.cachedContentTokenCount ?? 0),
+    candidatesTokenCount: total.candidatesTokenCount + (meta?.candidatesTokenCount ?? 0),
+    thoughtsTokenCount: total.thoughtsTokenCount + (meta?.thoughtsTokenCount ?? 0),
+    totalTokenCount: total.totalTokenCount + (meta?.totalTokenCount ?? 0),
+    callCount: total.callCount + 1,
+});
+
+/** Merge two usage totals (e.g. a stored conversation total plus a fresh follow-up run). */
+export const mergeUsage = (a: TokenUsage, b: TokenUsage): TokenUsage => ({
+    promptTokenCount: a.promptTokenCount + b.promptTokenCount,
+    cachedContentTokenCount: a.cachedContentTokenCount + b.cachedContentTokenCount,
+    candidatesTokenCount: a.candidatesTokenCount + b.candidatesTokenCount,
+    thoughtsTokenCount: a.thoughtsTokenCount + b.thoughtsTokenCount,
+    totalTokenCount: a.totalTokenCount + b.totalTokenCount,
+    callCount: a.callCount + b.callCount,
+});
+
+/** Build the `@posthog/ai` per-call tags from an observability object (empty when unset). */
+const posthogTags = (obs?: AgentObservability) =>
+    obs ? { posthogDistinctId: obs.distinctId, posthogTraceId: obs.traceId, posthogProperties: obs.properties } : {};
+
 export const translateBlock = async (provider: GeminiProvider, todo: TranslationTodo, language: string): Promise<TranslationBlockResult[]> => {
     const config = {
       responseMimeType: 'application/json',
@@ -241,6 +318,8 @@ export type SlideAgentRunResult = {
     messages: Content[];
     /** Whether the model called `set_translations` during this run. */
     setTranslationsCalled: boolean;
+    /** Token usage summed across this run's model calls (incl. cache hits). */
+    usage: TokenUsage;
 };
 
 /**
@@ -263,9 +342,11 @@ export const runSlideTranslationAgent = async (
         model?: string;
         bibleLanguages: string[];
         onToolCall?: (call: BibleToolCall) => void;
+        /** PostHog trace/distinct-id tags so every round groups under one conversation. */
+        observability?: AgentObservability;
     },
 ): Promise<SlideAgentRunResult> => {
-    const { sourceSlides, messages, bibleLanguages, onToolCall } = params;
+    const { sourceSlides, messages, bibleLanguages, onToolCall, observability } = params;
     const model = params.model ?? provider.defaultModel;
 
     const functionDeclarations: FunctionDeclaration[] = [SET_TRANSLATIONS_TOOL];
@@ -274,6 +355,7 @@ export const runSlideTranslationAgent = async (
 
     let translations: Record<string, TranslationBlockResult[]> = {};
     let setTranslationsCalled = false;
+    let usage = emptyUsage();
 
     for (let round = 0; round < MAX_AGENT_ROUNDS; round++) {
         const response = await provider.apiClient.models.generateContent({
@@ -285,7 +367,9 @@ export const runSlideTranslationAgent = async (
                 },
             },
             contents: messages,
+            ...posthogTags(observability),
         });
+        usage = addUsage(usage, response.usageMetadata);
         const calls = response.functionCalls ?? [];
         const modelContent = response.candidates?.[0]?.content;
         // Keep the model turn verbatim (incl. any thought signatures) so a later resume
@@ -336,7 +420,7 @@ export const runSlideTranslationAgent = async (
         messages.push({ role: 'user', parts: responseParts });
     }
 
-    return { translations, messages, setTranslationsCalled };
+    return { translations, messages, setTranslationsCalled, usage };
 };
 
 /**
@@ -533,9 +617,13 @@ export const draftItemTranslations = async (
         onToolCall?: (call: BibleToolCall) => void;
         /** Receives the full agent conversation (raw Gemini Content) once drafting completes. */
         onConversation?: (messages: Content[]) => void;
+        /** Receives the run's token usage (incl. cache hits) once drafting completes. */
+        onUsage?: (usage: TokenUsage) => void;
+        /** PostHog trace/distinct-id tags so the draft's generations group by conversation. */
+        observability?: AgentObservability;
     },
 ): Promise<Record<string, TranslationBlockResult[]>> => {
-    const { sourceSlides, targets, referenceText, existingTranslation, generalContext, onToolCall, onConversation } = params;
+    const { sourceSlides, targets, referenceText, existingTranslation, generalContext, onToolCall, onConversation, onUsage, observability } = params;
     const itemTitle = params.itemTitle?.trim();
     const model = params.model ?? provider.defaultModel;
     // Languages we can actually fetch canonical Scripture for.
@@ -560,7 +648,9 @@ export const draftItemTranslations = async (
         model,
         bibleLanguages,
         onToolCall,
+        observability,
     });
     onConversation?.(result.messages);
+    onUsage?.(result.usage);
     return result.translations;
 };

--- a/server.ts
+++ b/server.ts
@@ -11,8 +11,8 @@ import { ElevenLabs, ElevenLabsClient } from '@elevenlabs/elevenlabs-js';
 
 import { PostHog, setupExpressErrorHandler } from 'posthog-node';
 
-import { translateBlock, draftItemTranslations, runSlideTranslationAgent, buildSeedConversationPrompt, GeminiProvider } from './nlp.ts';
-import type { TranslationTodo } from './nlp.ts';
+import { translateBlock, draftItemTranslations, runSlideTranslationAgent, buildSeedConversationPrompt, GeminiProvider, emptyUsage, mergeUsage } from './nlp.ts';
+import type { TranslationTodo, TokenUsage, AgentObservability } from './nlp.ts';
 import { BIBLE_TRANSLATIONS, type BibleToolCall } from './bible.ts';
 import { SlideLibrary } from './slideLibrary.ts';
 import { translateItem } from './src/slideItemTranslation.ts';
@@ -104,6 +104,43 @@ const slideConversations = new SlideConversationStore(documentManager);
 /** Stable conversation key: the Proclaim itemId when present, else a content hash. */
 function conversationKey(itemId: string | undefined, slides: string[]): string {
   return itemId && itemId.trim() ? itemId.trim() : `hash:${slidesHash(slides)}`;
+}
+
+/**
+ * PostHog LLM-observability tags for a slide-translation conversation. The conversation id
+ * is the trace id, so every generation (initial draft + follow-ups) groups into one trace;
+ * the day's docId is the distinct id, so a day's review work groups under one "user".
+ */
+function slideObservability(
+  conversationId: string,
+  docId: string,
+  extra?: Record<string, unknown>,
+): AgentObservability {
+  return {
+    distinctId: docId,
+    traceId: conversationId,
+    properties: { conversationId, docId, ...extra },
+  };
+}
+
+/**
+ * Report a Bible lookup to PostHog, keyed to the same conversation as the LLM trace so it
+ * lines up with the agent's generations (`$ai_trace_id`) instead of the old hardcoded
+ * 'slide-review' distinct id that lumped every lookup together.
+ */
+function recordBibleLookup(call: BibleToolCall, conversationId: string, docId: string): void {
+  phClient.capture({
+    distinctId: docId,
+    event: 'bible_lookup',
+    properties: {
+      $ai_trace_id: conversationId,
+      conversationId,
+      reference: call.reference,
+      ok: call.ok,
+      foundLanguages: call.foundLanguages,
+      missingLanguages: call.missingLanguages,
+    },
+  });
 }
 
 const app = express();
@@ -328,11 +365,21 @@ app.post('/api/translateItem', async (req, res) => {
   }
   if (!docId) return res.status(400).json({ ok: false, error: 'Missing docId' });
 
+  // Stable conversation id up front so it can tag the LLM trace (and any bible_lookup events)
+  // as the agent runs — this is what makes a conversation's generations group in PostHog.
+  const conversationId = conversationKey(itemId, slides);
+  const observability = slideObservability(conversationId, docId, {
+    itemTitle: itemTitle || undefined,
+    source: 'translateItem',
+  });
+
   const lookup = slideLibrary.toLookup();
   // Bible lookups the model made while drafting — reported to PostHog and the review UI.
   const bibleLookups: BibleToolCall[] = [];
   // The raw agent history, captured so we can persist it for review + follow-ups.
   let conversationMessages: Content[] = [];
+  // Token usage across the draft's model calls (surfaced so cache hits/cost are visible).
+  let usage: TokenUsage = emptyUsage();
   const translations = await translateItem({
     slides,
     languages: requestedLanguages,
@@ -346,21 +393,16 @@ app.post('/api/translateItem', async (req, res) => {
         generalContext: SLIDE_TRANSLATION_CONTEXT,
         itemTitle: itemTitle || undefined,
         model: STRONG_MODEL,
+        observability,
         onToolCall: (call) => {
           bibleLookups.push(call);
-          phClient.capture({
-            distinctId: 'slide-review',
-            event: 'bible_lookup',
-            properties: {
-              reference: call.reference,
-              ok: call.ok,
-              foundLanguages: call.foundLanguages,
-              missingLanguages: call.missingLanguages,
-            },
-          });
+          recordBibleLookup(call, conversationId, docId);
         },
         onConversation: (messages) => {
           conversationMessages = messages;
+        },
+        onUsage: (runUsage) => {
+          usage = mergeUsage(usage, runUsage);
         },
       }),
   });
@@ -370,7 +412,6 @@ app.post('/api/translateItem', async (req, res) => {
   // seed a context-only conversation — slides + current translations + general context — so a
   // later follow-up resumes with real context instead of replying blind, without spending a
   // model call now.
-  const conversationId = conversationKey(itemId, slides);
   const seededMessages: Content[] = conversationMessages.length > 0
     ? conversationMessages
     : [{
@@ -392,6 +433,7 @@ app.post('/api/translateItem', async (req, res) => {
     languages: requestedLanguages,
     messages: seededMessages,
     status: 'idle',
+    usage,
   });
 
   return res.json({ ok: true, translations, bibleLookups, conversationId });
@@ -426,19 +468,25 @@ app.post('/api/slideConversation/message', async (req, res) => {
 
   const bibleLanguages = conversation.languages.filter((language) => BIBLE_TRANSLATIONS[language]);
   const bibleLookups: BibleToolCall[] = [];
+  // Same trace id as the initial draft so this follow-up's generations group with it.
+  const observability = slideObservability(itemId, docId, { source: 'followUp' });
   try {
     const result = await runSlideTranslationAgent(geminiProvider, {
       sourceSlides: conversation.slides,
       messages: conversation.messages, // mutated in place
       model: STRONG_MODEL,
       bibleLanguages,
+      observability,
       onToolCall: (call) => {
         bibleLookups.push(call);
+        recordBibleLookup(call, itemId, docId);
         // Stream the agent's progress (new tool-call/response messages) to watchers.
         writeConversation(conversationsMap, conversation);
       },
     });
     conversation.status = 'idle';
+    // Fold this run's tokens into the conversation's running total (initial draft + follow-ups).
+    conversation.usage = mergeUsage(conversation.usage ?? emptyUsage(), result.usage);
     writeConversation(conversationsMap, conversation);
 
     // Flatten revised translations for the browser to apply (auto / llm-agent provenance).

--- a/slideConversationStore.ts
+++ b/slideConversationStore.ts
@@ -18,6 +18,7 @@ import * as Y from 'yjs';
 import { createYjsProvider, type YSweetProvider } from '@y-sweet/client';
 import type { DocumentManager } from '@y-sweet/sdk';
 import type { Content } from '@google/genai';
+import type { TokenUsage } from './nlp.ts';
 
 export type SlideConversationStatus = 'running' | 'idle' | 'error';
 
@@ -32,6 +33,13 @@ export interface SlideConversation {
   /** Raw Gemini history, stored verbatim so a resume replays the agent faithfully. */
   messages: Content[];
   status: SlideConversationStatus;
+  /**
+   * Token usage summed across every agent run for this conversation (the initial draft plus
+   * each follow-up). `cachedContentTokenCount` shows how much of the re-sent prompt Gemini's
+   * context cache actually served — a running total stuck near 0 means we're paying full
+   * price for the prefix on every round. Absent on conversations created before this existed.
+   */
+  usage?: TokenUsage;
   updatedAt: number;
 }
 

--- a/src/SlideConversationPanel.tsx
+++ b/src/SlideConversationPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { Content, SlideConversation } from './slideTranslationApi';
+import type { Content, SlideConversation, TokenUsage } from './slideTranslationApi';
 import { useStrings } from './useLocale';
 
 /**
@@ -98,6 +98,30 @@ function MessageParts({ message, msgKey }: { message: Content; msgKey: string })
   return <div className="flex flex-col gap-1">{rendered}</div>;
 }
 
+/**
+ * One-line token summary: total prompt/output tokens, how many were served from Gemini's
+ * context cache, and the model-call count. The cache figure is the whole point — if it stays
+ * near 0 while prompt tokens are large, the re-sent prompt isn't being cached and cost is
+ * higher than it should be.
+ */
+function UsageSummary({ usage }: { usage: TokenUsage }) {
+  const cachePct =
+    usage.promptTokenCount > 0
+      ? Math.round((usage.cachedContentTokenCount / usage.promptTokenCount) * 100)
+      : 0;
+  return (
+    <p className="text-xs text-gray-400 dark:text-gray-500 font-mono" title="Token usage across all agent runs for this item">
+      {usage.promptTokenCount.toLocaleString()} in
+      {' · '}
+      {usage.candidatesTokenCount.toLocaleString()} out
+      {' · '}
+      {usage.cachedContentTokenCount.toLocaleString()} cached ({cachePct}%)
+      {' · '}
+      {usage.callCount} {usage.callCount === 1 ? 'call' : 'calls'}
+    </p>
+  );
+}
+
 export interface SlideConversationPanelProps {
   conversation: SlideConversation | null;
   busy: boolean;
@@ -133,6 +157,11 @@ export function SlideConversationPanel({
         </h3>
         {conversation?.status === 'running' && (
           <span className="text-xs text-blue-600 dark:text-blue-400">{s.agentThinking}</span>
+        )}
+        {conversation?.usage && conversation.usage.callCount > 0 && (
+          <span className="ml-auto">
+            <UsageSummary usage={conversation.usage} />
+          </span>
         )}
       </div>
 

--- a/src/slideTranslationApi.ts
+++ b/src/slideTranslationApi.ts
@@ -25,6 +25,20 @@ export interface TranslateItemResult {
 
 export type SlideConversationStatus = 'running' | 'idle' | 'error';
 
+/**
+ * Token usage summed across an item's agent runs. Mirrors the server's `TokenUsage`
+ * (nlp.ts). `cachedContentTokenCount` is the tell for whether Gemini's context cache is
+ * serving the re-sent prompt — near-0 against a large `promptTokenCount` means it isn't.
+ */
+export interface TokenUsage {
+  promptTokenCount: number;
+  cachedContentTokenCount: number;
+  candidatesTokenCount: number;
+  thoughtsTokenCount: number;
+  totalTokenCount: number;
+  callCount: number;
+}
+
 /** The server-side agent conversation for one item (raw Gemini history + snapshot). */
 export interface SlideConversation {
   itemId: string;
@@ -34,6 +48,8 @@ export interface SlideConversation {
   languages: string[];
   messages: Content[];
   status: SlideConversationStatus;
+  /** Running token total for this conversation; absent on pre-existing conversations. */
+  usage?: TokenUsage;
   updatedAt: number;
 }
 


### PR DESCRIPTION
## Summary

Adds comprehensive token usage tracking and PostHog LLM-observability support to the slide translation agent. This enables visibility into model call costs (including Gemini's context cache effectiveness) and groups all generations from a single conversation into one PostHog trace for better analytics.

## Key Changes

- **Token usage tracking**: New `TokenUsage` interface and utilities (`emptyUsage`, `addUsage`, `mergeUsage`) accumulate token counts across agent runs, including cache hits. Exposed via `SlideAgentRunResult` and persisted in `SlideConversation`.

- **PostHog observability**: New `AgentObservability` interface carries `distinctId` (docId), `traceId` (conversation id), and custom properties. Passed through to Gemini API calls via `posthogTags()` helper, ensuring all generations from one conversation group under a single trace instead of random distinct IDs.

- **Server-side integration**: 
  - `slideObservability()` helper constructs observability tags from conversation/doc IDs
  - `recordBibleLookup()` reports Bible lookups with the same trace ID as LLM generations, so they align in PostHog
  - Token usage merged across initial draft and follow-up runs via `mergeUsage()`
  - Conversation status now tracks cumulative usage

- **Frontend display**: New `UsageSummary` component in `SlideConversationPanel` shows token counts, cache percentage, and call count — making it visible whether Gemini's context cache is actually serving the re-sent prompt.

- **Tests**: Added comprehensive test suite for token accounting (`addUsage`, `mergeUsage`) and observability tagging, verifying that PostHog tags are passed through on every generation.

## Notable Details

- Token usage is tolerant of missing fields (e.g., tool-only responses with no `usageMetadata`)
- Cache hit percentage is the key metric: if it stays near 0% while prompt tokens are large, the prefix isn't being cached and cost is higher than expected
- Observability tags are passed to every `generateContent` call, not just the initial draft, so follow-up rounds also group under the conversation trace
- `usage` field is optional on pre-existing conversations (backward compatible)

https://claude.ai/code/session_012YU13fbjGdh1YMsVqcYec1