### PR TITLE
Refactor scroll-to-bottom into stick-to-bottom with pinned state

### DIFF
--- a/src/BilingualBlockViewer.tsx
+++ b/src/BilingualBlockViewer.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { useRef, useState, useCallback, useEffect, useEffectEvent, useMemo } from 'react';
 import snarkdown from 'snarkdown';
 import type { Block } from './blockTypes';
-import { useScrollToBottom } from './reactUtils';
+import { useStickToBottom } from './reactUtils';
 import { useTTS } from './useTTS';
 import { useStrings } from './useLocale';
 
@@ -57,7 +57,11 @@ export function BilingualBlockViewer({
     }).filter(line => line.trim() !== '');
   }, [nonEmptyBlocks, translations, language]);
 
-  useScrollToBottom(scrollContainerRef, contentEndRef, [nonEmptyBlocks.length, translations.size], true);
+  const { pinned, scrollToEnd } = useStickToBottom(
+    scrollContainerRef,
+    contentEndRef,
+    [nonEmptyBlocks.length, translations.size]
+  );
 
   const isTTSEnabled = language === 'French' || language === 'Spanish';
 
@@ -223,6 +227,16 @@ export function BilingualBlockViewer({
           <div ref={contentEndRef} />
         </div>
       </div>
+
+      {!pinned && (
+        <button
+          type='button'
+          onClick={() => scrollToEnd()}
+          className="absolute bottom-4 left-1/2 -translate-x-1/2 px-3 py-1 rounded-full text-sm font-medium shadow-lg bg-blue-500 text-white hover:bg-blue-600"
+        >
+          {s.jumpToLatest}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/BilingualBlockViewer.tsx
+++ b/src/BilingualBlockViewer.tsx
@@ -232,7 +232,7 @@ export function BilingualBlockViewer({
         <button
           type='button'
           onClick={() => scrollToEnd()}
-          className="absolute bottom-4 left-1/2 -translate-x-1/2 px-3 py-1 rounded-full text-sm font-medium shadow-lg bg-blue-500 text-white hover:bg-blue-600"
+          className="absolute bottom-4 left-1/2 -translate-x-1/2 px-3 py-1 rounded-full text-sm font-medium shadow-lg bg-blue-500 text-white hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-500"
         >
           {s.jumpToLatest}
         </button>

--- a/src/LiveTranscript.tsx
+++ b/src/LiveTranscript.tsx
@@ -8,9 +8,10 @@
 // for any viewer — a listener (whether or not they've started audio) or the
 // broadcaster — because reading it needs only the Yjs connection, not the audio
 // room.
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useStrings } from "./useLocale";
 import { useAsPlainText } from "./yjsUtils";
+import { useStickToBottom } from "./reactUtils";
 
 // One finalized transcript paragraph. Mounting fresh (only appended segments do)
 // plays a one-shot highlight animation, so new text is gently emphasized without
@@ -23,7 +24,7 @@ export function LiveTranscript({ langCode }: { langCode: string }) {
   const s = useStrings();
   const [finalized] = useAsPlainText(`liveTranscript-${langCode}`);
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  const atBottomRef = useRef(true);
+  const contentEndRef = useRef<HTMLDivElement | null>(null);
 
   const segments = useMemo(
     () => finalized.split("\n\n").map((t) => t.trim()).filter(Boolean),
@@ -34,39 +35,40 @@ export function LiveTranscript({ langCode }: { langCode: string }) {
   // Captured once via a lazy initializer (reading a ref during render is unsafe).
   const [baselineCount] = useState(() => segments.length);
 
-  // Auto-scroll only when the reader is already near the bottom, so reading older
-  // text isn't yanked away when new text arrives. Runs after every render (cheap);
-  // it only moves the scroll position when already pinned to the bottom.
-  const onScroll = () => {
-    const el = scrollRef.current;
-    if (!el) return;
-    atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
-  };
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el && atBottomRef.current) el.scrollTop = el.scrollHeight;
-  });
+  const { pinned, scrollToEnd } = useStickToBottom(scrollRef, contentEndRef, [segments.length]);
 
   const hasContent = segments.length > 0;
 
   return (
-    <div
-      ref={scrollRef}
-      onScroll={onScroll}
-      className="flex-1 overflow-auto text-gray-800 dark:text-gray-100"
-    >
-      {hasContent ? (
-        <div className="mx-auto max-w-[60ch] text-lg leading-relaxed">
-          {segments.map((seg, i) => (
-            <TranscriptSegment
-              key={`${i}-${seg.slice(0, 16)}`}
-              text={seg}
-              isNew={i >= baselineCount}
-            />
-          ))}
-        </div>
-      ) : (
-        <span className="italic text-gray-400">{s.waitingForSpeech}</span>
+    <div className="relative flex-1 flex flex-col min-h-0">
+      <div
+        ref={scrollRef}
+        className="flex-1 overflow-auto text-gray-800 dark:text-gray-100"
+      >
+        {hasContent ? (
+          <div className="mx-auto max-w-[60ch] text-lg leading-relaxed">
+            {segments.map((seg, i) => (
+              <TranscriptSegment
+                key={`${i}-${seg.slice(0, 16)}`}
+                text={seg}
+                isNew={i >= baselineCount}
+              />
+            ))}
+            <div ref={contentEndRef} />
+          </div>
+        ) : (
+          <span className="italic text-gray-400">{s.waitingForSpeech}</span>
+        )}
+      </div>
+
+      {hasContent && !pinned && (
+        <button
+          type='button'
+          onClick={() => scrollToEnd()}
+          className="absolute bottom-4 left-1/2 -translate-x-1/2 px-3 py-1 rounded-full text-sm font-medium shadow-lg bg-blue-500 text-white hover:bg-blue-600"
+        >
+          {s.jumpToLatest}
+        </button>
       )}
     </div>
   );

--- a/src/LiveTranscript.tsx
+++ b/src/LiveTranscript.tsx
@@ -35,7 +35,10 @@ export function LiveTranscript({ langCode }: { langCode: string }) {
   // Captured once via a lazy initializer (reading a ref during render is unsafe).
   const [baselineCount] = useState(() => segments.length);
 
-  const { pinned, scrollToEnd } = useStickToBottom(scrollRef, contentEndRef, [segments.length]);
+  // Key on the raw text, not segments.length: deltas stream into the *current*
+  // paragraph without adding a segment, so keying on the count would only
+  // re-stick at sentence boundaries and let mid-sentence text scroll off-screen.
+  const { pinned, scrollToEnd } = useStickToBottom(scrollRef, contentEndRef, [finalized]);
 
   const hasContent = segments.length > 0;
 
@@ -65,7 +68,7 @@ export function LiveTranscript({ langCode }: { langCode: string }) {
         <button
           type='button'
           onClick={() => scrollToEnd()}
-          className="absolute bottom-4 left-1/2 -translate-x-1/2 px-3 py-1 rounded-full text-sm font-medium shadow-lg bg-blue-500 text-white hover:bg-blue-600"
+          className="absolute bottom-4 left-1/2 -translate-x-1/2 px-3 py-1 rounded-full text-sm font-medium shadow-lg bg-blue-500 text-white hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-500"
         >
           {s.jumpToLatest}
         </button>

--- a/src/reactUtils.test.tsx
+++ b/src/reactUtils.test.tsx
@@ -170,6 +170,31 @@ describe('useStickToBottom', () => {
     expect(scrollTo).toHaveBeenCalledTimes(1);
   });
 
+  // Regression: a continuous stream whose deps change faster than the throttle
+  // window must still scroll. A reset-on-every-change debounce would push the
+  // timer out forever and never fire while the stream is live.
+  it('keeps scrolling during a fast delta stream (does not starve)', () => {
+    const { el, scrollTo } = makeParent();
+    const parentRef = { current: el };
+    const targetRef = { current: makeTarget() };
+
+    const { rerender } = renderHook(
+      ({ deps }) => useStickToBottom(parentRef, targetRef, deps),
+      { initialProps: { deps: [0] as unknown[] } },
+    );
+
+    // Deltas arrive every 40ms (< the 100ms window) for ~400ms.
+    for (let i = 1; i <= 10; i++) {
+      rerender({ deps: [i] });
+      act(() => {
+        vi.advanceTimersByTime(40);
+      });
+    }
+
+    // A throttle fires roughly once per window; a reset-debounce would be 0.
+    expect(scrollTo.mock.calls.length).toBeGreaterThan(1);
+  });
+
   it('does nothing (and does not throw) when refs are missing', () => {
     const parentRef = { current: null as HTMLElement | null };
     const targetRef = { current: null as HTMLElement | null };

--- a/src/reactUtils.test.tsx
+++ b/src/reactUtils.test.tsx
@@ -1,23 +1,40 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { act } from 'react';
-import { useScrollToBottom } from './reactUtils';
+import { useStickToBottom } from './reactUtils';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
- * A fake scroll-parent element that tracks scrollTo calls and reports a fixed
- * rect. Returns the mock separately so assertions target a plain mock (not an
+ * A fake scroll-parent element that tracks scrollTo calls, reports a fixed
+ * rect/size, and supports addEventListener/removeEventListener so the hook's
+ * scroll/wheel/touchmove listeners can be driven via `fire()`. Returns the
+ * scrollTo mock separately so assertions target a plain mock (not an
  * HTMLElement method, which trips @typescript-eslint/unbound-method).
  */
-function makeParent(bottom = 100, scrollTop = 50) {
+function makeParent({
+  bottom = 100,
+  scrollTop = 50,
+  scrollHeight = 950,
+  clientHeight = 900,
+} = {}) {
   const scrollTo = vi.fn();
+  const listeners: Record<string, (() => void)[]> = {};
   const el = {
     scrollTop,
+    scrollHeight,
+    clientHeight,
     scrollTo,
     getBoundingClientRect: () => ({ bottom }) as DOMRect,
+    addEventListener: (type: string, cb: () => void) => {
+      (listeners[type] ??= []).push(cb);
+    },
+    removeEventListener: (type: string, cb: () => void) => {
+      listeners[type] = (listeners[type] ?? []).filter((l) => l !== cb);
+    },
   } as unknown as HTMLElement;
-  return { el, scrollTo };
+  const fire = (type: string) => listeners[type]?.forEach((cb) => cb());
+  return { el, scrollTo, fire };
 }
 
 /** A fake target element that reports a fixed rect. */
@@ -27,7 +44,7 @@ function makeTarget(bottom = 200) {
   } as unknown as HTMLElement;
 }
 
-describe('useScrollToBottom', () => {
+describe('useStickToBottom', () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -37,11 +54,11 @@ describe('useScrollToBottom', () => {
   });
 
   it('scrolls the parent so the target sits at the bottom after the debounce', () => {
-    const { el, scrollTo } = makeParent(100, 50);
+    const { el, scrollTo } = makeParent({ bottom: 100, scrollTop: 50 });
     const parentRef = { current: el };
     const targetRef = { current: makeTarget(200) };
 
-    renderHook(({ deps }) => useScrollToBottom(parentRef, targetRef, deps, true), {
+    renderHook(({ deps }) => useStickToBottom(parentRef, targetRef, deps), {
       initialProps: { deps: [0] as unknown[] },
     });
 
@@ -56,20 +73,79 @@ describe('useScrollToBottom', () => {
     expect(scrollTo).toHaveBeenCalledWith({ top: 150, behavior: 'smooth' });
   });
 
-  it('does not scroll when disabled', () => {
-    const { el, scrollTo } = makeParent();
+  it('does not auto-scroll once the reader has scrolled away from the bottom', () => {
+    const { el, scrollTo, fire } = makeParent({
+      scrollTop: 0,
+      scrollHeight: 1000,
+      clientHeight: 900,
+    });
     const parentRef = { current: el };
     const targetRef = { current: makeTarget() };
 
-    renderHook(({ deps }) => useScrollToBottom(parentRef, targetRef, deps, false), {
-      initialProps: { deps: [0] as unknown[] },
-    });
+    const { result, rerender } = renderHook(
+      ({ deps }) => useStickToBottom(parentRef, targetRef, deps),
+      { initialProps: { deps: [0] as unknown[] } },
+    );
 
+    // Reader scrolls up: 1000 - 0 - 900 = 100px from bottom (past the 80px threshold).
+    act(() => fire('scroll'));
+    expect(result.current.pinned).toBe(false);
+
+    rerender({ deps: [1] });
     act(() => {
-      vi.advanceTimersByTime(100);
+      vi.advanceTimersByTime(200);
     });
 
     expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('holds off auto-scrolling while the reader is mid-gesture (wheel/touch)', () => {
+    const { el, scrollTo, fire } = makeParent();
+    const parentRef = { current: el };
+    const targetRef = { current: makeTarget() };
+
+    const { rerender } = renderHook(
+      ({ deps }) => useStickToBottom(parentRef, targetRef, deps),
+      { initialProps: { deps: [0] as unknown[] } },
+    );
+
+    act(() => fire('wheel'));
+    rerender({ deps: [1] });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    // Still within the post-gesture holdoff window: no scroll yet.
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    rerender({ deps: [2] });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    // Holdoff has elapsed and the reader never left the bottom, so it resumes.
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it('scrollToEnd jumps immediately and re-pins', () => {
+    const { el, scrollTo, fire } = makeParent({
+      scrollTop: 0,
+      scrollHeight: 1000,
+      clientHeight: 900,
+    });
+    const parentRef = { current: el };
+    const targetRef = { current: makeTarget() };
+
+    const { result } = renderHook(() => useStickToBottom(parentRef, targetRef, [0]));
+
+    act(() => fire('scroll'));
+    expect(result.current.pinned).toBe(false);
+
+    act(() => result.current.scrollToEnd());
+
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+    expect(result.current.pinned).toBe(true);
   });
 
   it('coalesces rapid dependency changes into a single scroll', () => {
@@ -78,7 +154,7 @@ describe('useScrollToBottom', () => {
     const targetRef = { current: makeTarget() };
 
     const { rerender } = renderHook(
-      ({ deps }) => useScrollToBottom(parentRef, targetRef, deps, true),
+      ({ deps }) => useStickToBottom(parentRef, targetRef, deps),
       { initialProps: { deps: [0] as unknown[] } },
     );
 
@@ -98,7 +174,7 @@ describe('useScrollToBottom', () => {
     const parentRef = { current: null as HTMLElement | null };
     const targetRef = { current: null as HTMLElement | null };
 
-    renderHook(({ deps }) => useScrollToBottom(parentRef, targetRef, deps, true), {
+    renderHook(({ deps }) => useStickToBottom(parentRef, targetRef, deps), {
       initialProps: { deps: [0] as unknown[] },
     });
 
@@ -118,7 +194,7 @@ describe('useScrollToBottom', () => {
     const targetRef = { current: makeTarget() as HTMLElement | null };
 
     const { rerender } = renderHook(
-      ({ deps }) => useScrollToBottom(parentRef, targetRef, deps, true),
+      ({ deps }) => useStickToBottom(parentRef, targetRef, deps),
       { initialProps: { deps: [0] as unknown[] } },
     );
 

--- a/src/reactUtils.test.tsx
+++ b/src/reactUtils.test.tsx
@@ -240,4 +240,30 @@ describe('useStickToBottom', () => {
     // Auto-scroll must resume, not stay wedged.
     expect(scrollTo).toHaveBeenCalledTimes(1);
   });
+
+  // Coverage for the real DOM path: the other tests hand the hook a fake `el`
+  // with a mock scrollTo, so they can't catch that jsdom lacks Element.scrollTo.
+  // This drives the hook against an actual node, so the genuine scroll path
+  // (getBoundingClientRect, scrollHeight, scrollTo) runs on every test run —
+  // it fails outright if the test-setup scrollTo stub ever goes missing.
+  it('scrolls a real DOM element (covers the real scrollTo path)', () => {
+    const parent = document.createElement('div');
+    const target = document.createElement('div');
+    parent.appendChild(target);
+    document.body.appendChild(parent);
+    const scrollTo = vi.spyOn(parent, 'scrollTo');
+
+    renderHook(
+      ({ deps }) =>
+        useStickToBottom({ current: parent }, { current: target }, deps),
+      { initialProps: { deps: [0] as unknown[] } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+    document.body.removeChild(parent);
+  });
 });

--- a/src/reactUtils.tsx
+++ b/src/reactUtils.tsx
@@ -1,43 +1,89 @@
 import React from 'react';
 
-export function useScrollToBottom(
+// Reader is considered "pinned" to the bottom (and thus eligible for
+// auto-scroll) when within this many px of it.
+const NEAR_BOTTOM_PX = 80;
+// How long after a wheel/touch gesture we still treat the reader as
+// "actively scrolling" and hold off auto-scrolling, so our own scroll
+// doesn't fight their gesture mid-motion.
+const USER_SCROLL_HOLDOFF_MS = 150;
+
+/**
+ * Keeps a scroll container stuck to a bottom sentinel element as content is
+ * appended (new transcript segments, new translated blocks, etc.) — but only
+ * while the reader hasn't scrolled away to read something earlier. Returns
+ * `pinned` so callers can show a "jump to latest" affordance when it's false,
+ * and `scrollToEnd` to jump back down (e.g. from that affordance's onClick).
+ */
+export function useStickToBottom(
   scrollParentRef: React.RefObject<HTMLElement | null>,
   targetRef: React.RefObject<HTMLElement | null>,
-  deps: React.DependencyList,
-  enabled: boolean
+  deps: React.DependencyList
 ) {
-  const timeoutRef = React.useRef<NodeJS.Timeout | null>(null);
-  const enabledRef = React.useRef(enabled);
+  const [pinned, setPinned] = React.useState(true);
+  const userScrollingRef = React.useRef(false);
+  const holdoffTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+  const scrollTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+
+  const updatePinned = React.useCallback(() => {
+    const el = scrollParentRef.current;
+    if (!el) return;
+    setPinned(el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const markUserScrolling = React.useCallback(() => {
+    userScrollingRef.current = true;
+    if (holdoffTimeoutRef.current) clearTimeout(holdoffTimeoutRef.current);
+    holdoffTimeoutRef.current = setTimeout(() => {
+      userScrollingRef.current = false;
+    }, USER_SCROLL_HOLDOFF_MS);
+  }, []);
+
   React.useEffect(() => {
-    enabledRef.current = enabled;
-  }, [enabled]);
-  React.useEffect(() => {
-    if (timeoutRef.current || !enabledRef.current) {
-      return;
-    }
+    const el = scrollParentRef.current;
+    if (!el) return;
+    // 'scroll' also fires for our own programmatic scrollToEnd(), so it only
+    // updates `pinned`. Only wheel/touch input marks the reader as actively
+    // scrolling, since those are unambiguously user-initiated.
+    el.addEventListener('scroll', updatePinned, { passive: true });
+    el.addEventListener('wheel', markUserScrolling, { passive: true });
+    el.addEventListener('touchmove', markUserScrolling, { passive: true });
+    return () => {
+      el.removeEventListener('scroll', updatePinned);
+      el.removeEventListener('wheel', markUserScrolling);
+      el.removeEventListener('touchmove', markUserScrolling);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [updatePinned, markUserScrolling]);
+
+  const scrollToEnd = React.useCallback((behavior: ScrollBehavior = 'smooth') => {
     const scrollParent = scrollParentRef.current;
     const target = targetRef.current;
     if (!scrollParent || !target) return;
 
-    timeoutRef.current = setTimeout(() => {
-      // Clear the handle first so a bailout below can't leave it stuck non-null,
-      // which would permanently block every future scroll for this component.
-      timeoutRef.current = null;
+    // Scroll so the target is at the bottom of the scroll parent
+    const targetRect = target.getBoundingClientRect();
+    const parentRect = scrollParent.getBoundingClientRect();
+    const scrollTop = scrollParent.scrollTop + (targetRect.bottom - parentRect.bottom);
 
-      const scrollParent = scrollParentRef.current;
-      const target = targetRef.current;
-      if (!scrollParent || !target || !enabledRef.current) return;
+    scrollParent.scrollTo({ top: scrollTop, behavior });
+    setPinned(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-      // Scroll so the target is at the bottom of the scroll parent
-      const targetRect = target.getBoundingClientRect();
-      const parentRect = scrollParent.getBoundingClientRect();
-      const scrollTop = scrollParent.scrollTop + (targetRect.bottom - parentRect.bottom);
-
-      scrollParent.scrollTo({
-        top: scrollTop,
-        behavior: 'smooth',
-      });
+  React.useEffect(() => {
+    if (!pinned || userScrollingRef.current) return;
+    if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
+    scrollTimeoutRef.current = setTimeout(() => {
+      scrollTimeoutRef.current = null;
+      if (pinned && !userScrollingRef.current) scrollToEnd('smooth');
     }, 100);
+    return () => {
+      if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
+
+  return { pinned, scrollToEnd };
 }

--- a/src/reactUtils.tsx
+++ b/src/reactUtils.tsx
@@ -7,6 +7,11 @@ const NEAR_BOTTOM_PX = 80;
 // "actively scrolling" and hold off auto-scrolling, so our own scroll
 // doesn't fight their gesture mid-motion.
 const USER_SCROLL_HOLDOFF_MS = 150;
+// Auto-scroll fires at most once per this window. This is a throttle, not a
+// reset-on-every-change debounce: a fast delta stream (deps changing faster
+// than we scroll) must not perpetually push the timer out and starve the
+// scroll — it should keep the bottom in view instead.
+const AUTO_SCROLL_THROTTLE_MS = 100;
 
 /**
  * Keeps a scroll container stuck to a bottom sentinel element as content is
@@ -25,12 +30,20 @@ export function useStickToBottom(
   const holdoffTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
   const scrollTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
 
-  const updatePinned = React.useCallback(() => {
+  // Ground truth for "is the reader at the bottom", read live from the DOM.
+  // `pinned` is just this measurement surfaced as state (for the pill); the
+  // scheduled auto-scroll re-reads this at fire time rather than trusting a
+  // value captured when it was queued, so a reader who has since scrolled away
+  // (by any means — wheel, touch, keyboard, scrollbar) isn't yanked back down.
+  const isNearBottom = React.useCallback(() => {
     const el = scrollParentRef.current;
-    if (!el) return;
-    setPinned(el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX);
+    return !!el && el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const updatePinned = React.useCallback(() => {
+    setPinned(isNearBottom());
+  }, [isNearBottom]);
 
   const markUserScrolling = React.useCallback(() => {
     userScrollingRef.current = true;
@@ -72,18 +85,25 @@ export function useStickToBottom(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // When tracked content grows, re-stick to the bottom. Throttled (schedule
+  // only when nothing is already queued) so a burst of dependency changes
+  // coalesces into a single scroll instead of resetting the timer forever.
   React.useEffect(() => {
-    if (!pinned || userScrollingRef.current) return;
-    if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
+    if (scrollTimeoutRef.current || userScrollingRef.current || !isNearBottom()) return;
     scrollTimeoutRef.current = setTimeout(() => {
       scrollTimeoutRef.current = null;
-      if (pinned && !userScrollingRef.current) scrollToEnd('smooth');
-    }, 100);
-    return () => {
-      if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
-    };
+      if (!userScrollingRef.current && isNearBottom()) scrollToEnd('smooth');
+    }, AUTO_SCROLL_THROTTLE_MS);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
+
+  React.useEffect(
+    () => () => {
+      if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
+      if (holdoffTimeoutRef.current) clearTimeout(holdoffTimeoutRef.current);
+    },
+    []
+  );
 
   return { pinned, scrollToEnd };
 }

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -42,6 +42,9 @@ export interface AppStrings {
   noContent: string;
   notTranslated: string;
 
+  // Stick-to-bottom scrolling (BilingualBlockViewer, LiveTranscript)
+  jumpToLatest: string;
+
   // Slide viewer
   noSlides: string;
   waitingForProclaim: string;
@@ -141,6 +144,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     ttsError: 'Error: ',
     noContent: 'No content yet',
     notTranslated: '(not translated)',
+    jumpToLatest: '↓ New',
     listenLive: 'Listen live',
     stopAudio: 'Stop audio',
     englishTranscript: 'English transcript',
@@ -227,6 +231,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     ttsError: 'Erreur\u00a0: ',
     noContent: 'Aucun contenu pour l\u2019instant',
     notTranslated: '(non traduit)',
+    jumpToLatest: '\u2193 Nouveau',
     listenLive: 'Écouter en direct',
     stopAudio: 'Couper le son',
     englishTranscript: 'Transcription anglaise',
@@ -313,6 +318,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     ttsError: 'Error: ',
     noContent: 'Sin contenido a\u00fan',
     notTranslated: '(no traducido)',
+    jumpToLatest: '\u2193 Nuevo',
     listenLive: 'Escuchar en vivo',
     stopAudio: 'Detener audio',
     englishTranscript: 'Transcripción en inglés',
@@ -399,6 +405,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     ttsError: 'Er\u00e8\u00a0: ',
     noContent: 'Pa gen kontni pou kounye a',
     notTranslated: '(pa tradui)',
+    jumpToLatest: '↓ Nouvo',
     listenLive: 'Koute an dirèk',
     stopAudio: 'Sispann odyo',
     englishTranscript: 'Transkripsyon anglè',

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -15,3 +15,10 @@ global.Audio = vi.fn().mockImplementation(() => ({
   removeEventListener: vi.fn(),
   load: vi.fn(),
 }));
+
+// jsdom doesn't implement Element.scrollTo. Components using scroll-to-bottom
+// hooks (useStickToBottom) fire a throttled scrollTo on a real element during
+// tests; without this stub that throws asynchronously and fails the run.
+if (!Element.prototype.scrollTo) {
+  Element.prototype.scrollTo = vi.fn();
+}


### PR DESCRIPTION
## Summary

Renames and significantly enhances the scroll-to-bottom utility into a more sophisticated "stick-to-bottom" hook that intelligently keeps content pinned to the bottom only while the reader is actively viewing the latest content. When the reader scrolls away, a "jump to latest" button appears to let them quickly return.

## Key Changes

- **Hook rename & API redesign**: `useScrollToBottom()` → `useStickToBottom()` with a new return signature `{ pinned, scrollToEnd }` instead of a boolean `enabled` parameter
  - Removes the `enabled` prop; the hook now manages its own pinned state internally
  - Exposes `scrollToEnd()` callback for manual jumps (e.g., from UI buttons)

- **Pinned state tracking**: 
  - Tracks whether the reader is within 80px of the bottom (`NEAR_BOTTOM_PX`)
  - Updates on scroll events; exposed via `pinned` return value
  - Allows UI to show/hide "jump to latest" affordance

- **User gesture detection**:
  - Listens for `wheel` and `touchmove` events to detect active scrolling
  - Holds off auto-scroll for 150ms after user gestures (`USER_SCROLL_HOLDOFF_MS`) to avoid fighting mid-motion
  - Prevents jarring scroll conflicts when reader is mid-gesture

- **Improved test coverage**:
  - Enhanced `makeParent()` helper to support `addEventListener`/`removeEventListener` and event firing
  - New tests for unpinning behavior, gesture holdoff, and `scrollToEnd()` manual jump
  - Tests verify the hook respects user scroll position and gesture state

- **UI integration** (LiveTranscript & BilingualBlockViewer):
  - Both components now render a "jump to latest" button when `!pinned`
  - Button uses `scrollToEnd()` to jump back to bottom with smooth scroll
  - Cleaner component logic: removed manual scroll tracking, now delegated to hook

- **Localization**: Added `jumpToLatest` string to all supported locales (English: "↓ New", French: "↓ Nouveau", Spanish: "↓ Nuevo")

## Implementation Details

- The hook uses three timeout refs to manage debouncing (scroll, holdoff, and gesture detection)
- `updatePinned()` callback calculates distance from bottom: `scrollHeight - scrollTop - clientHeight`
- Event listeners are passive for better scroll performance
- Dependency array uses `deps` parameter to trigger auto-scroll on content changes (e.g., new segments)
- `scrollToEnd()` immediately sets `pinned: true` to re-engage auto-scroll after manual jump

https://claude.ai/code/session_01RCwCxmbMK4Q17BDKcYmNeH