### PR TITLE
macOS audio feeder: fix fiddly menu-bar popup (NSStatusItem + NSPopover)

### DIFF
--- a/macos-audio-feeder/.gitignore
+++ b/macos-audio-feeder/.gitignore
@@ -1,0 +1,5 @@
+.build/
+.swiftpm/
+*.xcodeproj
+DerivedData/
+Package.resolved

--- a/macos-audio-feeder/Package.swift
+++ b/macos-audio-feeder/Package.swift
@@ -1,0 +1,55 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// AudioFeeder: a native macOS menu-bar app that feeds one channel of a multichannel
+// sound board into the live-translation pipeline by publishing to the session's LiveKit
+// room as `organizer-host` (the same identity the browser broadcast page uses).
+//
+// Layout:
+//   - AudioFeederCore  : pure, dependency-light logic (Config, Scheduler, LevelMeter,
+//                        ChannelExtractor). Unit-tested. The non-AVFoundation pieces also
+//                        build on Linux so the math is testable anywhere.
+//   - AudioFeederApp   : the executable app (SwiftUI MenuBarExtra, CoreAudio capture,
+//                        LiveKit publishing). macOS-only; depends on the LiveKit Swift SDK.
+let package = Package(
+    name: "AudioFeeder",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .library(name: "AudioFeederCore", targets: ["AudioFeederCore"]),
+        .executable(name: "AudioFeederApp", targets: ["AudioFeederApp"]),
+        // A tiny standalone command-line spike to de-risk the linchpin: does
+        // AudioManager manual rendering + mixer.capture(appAudio:) actually publish
+        // audio on macOS? Run it, then join the session in a browser to listen.
+        .executable(name: "AudioFeederSpike", targets: ["AudioFeederSpike"]),
+    ],
+    dependencies: [
+        // The LiveKit Swift client SDK provides the custom-audio publishing path
+        // (AudioManager manual rendering + mixer.capture(appAudio:)).
+        .package(url: "https://github.com/livekit/client-sdk-swift.git", from: "2.0.7"),
+    ],
+    targets: [
+        .target(
+            name: "AudioFeederCore"
+        ),
+        .executableTarget(
+            name: "AudioFeederApp",
+            dependencies: [
+                "AudioFeederCore",
+                .product(name: "LiveKit", package: "client-sdk-swift"),
+            ]
+        ),
+        .executableTarget(
+            name: "AudioFeederSpike",
+            dependencies: [
+                "AudioFeederCore",
+                .product(name: "LiveKit", package: "client-sdk-swift"),
+            ]
+        ),
+        .testTarget(
+            name: "AudioFeederCoreTests",
+            dependencies: ["AudioFeederCore"]
+        ),
+    ]
+)

--- a/macos-audio-feeder/Packaging/AudioFeeder.entitlements
+++ b/macos-audio-feeder/Packaging/AudioFeeder.entitlements
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Entitlements for the signed .app bundle. App Sandbox + the audio-input entitlement give
+  a clean first-class microphone TCC grant; the network client entitlement is needed to
+  reach the live-notes token endpoint and LiveKit.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+</dict>
+</plist>

--- a/macos-audio-feeder/Packaging/Info.plist
+++ b/macos-audio-feeder/Packaging/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Info.plist for the packaged .app bundle (Xcode app target or a bundling build script).
+  SwiftPM executables don't apply this automatically; it's here so the menu-bar/login-item
+  behavior and the microphone permission prompt are correctly configured when packaging.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>Audio Feeder</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.kenarnold.audio-feeder</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <!-- Menu-bar-only: no Dock icon, no main window. -->
+    <key>LSUIElement</key>
+    <true/>
+    <!-- Shown in the one-time microphone permission prompt. -->
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Audio Feeder captures one channel of your sound board to broadcast it for live translation.</string>
+</dict>
+</plist>

--- a/macos-audio-feeder/README.md
+++ b/macos-audio-feeder/README.md
@@ -1,0 +1,105 @@
+# macOS Audio Feeder
+
+A native macOS menu-bar app that feeds **one channel of a multichannel sound board** into
+the live-notes translation pipeline — automatically, on a schedule. It publishes to the
+session's LiveKit room as `organizer-host`, the **same identity the browser broadcast page
+uses** (`src/BroadcastControl.tsx`), so there are **no server changes** and the browser
+broadcast still works as an alternative input. (LiveKit allows one participant per identity,
+so the app and the browser page are mutually exclusive — use one or the other.)
+
+See the design notes for the full rationale (TCC/permissions, why pure Swift, the
+custom-audio publishing path).
+
+## Requirements
+
+- macOS 14+
+- Xcode 15+ / a recent Swift toolchain
+- The live-notes server must have LiveKit configured (`LIVEKIT_URL`, `LIVEKIT_API_KEY`,
+  `LIVEKIT_API_SECRET`), otherwise `/api/livekit/token` returns 503.
+
+## The spike — run this first
+
+The whole design hinges on one unverified assumption: that the LiveKit Swift SDK's
+custom-audio path (`AudioManager.setManualRenderingMode(true)` +
+`AudioManager.shared.mixer.capture(appAudio:)`) actually publishes audio on macOS. The
+`AudioFeederSpike` executable proves it end-to-end by publishing a sine tone — no sound
+board required.
+
+```bash
+cd macos-audio-feeder
+
+# Publish a 440 Hz tone into today's session on your dev server:
+swift run AudioFeederSpike --server-url https://dev8.kenarnold.org
+
+# …or target a specific doc / pitch:
+swift run AudioFeederSpike --server-url https://dev8.kenarnold.org --doc doc-2025-06-30 --freq 660
+```
+
+Then open that session in a browser **as a listener** (not the broadcast page) and confirm:
+
+1. `organizer-host` shows up as a participant.
+2. A translator bot spins up and you can hear/See the tone being carried.
+3. Press **Ctrl-C** in the terminal to stop; `organizer-host` leaves and the browser
+   broadcast page becomes usable again.
+
+The first run will prompt for **Microphone** permission (manual rendering still counts as
+audio I/O). Grant it.
+
+### If the spike's API names don't resolve
+
+`setManualRenderingMode` / `mixer.capture(appAudio:)` come from the SDK's `Docs/audio.md`.
+If they don't match the installed SDK version, reconcile them in
+`Sources/AudioFeederSpike/main.swift` (the call site is marked `<<< API UNDER TEST >>>`).
+If the custom-audio path turns out not to work on macOS at all, the fallback is to expose
+the desired channel as its own input device via a macOS **Aggregate Device** and use the
+SDK's normal device capture — still pure Swift.
+
+## Tests
+
+The pure logic (scheduler, level/RMS, channel extraction, config, token contract) is unit
+tested and has no audio/LiveKit dependencies:
+
+```bash
+swift test
+```
+
+## Project layout
+
+```
+macos-audio-feeder/
+  Package.swift
+  Sources/
+    AudioFeederCore/     # pure, tested: Config, Scheduler, LevelMeter, ChannelExtractor,
+                         #               ToneGenerator, LiveKitTokenClient
+    AudioFeederSpike/    # standalone tone-publishing spike (run this first)
+    AudioFeederApp/      # the menu-bar app (capture + publish + UI)
+  Tests/
+    AudioFeederCoreTests/
+```
+
+## The app
+
+```bash
+swift build              # compiles AudioFeederApp (and the core + spike)
+swift run AudioFeederApp # runs from the SwiftPM build for development
+```
+
+> **Packaging caveat:** a SwiftPM executable is fine for development, but the menu-bar-only
+> behavior (`LSUIElement`), the microphone permission string, login-item registration
+> (`SMAppService`), and signing/notarization all require a real `.app` **bundle**. The
+> `Packaging/Info.plist` and `Packaging/AudioFeeder.entitlements` here are ready for an
+> Xcode app target (or a bundling build script) — that step is still to do.
+
+## Status
+
+- [x] Pure core + unit tests (scheduler, level/RMS, channel pick, config, token contract)
+- [x] Spike (validate custom-audio publishing on macOS) — **ready to run**
+- [x] Capture (`AudioCapture`: AVAudioEngine bound to device by UID, channel extraction)
+- [x] Device enumeration + hot-plug (`DeviceMonitor`, CoreAudio)
+- [x] LiveKit publisher (`Publisher`: token fetch, manual rendering + mixer.capture,
+      retry/backoff, identity release on stop)
+- [x] Orchestration (`AppController`: schedule eval, manual override, waiting-for-device)
+- [x] MenuBarExtra UI + settings + login-item toggle
+- [ ] Package as a signed/notarized `.app` bundle (Info.plist/entitlements provided)
+- [ ] (Optional) WKWebView transcript/translations pane
+- [ ] Verify on a Mac: spike first, then end-to-end with a real board

--- a/macos-audio-feeder/README.md
+++ b/macos-audio-feeder/README.md
@@ -99,7 +99,7 @@ swift run AudioFeederApp # runs from the SwiftPM build for development
 - [x] LiveKit publisher (`Publisher`: token fetch, manual rendering + mixer.capture,
       retry/backoff, identity release on stop)
 - [x] Orchestration (`AppController`: schedule eval, manual override, waiting-for-device)
-- [x] MenuBarExtra UI + settings + login-item toggle
+- [x] Menu-bar UI (NSStatusItem + NSPopover) + settings window + login-item toggle
 - [ ] Package as a signed/notarized `.app` bundle (Info.plist/entitlements provided)
 - [ ] (Optional) WKWebView transcript/translations pane
 - [ ] Verify on a Mac: spike first, then end-to-end with a real board

--- a/macos-audio-feeder/Sources/AudioFeederApp/AppController.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/AppController.swift
@@ -1,0 +1,168 @@
+import Foundation
+import AVFoundation
+import Combine
+import CoreAudio
+import AudioFeederCore
+
+/// Orchestrates the feeder: evaluates the schedule, manages the capture→publish lifecycle,
+/// handles device presence/hot-plug, and exposes observable state for the menu-bar UI.
+@MainActor
+final class AppController: ObservableObject {
+
+    /// High-level status surfaced in the UI.
+    enum Status: Equatable {
+        case idle                    // schedule says off
+        case waitingForDevice(String)
+        case connecting
+        case publishing
+        case error(String)
+
+        var label: String {
+            switch self {
+            case .idle: return "Idle (off schedule)"
+            case let .waitingForDevice(name): return "Waiting for device: \(name)"
+            case .connecting: return "Connecting…"
+            case .publishing: return "Publishing"
+            case let .error(msg): return "Error: \(msg)"
+            }
+        }
+    }
+
+    @Published private(set) var status: Status = .idle
+    @Published private(set) var level: Float = 0          // 0...1 for the meter
+    @Published private(set) var devices: [AudioInputDevice] = []
+    @Published var config: FeederConfig {
+        didSet { configChanged() }
+    }
+
+    private let store = ConfigStore()
+    private let deviceMonitor = DeviceMonitor()
+    private var capture: AudioCapture?
+    private var publisher: Publisher?
+
+    private var tick: Timer?
+    private var retryAfter: Date?
+    private var retryBackoff: TimeInterval = 2
+
+    init() {
+        self.config = store.load()
+        refreshDevices()
+
+        deviceMonitor.onDevicesChanged = { [weak self] in
+            self?.refreshDevices()
+            self?.evaluate()
+        }
+        deviceMonitor.startMonitoring()
+
+        // Re-evaluate on a coarse cadence so scheduled windows start/stop on time.
+        tick = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.evaluate() }
+        }
+        evaluate()
+    }
+
+    // MARK: - Manual override (UI buttons)
+
+    func startNow() { config.manualOverride = .forceOn }   // didSet → save + evaluate
+    func stopNow() { config.manualOverride = .forceOff }
+    func followSchedule() { config.manualOverride = .off }
+
+    func refreshDevices() {
+        devices = DeviceMonitor.inputDevices()
+    }
+
+    /// The currently configured device, if connected.
+    var selectedDevice: AudioInputDevice? {
+        guard let uid = config.deviceUID else { return nil }
+        return devices.first { $0.uid == uid }
+    }
+
+    // MARK: - Core evaluation
+
+    private func configChanged() {
+        store.save(config)
+        evaluate()
+    }
+
+    /// Decide whether we should be running and reconcile the capture/publish lifecycle.
+    private func evaluate() {
+        let wantRun = Scheduler.shouldRun(now: Date(),
+                                          schedule: config.schedule,
+                                          manualOverride: config.manualOverride)
+        if !wantRun {
+            teardown()
+            status = .idle
+            return
+        }
+
+        guard let uid = config.deviceUID, let device = DeviceMonitor.device(forUID: uid) else {
+            teardown()
+            let name = config.deviceUID ?? "none selected"
+            status = .waitingForDevice(name)
+            return
+        }
+
+        // Honor backoff after a failure before retrying.
+        if let retryAfter, Date() < retryAfter { return }
+
+        if capture == nil { startPipeline(device: device) }
+    }
+
+    private func startPipeline(device: AudioInputDevice) {
+        let docID = config.resolvedDocID()
+
+        let publisher = Publisher(serverURL: config.serverURL)
+        publisher.onStateChange = { [weak self] pubState in
+            Task { @MainActor in self?.handlePublisherState(pubState) }
+        }
+        self.publisher = publisher
+
+        let capture = AudioCapture(channelIndex: config.channelIndex)
+        capture.onMonoBuffer = { [weak publisher] buffer in
+            Task { @MainActor in publisher?.capture(buffer) }
+        }
+        capture.onLevel = { [weak self] level in
+            Task { @MainActor in self?.level = LevelMeter.displayLevel(rms: level) }
+        }
+        self.capture = capture
+
+        do {
+            try capture.start(deviceID: device.id)
+            publisher.start(room: docID)
+            status = .connecting
+        } catch {
+            status = .error("\(error)")
+            scheduleRetry()
+        }
+    }
+
+    private func handlePublisherState(_ pubState: Publisher.State) {
+        switch pubState {
+        case .connecting:
+            status = .connecting
+        case .connected:
+            status = .publishing
+            retryBackoff = 2               // reset backoff on success
+            retryAfter = nil
+        case .disconnected:
+            if case .publishing = status { status = .idle }
+        case let .failed(msg):
+            status = .error(msg)
+            teardown()
+            scheduleRetry()
+        }
+    }
+
+    private func scheduleRetry() {
+        retryAfter = Date().addingTimeInterval(retryBackoff)
+        retryBackoff = min(retryBackoff * 2, 30)
+    }
+
+    private func teardown() {
+        capture?.stop()
+        capture = nil
+        publisher?.stop()
+        publisher = nil
+        level = 0
+    }
+}

--- a/macos-audio-feeder/Sources/AudioFeederApp/AudioCapture.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/AudioCapture.swift
@@ -1,0 +1,80 @@
+import Foundation
+import AVFoundation
+import CoreAudio
+import AudioFeederCore
+
+enum AudioCaptureError: Error, CustomStringConvertible {
+    case couldNotSetDevice(OSStatus)
+    case noInputAudioUnit
+    case engineStartFailed(Error)
+
+    var description: String {
+        switch self {
+        case let .couldNotSetDevice(status): return "could not bind input device (OSStatus \(status))"
+        case .noInputAudioUnit: return "input node has no audio unit"
+        case let .engineStartFailed(error): return "audio engine failed to start: \(error)"
+        }
+    }
+}
+
+/// Captures audio from a chosen CoreAudio input device, pulls one channel, and emits a mono
+/// buffer plus a level reading per tap. Pure channel/level math lives in AudioFeederCore.
+final class AudioCapture {
+    /// Delivered on the tap's (real-time) thread; keep handlers light.
+    var onMonoBuffer: ((AVAudioPCMBuffer) -> Void)?
+    var onLevel: ((Float) -> Void)?
+
+    private let engine = AVAudioEngine()
+    private let channelIndex: Int
+    private var running = false
+
+    init(channelIndex: Int) {
+        self.channelIndex = channelIndex
+    }
+
+    func start(deviceID: AudioDeviceID) throws {
+        guard !running else { return }
+
+        // Bind the engine's input node to the selected hardware device (macOS).
+        let inputNode = engine.inputNode
+        guard let audioUnit = inputNode.audioUnit else { throw AudioCaptureError.noInputAudioUnit }
+        var device = deviceID
+        let status = AudioUnitSetProperty(
+            audioUnit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &device,
+            UInt32(MemoryLayout<AudioDeviceID>.size))
+        guard status == noErr else { throw AudioCaptureError.couldNotSetDevice(status) }
+
+        // Tap the input in its native (multichannel) format; extract our channel per buffer.
+        let format = inputNode.inputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak self] buffer, _ in
+            guard let self else { return }
+            guard let mono = ChannelExtractor.extractMono(from: buffer, channel: self.channelIndex) else {
+                return
+            }
+            self.onLevel?(LevelMeter.rms(buffer: mono))
+            self.onMonoBuffer?(mono)
+        }
+
+        engine.prepare()
+        do {
+            try engine.start()
+        } catch {
+            inputNode.removeTap(onBus: 0)
+            throw AudioCaptureError.engineStartFailed(error)
+        }
+        running = true
+    }
+
+    func stop() {
+        guard running else { return }
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        running = false
+    }
+
+    var isRunning: Bool { running }
+}

--- a/macos-audio-feeder/Sources/AudioFeederApp/AudioFeederApp.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/AudioFeederApp.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Menu-bar-only app (no Dock icon — set `LSUIElement` in the bundle's Info.plist when
+/// packaging). The window-style MenuBarExtra hosts the level meter, status, and controls.
+@main
+struct AudioFeederApp: App {
+    @StateObject private var controller = AppController()
+
+    var body: some Scene {
+        MenuBarExtra {
+            MenuContentView(controller: controller)
+                .frame(width: 340)
+        } label: {
+            // SF Symbol reflects whether we're live.
+            Image(systemName: controller.isPublishing ? "dot.radiowaves.left.and.right" : "waveform")
+        }
+        .menuBarExtraStyle(.window)
+    }
+}
+
+extension AppController {
+    /// Convenience for the menu-bar glyph.
+    var isPublishing: Bool { if case .publishing = status { return true } else { return false } }
+}

--- a/macos-audio-feeder/Sources/AudioFeederApp/AudioFeederApp.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/AudioFeederApp.swift
@@ -1,20 +1,72 @@
 import SwiftUI
+import AppKit
+import Combine
 
-/// Menu-bar-only app (no Dock icon — set `LSUIElement` in the bundle's Info.plist when
-/// packaging). The window-style MenuBarExtra hosts the level meter, status, and controls.
+/// Menu-bar-only app. We drive the menu bar with an `NSStatusItem` + `NSPopover`
+/// (via the AppDelegate) instead of SwiftUI's `MenuBarExtra`, because a `MenuBarExtra(.window)`
+/// panel auto-dismisses the moment any child menu/sheet steals key focus — which is exactly
+/// what made the device `Picker` flicker away. An `NSPopover` behaves like Dropbox's menu:
+/// the container stays put while a Picker's dropdown floats over it.
+///
+/// The only SwiftUI `Scene` is the standard `Settings` window (opened from the popover via
+/// `SettingsLink`), which hosts the existing `ConfigView`. Settings controls — including the
+/// device Picker — live in a real window, so they work normally.
 @main
 struct AudioFeederApp: App {
-    @StateObject private var controller = AppController()
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     var body: some Scene {
-        MenuBarExtra {
-            MenuContentView(controller: controller)
-                .frame(width: 340)
-        } label: {
-            // SF Symbol reflects whether we're live.
-            Image(systemName: controller.isPublishing ? "dot.radiowaves.left.and.right" : "waveform")
+        Settings {
+            ConfigView(controller: appDelegate.controller)
         }
-        .menuBarExtraStyle(.window)
+    }
+}
+
+/// Owns the status-bar item and the popover. No Dock icon (`.accessory`).
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    let controller = AppController()
+
+    private var statusItem: NSStatusItem?
+    private let popover = NSPopover()
+    private var statusObserver: AnyCancellable?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Menu-bar only — no Dock icon, no app menu. (At package time `LSUIElement` in the
+        // bundle's Info.plist does the same thing; this covers the SwiftPM dev run too.)
+        NSApp.setActivationPolicy(.accessory)
+
+        popover.behavior = .transient        // closes when you click outside, like a menu
+        popover.animates = true
+        popover.contentViewController = NSHostingController(
+            rootView: MenuContentView(controller: controller))
+
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        item.button?.action = #selector(togglePopover(_:))
+        item.button?.target = self
+        statusItem = item
+        updateStatusIcon()
+
+        // Keep the menu-bar glyph in sync with publishing state.
+        statusObserver = controller.$status.sink { [weak self] _ in
+            MainActor.assumeIsolated { self?.updateStatusIcon() }
+        }
+    }
+
+    private func updateStatusIcon() {
+        let symbol = controller.isPublishing ? "dot.radiowaves.left.and.right" : "waveform"
+        statusItem?.button?.image = NSImage(systemSymbolName: symbol,
+                                            accessibilityDescription: "Audio Feeder")
+    }
+
+    @objc private func togglePopover(_ sender: NSStatusBarButton) {
+        if popover.isShown {
+            popover.performClose(sender)
+        } else {
+            popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
+            // Let the popover take key focus so any controls inside behave normally.
+            popover.contentViewController?.view.window?.makeKey()
+        }
     }
 }
 

--- a/macos-audio-feeder/Sources/AudioFeederApp/ConfigStore.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/ConfigStore.swift
@@ -1,0 +1,31 @@
+import Foundation
+import AudioFeederCore
+
+/// Loads/saves `FeederConfig` as JSON under Application Support. Single source of truth for
+/// user settings; the UI edits a copy and calls `save`.
+final class ConfigStore {
+    private let url: URL
+
+    init(appName: String = "AudioFeeder") {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(appName, isDirectory: true)
+        try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        self.url = base.appendingPathComponent("config.json")
+    }
+
+    func load() -> FeederConfig {
+        guard let data = try? Data(contentsOf: url),
+              let cfg = try? JSONDecoder().decode(FeederConfig.self, from: data) else {
+            return FeederConfig()
+        }
+        return cfg
+    }
+
+    func save(_ config: FeederConfig) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        if let data = try? encoder.encode(config) {
+            try? data.write(to: url, options: .atomic)
+        }
+    }
+}

--- a/macos-audio-feeder/Sources/AudioFeederApp/ConfigView.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/ConfigView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+import AudioFeederCore
+
+/// Settings sheet: server, doc, device + channel, schedule, and login-item registration.
+struct ConfigView: View {
+    @ObservedObject var controller: AppController
+    @Environment(\.dismiss) private var dismiss
+    @State private var launchAtLogin = LoginItem.isEnabled
+
+    private let weekdaySymbols = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] // index 0 => weekday 1
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Audio Feeder Settings").font(.headline).padding()
+            Divider()
+            Form {
+                Section("Server") {
+                    TextField("Server URL", text: $controller.config.serverURL)
+                    TextField("Doc id (blank = today's doc-YYYY-MM-DD)",
+                              text: Binding(
+                                get: { controller.config.docIDOverride ?? "" },
+                                set: { controller.config.docIDOverride = $0.isEmpty ? nil : $0 }))
+                    Text("Will publish to room: \(controller.config.resolvedDocID())")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+
+                Section("Input") {
+                    Picker("Device", selection: Binding(
+                        get: { controller.config.deviceUID ?? "" },
+                        set: { controller.config.deviceUID = $0.isEmpty ? nil : $0 })) {
+                        Text("None").tag("")
+                        ForEach(controller.devices) { dev in
+                            Text("\(dev.name) (\(dev.inputChannelCount) ch)").tag(dev.uid)
+                        }
+                    }
+                    Button("Refresh devices") { controller.refreshDevices() }
+
+                    Stepper(value: $controller.config.channelIndex,
+                            in: 0...maxChannel) {
+                        Text("Channel: \(controller.config.channelIndex + 1)\(channelSuffix)")
+                    }
+                }
+
+                Section("Schedule") {
+                    Toggle("Enable schedule", isOn: $controller.config.schedule.enabled)
+                    weekdayPicker
+                    timeField("Start", minute: $controller.config.schedule.startMinute)
+                    timeField("Stop", minute: $controller.config.schedule.stopMinute)
+                    Text("Manual override always wins over the schedule.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+
+                Section("Service") {
+                    Toggle("Launch at login (run as a service)", isOn: $launchAtLogin)
+                        .onChange(of: launchAtLogin) { _, newValue in
+                            LoginItem.setEnabled(newValue)
+                        }
+                    Text("Audio capture needs a logged-in session; on an auto-login Mac this runs unattended.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            .formStyle(.grouped)
+
+            Divider()
+            HStack {
+                Spacer()
+                Button("Done") { dismiss() }.keyboardShortcut(.defaultAction)
+            }
+            .padding()
+        }
+        .frame(width: 420, height: 560)
+    }
+
+    private var maxChannel: Int {
+        max(0, (controller.selectedDevice?.inputChannelCount ?? 32) - 1)
+    }
+
+    private var channelSuffix: String {
+        if let dev = controller.selectedDevice { return " of \(dev.inputChannelCount)" }
+        return ""
+    }
+
+    private var weekdayPicker: some View {
+        HStack(spacing: 4) {
+            ForEach(0..<7, id: \.self) { idx in
+                let weekday = idx + 1
+                let on = controller.config.schedule.days.contains(weekday)
+                Button(weekdaySymbols[idx]) {
+                    if on { controller.config.schedule.days.remove(weekday) }
+                    else { controller.config.schedule.days.insert(weekday) }
+                }
+                .buttonStyle(.bordered)
+                .tint(on ? .accentColor : .gray)
+                .font(.caption)
+            }
+        }
+    }
+
+    private func timeField(_ label: String, minute: Binding<Int>) -> some View {
+        HStack {
+            Text(label)
+            Spacer()
+            TextField("HH:mm", text: Binding(
+                get: { Schedule.formatHHMM(minute.wrappedValue) },
+                set: { if let m = Schedule.parseHHMM($0) { minute.wrappedValue = m } }))
+                .frame(width: 70)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+}

--- a/macos-audio-feeder/Sources/AudioFeederApp/DeviceMonitor.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/DeviceMonitor.swift
@@ -1,0 +1,111 @@
+import Foundation
+import CoreAudio
+
+/// A selectable CoreAudio input device.
+struct AudioInputDevice: Identifiable, Hashable {
+    let id: AudioDeviceID
+    let uid: String
+    let name: String
+    let inputChannelCount: Int
+}
+
+/// Enumerates CoreAudio input devices and notifies on hot-plug changes. Devices are keyed
+/// by **UID** (stable across reconnects), not the transient AudioDeviceID/index.
+final class DeviceMonitor {
+    /// Called on the main queue whenever the set of hardware devices changes.
+    var onDevicesChanged: (() -> Void)?
+
+    private var listenerInstalled = false
+    private var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDevices,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain)
+
+    func startMonitoring() {
+        guard !listenerInstalled else { return }
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject), &address, DispatchQueue.main) { [weak self] _, _ in
+                self?.onDevicesChanged?()
+            }
+        listenerInstalled = (status == noErr)
+    }
+
+    func stopMonitoring() {
+        guard listenerInstalled else { return }
+        AudioObjectRemovePropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject), &address, DispatchQueue.main) { _, _ in }
+        listenerInstalled = false
+    }
+
+    /// All current input-capable devices.
+    static func inputDevices() -> [AudioInputDevice] {
+        deviceIDs().compactMap { id in
+            let channels = inputChannelCount(id)
+            guard channels > 0, let uid = stringProperty(id, kAudioDevicePropertyDeviceUID) else {
+                return nil
+            }
+            let name = stringProperty(id, kAudioObjectPropertyName) ?? uid
+            return AudioInputDevice(id: id, uid: uid, name: name, inputChannelCount: channels)
+        }
+    }
+
+    /// Resolve a configured UID to the current device, or nil if it isn't connected.
+    static func device(forUID uid: String) -> AudioInputDevice? {
+        inputDevices().first { $0.uid == uid }
+    }
+
+    // MARK: - CoreAudio plumbing
+
+    private static func deviceIDs() -> [AudioDeviceID] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var dataSize: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize) == noErr else {
+            return []
+        }
+        let count = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
+        var ids = [AudioDeviceID](repeating: 0, count: count)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize, &ids) == noErr else {
+            return []
+        }
+        return ids
+    }
+
+    private static func inputChannelCount(_ device: AudioDeviceID) -> Int {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioObjectPropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain)
+        var dataSize: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(device, &address, 0, nil, &dataSize) == noErr,
+              dataSize > 0 else { return 0 }
+
+        let bufferList = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(dataSize), alignment: MemoryLayout<AudioBufferList>.alignment)
+        defer { bufferList.deallocate() }
+        guard AudioObjectGetPropertyData(device, &address, 0, nil, &dataSize, bufferList) == noErr else {
+            return 0
+        }
+        let abl = UnsafeMutableAudioBufferListPointer(
+            bufferList.assumingMemoryBound(to: AudioBufferList.self))
+        return abl.reduce(0) { $0 + Int($1.mNumberChannels) }
+    }
+
+    private static func stringProperty(_ device: AudioDeviceID, _ selector: AudioObjectPropertySelector) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var dataSize = UInt32(MemoryLayout<CFString?>.size)
+        var cfString: CFString? = nil
+        let status = withUnsafeMutablePointer(to: &cfString) { ptr -> OSStatus in
+            AudioObjectGetPropertyData(device, &address, 0, nil, &dataSize, ptr)
+        }
+        guard status == noErr, let result = cfString else { return nil }
+        return result as String
+    }
+}

--- a/macos-audio-feeder/Sources/AudioFeederApp/LevelMeterView.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/LevelMeterView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Horizontal level meter, mirroring the browser broadcast page's mic meter
+/// (green fill, smooth animation). `level` is 0...1.
+struct LevelMeterView: View {
+    var level: Float
+    var active: Bool
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color.gray.opacity(0.25))
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(active ? Color.green : Color.gray)
+                    .frame(width: max(0, min(1, CGFloat(level))) * geo.size.width)
+                    .animation(.easeOut(duration: 0.075), value: level)
+            }
+        }
+        .frame(height: 8)
+    }
+}

--- a/macos-audio-feeder/Sources/AudioFeederApp/LoginItem.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/LoginItem.swift
@@ -1,0 +1,27 @@
+import Foundation
+import ServiceManagement
+
+/// Registers the app as a background **login item** so it runs as a de-facto service on a
+/// (auto-)logged-in Mac. Mic capture requires a user session, so this is the correct
+/// "service" form on macOS — see the design notes.
+enum LoginItem {
+    static var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    static func setEnabled(_ enabled: Bool) {
+        do {
+            if enabled {
+                if SMAppService.mainApp.status != .enabled {
+                    try SMAppService.mainApp.register()
+                }
+            } else {
+                if SMAppService.mainApp.status == .enabled {
+                    try SMAppService.mainApp.unregister()
+                }
+            }
+        } catch {
+            NSLog("LoginItem toggle failed: \(error)")
+        }
+    }
+}

--- a/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
@@ -4,7 +4,7 @@ import AudioFeederCore
 /// The menu-bar popover: status, level meter, manual controls, and a way into settings.
 struct MenuContentView: View {
     @ObservedObject var controller: AppController
-    @State private var showingConfig = false
+    @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -52,15 +52,17 @@ struct MenuContentView: View {
             Divider()
 
             HStack {
-                Button("Settings…") { showingConfig = true }
+                // Open the standard Settings scene (a real window) and pull it to the front —
+                // an .accessory app won't raise its own windows automatically.
+                Button("Settings…") {
+                    openSettings()
+                    NSApp.activate(ignoringOtherApps: true)
+                }
                 Spacer()
                 Button("Quit") { NSApplication.shared.terminate(nil) }
             }
         }
         .padding(14)
-        .sheet(isPresented: $showingConfig) {
-            ConfigView(controller: controller)
-        }
     }
 
     private var deviceSummary: some View {

--- a/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+import AudioFeederCore
+
+/// The menu-bar popover: status, level meter, manual controls, and a way into settings.
+struct MenuContentView: View {
+    @ObservedObject var controller: AppController
+    @State private var showingConfig = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Audio Feeder").font(.headline)
+                Spacer()
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 10, height: 10)
+            }
+
+            Text(controller.status.label)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Input level").font(.caption).foregroundStyle(.secondary)
+                LevelMeterView(level: controller.level, active: controller.isPublishing)
+            }
+
+            deviceSummary
+
+            Divider()
+
+            // Manual override controls (your "manual + scheduled" choice).
+            HStack {
+                Button("Start now") { controller.startNow() }
+                    .disabled(controller.config.manualOverride == .forceOn)
+                Button("Stop now") { controller.stopNow() }
+                    .disabled(controller.config.manualOverride == .forceOff)
+                if controller.config.manualOverride != .off {
+                    Button("Follow schedule") { controller.followSchedule() }
+                }
+            }
+            .font(.callout)
+
+            if controller.isPublishing {
+                Label("Live as organizer-host — this takes over the broadcast.",
+                      systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            Divider()
+
+            HStack {
+                Button("Settings…") { showingConfig = true }
+                Spacer()
+                Button("Quit") { NSApplication.shared.terminate(nil) }
+            }
+        }
+        .padding(14)
+        .sheet(isPresented: $showingConfig) {
+            ConfigView(controller: controller)
+        }
+    }
+
+    private var deviceSummary: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "rectangle.connected.to.line.below")
+            if let dev = controller.selectedDevice {
+                Text("\(dev.name) · ch \(controller.config.channelIndex + 1)/\(dev.inputChannelCount)")
+                    .lineLimit(1)
+            } else if let uid = controller.config.deviceUID {
+                Text("\(uid) (not connected)").foregroundStyle(.orange).lineLimit(1)
+            } else {
+                Text("No device selected").foregroundStyle(.secondary)
+            }
+        }
+        .font(.caption)
+    }
+
+    private var statusColor: Color {
+        switch controller.status {
+        case .publishing: return .green
+        case .connecting: return .yellow
+        case .waitingForDevice: return .orange
+        case .error: return .red
+        case .idle: return .gray
+        }
+    }
+}

--- a/macos-audio-feeder/Sources/AudioFeederApp/Publisher.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/Publisher.swift
@@ -1,0 +1,79 @@
+import Foundation
+import AVFoundation
+import LiveKit
+import AudioFeederCore
+
+/// Publishes captured mono audio into the session's LiveKit room as `organizer-host`,
+/// reusing the live-notes token endpoint. Mirrors the browser broadcast contract, so the
+/// server needs no changes and the browser page remains a valid alternative input.
+///
+/// Uses the SDK's custom-audio path (validated by AudioFeederSpike): manual rendering mode
+/// so the physical mic is never opened, and `mixer.capture(appAudio:)` to feed our buffers.
+@MainActor
+final class Publisher {
+    enum State: Equatable {
+        case disconnected
+        case connecting
+        case connected
+        case failed(String)
+    }
+
+    private(set) var state: State = .disconnected {
+        didSet { if state != oldValue { onStateChange?(state) } }
+    }
+    var onStateChange: ((State) -> Void)?
+
+    private let serverURL: String
+    private var room: Room?
+    private var connectTask: Task<Void, Never>?
+
+    init(serverURL: String) {
+        self.serverURL = serverURL
+    }
+
+    /// Connect to `room` (the doc id) and publish. Idempotent while connected/connecting.
+    func start(room docID: String) {
+        guard case .disconnected = state else { return }
+        state = .connecting
+        connectTask = Task { await self.connect(docID: docID) }
+    }
+
+    /// Feed one captured mono buffer to the publish mixer. No-op until connected.
+    func capture(_ buffer: AVAudioPCMBuffer) {
+        guard case .connected = state else { return }
+        AudioManager.shared.mixer.capture(appAudio: buffer)
+    }
+
+    /// Stop publishing and disconnect so the `organizer-host` identity is released for the
+    /// browser broadcast path.
+    func stop() {
+        connectTask?.cancel()
+        connectTask = nil
+        let room = self.room
+        self.room = nil
+        state = .disconnected
+        Task {
+            try? AudioManager.shared.setManualRenderingMode(false)
+            try? await room?.disconnect()
+        }
+    }
+
+    private func connect(docID: String) async {
+        do {
+            let token = try await LiveKitTokenClient(serverURL: serverURL).fetchToken(room: docID)
+            if Task.isCancelled { return }
+
+            let room = Room()
+            try await room.connect(url: token.serverUrl, token: token.token)
+            if Task.isCancelled { try? await room.disconnect(); return }
+
+            try AudioManager.shared.setManualRenderingMode(true)
+            try await room.localParticipant.setMicrophone(enabled: true)
+
+            self.room = room
+            state = .connected
+        } catch {
+            state = .failed("\(error)")
+        }
+    }
+}

--- a/macos-audio-feeder/Sources/AudioFeederCore/ChannelExtractor.swift
+++ b/macos-audio-feeder/Sources/AudioFeederCore/ChannelExtractor.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Extracts a single channel from multichannel audio.
+public enum ChannelExtractor {
+
+    /// Pick channel `index` from per-channel sample arrays. Returns an empty array if the
+    /// index is out of range (caller treats that as "channel not present").
+    public static func pickChannel(_ channels: [[Float]], _ index: Int) -> [Float] {
+        guard index >= 0, index < channels.count else { return [] }
+        return channels[index]
+    }
+}
+
+#if canImport(AVFoundation)
+import AVFoundation
+
+extension ChannelExtractor {
+    /// Copy `channel` of a non-interleaved float `source` buffer into a new mono buffer at
+    /// the same sample rate. Returns nil if the source isn't float/non-interleaved or the
+    /// channel is out of range — the caller falls back to "waiting for valid audio".
+    public static func extractMono(from source: AVAudioPCMBuffer, channel: Int) -> AVAudioPCMBuffer? {
+        guard let srcData = source.floatChannelData else { return nil }
+        let channelCount = Int(source.format.channelCount)
+        guard channel >= 0, channel < channelCount else { return nil }
+
+        let frames = source.frameLength
+        guard frames > 0,
+              let monoFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                             sampleRate: source.format.sampleRate,
+                                             channels: 1,
+                                             interleaved: false),
+              let out = AVAudioPCMBuffer(pcmFormat: monoFormat, frameCapacity: frames),
+              let dstData = out.floatChannelData else { return nil }
+
+        out.frameLength = frames
+        memcpy(dstData[0], srcData[channel], Int(frames) * MemoryLayout<Float>.size)
+        return out
+    }
+}
+#endif

--- a/macos-audio-feeder/Sources/AudioFeederCore/Config.swift
+++ b/macos-audio-feeder/Sources/AudioFeederCore/Config.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Whether the user has forced the feeder on/off regardless of the schedule.
+public enum ManualOverride: String, Codable, Sendable, CaseIterable {
+    /// Follow the schedule.
+    case off
+    /// Run now, ignore the schedule.
+    case forceOn
+    /// Stay off now, ignore the schedule.
+    case forceOff
+}
+
+/// A daily run window plus the weekdays it applies to.
+///
+/// Minutes are minutes-since-local-midnight in `[0, 1440)`. If `stopMinute` is greater
+/// than `startMinute` the window is same-day `[start, stop)`; if it is less, the window
+/// wraps past midnight (anchored to the start day); if equal, the window is empty.
+public struct Schedule: Codable, Equatable, Sendable {
+    public var enabled: Bool
+    /// Calendar weekdays the window starts on: 1 = Sunday ... 7 = Saturday (matches `Calendar`).
+    public var days: Set<Int>
+    public var startMinute: Int
+    public var stopMinute: Int
+
+    public init(enabled: Bool = false,
+                days: Set<Int> = [1, 2, 3, 4, 5, 6, 7],
+                startMinute: Int = 10 * 60,
+                stopMinute: Int = 12 * 60) {
+        self.enabled = enabled
+        self.days = days
+        self.startMinute = startMinute
+        self.stopMinute = stopMinute
+    }
+
+    /// `"HH:mm"` for a minutes-since-midnight value, clamped to a valid range.
+    public static func formatHHMM(_ minute: Int) -> String {
+        let m = max(0, min(24 * 60 - 1, minute))
+        return String(format: "%02d:%02d", m / 60, m % 60)
+    }
+
+    /// Parse `"HH:mm"` into minutes since midnight, or nil if malformed/out of range.
+    public static func parseHHMM(_ text: String) -> Int? {
+        let parts = text.split(separator: ":")
+        guard parts.count == 2, let h = Int(parts[0]), let m = Int(parts[1]),
+              (0..<24).contains(h), (0..<60).contains(m) else { return nil }
+        return h * 60 + m
+    }
+}
+
+/// User-editable settings for the feeder. Persisted as JSON.
+public struct FeederConfig: Codable, Equatable, Sendable {
+    /// Base URL of the live-notes server that issues LiveKit tokens, e.g. `https://notelate.com`.
+    public var serverURL: String
+    /// Optional explicit Y-Sweet/LiveKit doc id. When nil, defaults to `doc-YYYY-MM-DD` (local).
+    public var docIDOverride: String?
+    /// CoreAudio device UID of the sound board (stable across hotplug, unlike device index).
+    public var deviceUID: String?
+    /// 0-based channel index to pull from the multichannel device.
+    public var channelIndex: Int
+    public var schedule: Schedule
+    public var manualOverride: ManualOverride
+
+    public init(serverURL: String = "https://notelate.com",
+                docIDOverride: String? = nil,
+                deviceUID: String? = nil,
+                channelIndex: Int = 0,
+                schedule: Schedule = Schedule(),
+                manualOverride: ManualOverride = .off) {
+        self.serverURL = serverURL
+        self.docIDOverride = docIDOverride
+        self.deviceUID = deviceUID
+        self.channelIndex = channelIndex
+        self.schedule = schedule
+        self.manualOverride = manualOverride
+    }
+
+    /// The effective doc id / LiveKit room name for `now`, honoring an override.
+    public func resolvedDocID(now: Date = Date(), calendar: Calendar = .current) -> String {
+        if let override = docIDOverride, !override.trimmingCharacters(in: .whitespaces).isEmpty {
+            return override
+        }
+        let c = calendar.dateComponents([.year, .month, .day], from: now)
+        return String(format: "doc-%04d-%02d-%02d", c.year ?? 0, c.month ?? 0, c.day ?? 0)
+    }
+}

--- a/macos-audio-feeder/Sources/AudioFeederCore/LevelMeter.swift
+++ b/macos-audio-feeder/Sources/AudioFeederCore/LevelMeter.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Audio level computation for the UI meter. The array-based math is pure and builds
+/// everywhere; the `AVAudioPCMBuffer` convenience is macOS-only.
+public enum LevelMeter {
+
+    /// Root-mean-square amplitude of mono float samples in `[0, 1]` (for normalized PCM).
+    public static func rms(_ samples: [Float]) -> Float {
+        guard !samples.isEmpty else { return 0 }
+        var sum: Double = 0
+        for s in samples { sum += Double(s) * Double(s) }
+        return Float((sum / Double(samples.count)).squareRoot())
+    }
+
+    /// Map an RMS amplitude to a `[0, 1]` meter fill. Speech RMS sits well below 1.0, so we
+    /// apply gain and clamp — mirroring the browser meter, which scales volume by ~140x
+    /// (see `MicLevelMeter` in BroadcastControl.tsx).
+    public static func displayLevel(rms: Float, gain: Float = 5.0) -> Float {
+        max(0, min(1, rms * gain))
+    }
+
+    /// Convenience: dBFS for an RMS amplitude (−∞ floored to −120 dB).
+    public static func dBFS(rms: Float) -> Float {
+        rms <= 0 ? -120 : max(-120, 20 * log10(rms))
+    }
+}
+
+#if canImport(AVFoundation)
+import AVFoundation
+
+extension LevelMeter {
+    /// RMS over channel 0 of a non-interleaved float buffer (the format our mono capture uses).
+    public static func rms(buffer: AVAudioPCMBuffer) -> Float {
+        guard let channelData = buffer.floatChannelData, buffer.frameLength > 0 else { return 0 }
+        let n = Int(buffer.frameLength)
+        let ptr = channelData[0]
+        var sum: Double = 0
+        for i in 0..<n {
+            let s = Double(ptr[i])
+            sum += s * s
+        }
+        return Float((sum / Double(n)).squareRoot())
+    }
+}
+#endif

--- a/macos-audio-feeder/Sources/AudioFeederCore/LiveKitTokenClient.swift
+++ b/macos-audio-feeder/Sources/AudioFeederCore/LiveKitTokenClient.swift
@@ -1,0 +1,73 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// What `POST /api/livekit/token` returns: a LiveKit JWT plus the LiveKit ws server URL.
+public struct LiveKitToken: Decodable, Sendable, Equatable {
+    public let token: String
+    public let serverUrl: String
+}
+
+public enum LiveKitTokenError: Error, CustomStringConvertible {
+    case badStatus(Int, String)
+    case malformedResponse
+    case missingFields
+
+    public var description: String {
+        switch self {
+        case let .badStatus(code, body): return "token endpoint returned HTTP \(code): \(body)"
+        case .malformedResponse: return "token endpoint returned a non-JSON response"
+        case .missingFields: return "token response missing token/serverUrl (is LIVEKIT_* configured?)"
+        }
+    }
+}
+
+/// Thin client for the live-notes server's LiveKit token endpoint. Mirrors the request the
+/// browser broadcast page makes (see BroadcastControl.tsx): the speaker joins as
+/// `organizer-host` with role `organizer` into room == docId.
+public struct LiveKitTokenClient: Sendable {
+    public static let organizerIdentity = "organizer-host"
+
+    public var serverURL: String
+    private let session: URLSession
+
+    public init(serverURL: String, session: URLSession = .shared) {
+        self.serverURL = serverURL
+        self.session = session
+    }
+
+    /// Build the request body the server expects.
+    public static func requestBody(room: String,
+                                   identity: String = organizerIdentity,
+                                   role: String = "organizer") -> [String: String] {
+        ["room": room, "identity": identity, "role": role]
+    }
+
+    public func fetchToken(room: String,
+                           identity: String = organizerIdentity,
+                           role: String = "organizer") async throws -> LiveKitToken {
+        let base = serverURL.hasSuffix("/") ? String(serverURL.dropLast()) : serverURL
+        guard let url = URL(string: "\(base)/api/livekit/token") else {
+            throw LiveKitTokenError.malformedResponse
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(
+            withJSONObject: Self.requestBody(room: room, identity: identity, role: role))
+
+        let (data, response) = try await session.data(for: req)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw LiveKitTokenError.badStatus(http.statusCode, body)
+        }
+        guard let decoded = try? JSONDecoder().decode(LiveKitToken.self, from: data) else {
+            throw LiveKitTokenError.malformedResponse
+        }
+        guard !decoded.token.isEmpty, !decoded.serverUrl.isEmpty else {
+            throw LiveKitTokenError.missingFields
+        }
+        return decoded
+    }
+}

--- a/macos-audio-feeder/Sources/AudioFeederCore/Scheduler.swift
+++ b/macos-audio-feeder/Sources/AudioFeederCore/Scheduler.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Pure decision logic for whether the feeder should be running right now.
+///
+/// Kept free of any audio/LiveKit dependencies so it is trivially unit-testable with an
+/// injected clock and calendar.
+public enum Scheduler {
+
+    /// Whether the feeder should be capturing+publishing at `now`.
+    ///
+    /// Manual override wins; otherwise we fall back to the schedule (disabled => off).
+    public static func shouldRun(now: Date,
+                                 schedule: Schedule,
+                                 manualOverride: ManualOverride,
+                                 calendar: Calendar = .current) -> Bool {
+        switch manualOverride {
+        case .forceOn:
+            return true
+        case .forceOff:
+            return false
+        case .off:
+            guard schedule.enabled else { return false }
+            let comps = calendar.dateComponents([.weekday, .hour, .minute], from: now)
+            guard let weekday = comps.weekday, let hour = comps.hour, let minute = comps.minute else {
+                return false
+            }
+            return isWithinWindow(weekday: weekday, minuteOfDay: hour * 60 + minute, schedule: schedule)
+        }
+    }
+
+    /// Whether `(weekday, minuteOfDay)` falls inside the schedule's window. Handles
+    /// same-day and past-midnight (wrapping) windows; an empty window (start == stop)
+    /// is never active.
+    public static func isWithinWindow(weekday: Int, minuteOfDay: Int, schedule: Schedule) -> Bool {
+        let start = schedule.startMinute
+        let stop = schedule.stopMinute
+        if start == stop { return false }
+
+        if start < stop {
+            // Same-day window [start, stop).
+            return schedule.days.contains(weekday) && minuteOfDay >= start && minuteOfDay < stop
+        } else {
+            // Window wraps past midnight; the run is anchored to its start day.
+            if schedule.days.contains(weekday) && minuteOfDay >= start {
+                return true
+            }
+            // Early-morning tail belongs to the previous day's window.
+            if schedule.days.contains(previousWeekday(weekday)) && minuteOfDay < stop {
+                return true
+            }
+            return false
+        }
+    }
+
+    /// Previous calendar weekday (1 = Sunday ... 7 = Saturday), wrapping Sunday -> Saturday.
+    public static func previousWeekday(_ weekday: Int) -> Int {
+        weekday == 1 ? 7 : weekday - 1
+    }
+}

--- a/macos-audio-feeder/Sources/AudioFeederCore/ToneGenerator.swift
+++ b/macos-audio-feeder/Sources/AudioFeederCore/ToneGenerator.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Generates a sine tone as raw float samples. Pure and portable so it can drive both the
+/// spike (a known signal to publish) and unit tests.
+public struct ToneGenerator {
+    public var frequency: Double
+    public var amplitude: Float
+    public var sampleRate: Double
+    private var phase: Double = 0
+
+    public init(frequency: Double = 440, amplitude: Float = 0.25, sampleRate: Double = 48_000) {
+        self.frequency = frequency
+        self.amplitude = amplitude
+        self.sampleRate = sampleRate
+    }
+
+    /// Produce the next `count` samples, advancing the phase so successive calls are
+    /// continuous (no clicks at buffer boundaries).
+    public mutating func next(_ count: Int) -> [Float] {
+        guard count > 0 else { return [] }
+        var out = [Float](repeating: 0, count: count)
+        let increment = 2.0 * Double.pi * frequency / sampleRate
+        for i in 0..<count {
+            out[i] = amplitude * Float(sin(phase))
+            phase += increment
+            if phase > 2.0 * Double.pi { phase -= 2.0 * Double.pi }
+        }
+        return out
+    }
+}

--- a/macos-audio-feeder/Sources/AudioFeederSpike/main.swift
+++ b/macos-audio-feeder/Sources/AudioFeederSpike/main.swift
@@ -87,8 +87,45 @@ func makeBuffer(_ samples: [Float], sampleRate: Double) -> AVAudioPCMBuffer? {
     return buffer
 }
 
+/// Taps the frames actually handed to WebRTC on the local (published) audio track and prints a
+/// once-per-second heartbeat with the RMS level. Non-silent RMS here means audio really is being
+/// published — so any "no sound" problem is downstream (subscription/listener). Silence/no frames
+/// means the app-audio → engine path never delivered anything.
+final class TapRenderer: NSObject, AudioRenderer, @unchecked Sendable {
+    private let lock = NSLock()
+    private var frames = 0
+    private var sumSquares = 0.0
+    private var lastPrint = Date()
+
+    func render(pcmBuffer: AVAudioPCMBuffer) {
+        let n = Int(pcmBuffer.frameLength)
+        var energy = 0.0
+        if let ch = pcmBuffer.floatChannelData {
+            for i in 0..<n { let v = Double(ch[0][i]); energy += v * v }
+        } else if let ch = pcmBuffer.int16ChannelData {
+            for i in 0..<n { let v = Double(ch[0][i]) / 32768.0; energy += v * v }
+        }
+        lock.lock()
+        frames += n
+        sumSquares += energy
+        let now = Date()
+        if now.timeIntervalSince(lastPrint) >= 1.0 {
+            let rms = frames > 0 ? (sumSquares / Double(frames)).squareRoot() : 0
+            print(String(format: "[tap] local track: %d frames/s, rms=%.4f", frames, rms))
+            frames = 0; sumSquares = 0; lastPrint = now
+        }
+        lock.unlock()
+    }
+}
+
 let args = Args.parse()
 let sampleRate = 48_000.0
+
+// Route the SDK's logs to stdout. The default OSLogger sends everything to macOS unified
+// logging (subsystem io.livekit.sdk) where it's invisible in a terminal — so warnings like
+// "Engine is not running" from the app-audio path never show. PrintLogger prints them here.
+// Must be set before any other SDK logging happens.
+LiveKitSDK.setLogger(PrintLogger(minLevel: .debug))
 
 print("[spike] server = \(args.serverURL)")
 print("[spike] room   = \(args.docID)")
@@ -136,18 +173,47 @@ do {
     exit(1)
 }
 
-// 4) Feed a continuous sine tone, ~100 ms per push, on a background task.
+// Tap the published local track so we can see whether real frames reach WebRTC. The track may
+// take a moment to appear after setMicrophone; poll briefly, then attach the renderer.
+let tap = TapRenderer()
+var attached = false
+for _ in 0..<20 {
+    if let pub = room.localParticipant.localAudioTracks.first,
+       let track = pub.track as? LocalAudioTrack {
+        track.add(audioRenderer: tap)
+        attached = true
+        print("[spike] tap attached to local audio track \(pub.sid)")
+        break
+    }
+    try? await Task.sleep(nanoseconds: 100_000_000)
+}
+if !attached { print("[spike] WARNING: never found a local audio track to tap") }
+
+// 4) Feed a continuous sine tone on a background task.
+// IMPORTANT: keep each buffer at or below the engine's maximumFramesToRender (logged as 3072 =
+// 64ms @ 48k). The SDK's MixerEngineObserver warns that exceeding it triggers
+// kAudioUnitErr_TooManyFramesToProcess (-10874), which renders as silence — our first attempt
+// pushed 4800-frame (100ms) buffers and the published track was dead silent (rms=0). Use 50ms
+// buffers, pushed a touch faster than realtime so the player node never underruns.
 var generator = ToneGenerator(frequency: args.frequency, amplitude: 0.25, sampleRate: sampleRate)
-let framesPerPush = Int(sampleRate * 0.1)
+let framesPerPush = Int(sampleRate * 0.05) // 2400 frames = 50ms, under the 3072 render cap
 
 let feeder = Task {
+    var pushes = 0
+    var lastBeat = Date()
     while !Task.isCancelled {
         let samples = generator.next(framesPerPush)
         if let buffer = makeBuffer(samples, sampleRate: sampleRate) {
             // <<< API UNDER TEST >>> feed app audio to the publish mixer.
             AudioManager.shared.mixer.capture(appAudio: buffer)
+            pushes += 1
         }
-        try? await Task.sleep(nanoseconds: 100_000_000) // 100 ms
+        let now = Date()
+        if now.timeIntervalSince(lastBeat) >= 1.0 {
+            print("[feed] pushed \(pushes) buffers/s; manualRendering=\(AudioManager.shared.isManualRenderingMode)")
+            pushes = 0; lastBeat = now
+        }
+        try? await Task.sleep(nanoseconds: 40_000_000) // 40 ms sleep vs 50 ms of audio → slight lead
     }
 }
 

--- a/macos-audio-feeder/Sources/AudioFeederSpike/main.swift
+++ b/macos-audio-feeder/Sources/AudioFeederSpike/main.swift
@@ -1,0 +1,168 @@
+import Foundation
+import AVFoundation
+import LiveKit
+import AudioFeederCore
+
+// =============================================================================
+// AudioFeederSpike — de-risk the linchpin of the whole project.
+//
+// Question this answers: on macOS, does the LiveKit Swift SDK's custom-audio path
+// (AudioManager manual rendering + mixer.capture(appAudio:)) actually publish audio that
+// a listener/translator bot receives? If yes, the full app can synthesize its audio
+// (one extracted board channel) the same way. If no, we fall back to an Aggregate Device
+// + the SDK's normal device capture.
+//
+// What it does: fetches an organizer token from the live-notes server, joins the session's
+// LiveKit room as `organizer-host`, and publishes a steady sine tone via the custom-audio
+// API. Join the same session in a browser as a listener and confirm you hear the tone.
+//
+// Usage:
+//   swift run AudioFeederSpike --server-url https://dev8.kenarnold.org --doc doc-2025-06-30
+//   # --doc is optional; defaults to today's doc-YYYY-MM-DD. Add --freq 440 to change pitch.
+//
+// NOTE: The exact AudioManager custom-audio API names (setManualRenderingMode / mixer /
+// capture(appAudio:)) are taken from the SDK's Docs/audio.md. If they don't resolve against
+// the installed SDK version, this spike is exactly where to reconcile them — see the marked
+// section below.
+// =============================================================================
+
+struct Args {
+    var serverURL: String
+    var docID: String
+    var frequency: Double
+
+    static func parse() -> Args {
+        var serverURL: String?
+        var docID: String?
+        var frequency = 440.0
+        var it = CommandLine.arguments.dropFirst().makeIterator()
+        while let arg = it.next() {
+            switch arg {
+            case "--server-url", "-s": serverURL = it.next()
+            case "--doc", "-d": docID = it.next()
+            case "--freq", "-f": if let v = it.next(), let d = Double(v) { frequency = d }
+            case "--help", "-h":
+                printUsageAndExit(code: 0)
+            default:
+                FileHandle.standardError.write(Data("Unknown argument: \(arg)\n".utf8))
+                printUsageAndExit(code: 2)
+            }
+        }
+        guard let server = serverURL else {
+            FileHandle.standardError.write(Data("Missing --server-url\n".utf8))
+            printUsageAndExit(code: 2)
+        }
+        let resolvedDoc = docID ?? FeederConfig().resolvedDocID()
+        return Args(serverURL: server, docID: resolvedDoc, frequency: frequency)
+    }
+
+    static func printUsageAndExit(code: Int32) -> Never {
+        let usage = """
+        Usage: AudioFeederSpike --server-url <url> [--doc <doc-id>] [--freq <hz>]
+
+          --server-url, -s   live-notes server base URL (issues the LiveKit token)
+          --doc, -d          session doc id / LiveKit room (default: today's doc-YYYY-MM-DD)
+          --freq, -f         tone frequency in Hz (default: 440)
+
+        """
+        FileHandle.standardError.write(Data(usage.utf8))
+        exit(code)
+    }
+}
+
+/// Build a mono float32 PCM buffer from raw samples at `sampleRate`.
+func makeBuffer(_ samples: [Float], sampleRate: Double) -> AVAudioPCMBuffer? {
+    guard let format = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                     sampleRate: sampleRate,
+                                     channels: 1,
+                                     interleaved: false),
+          let buffer = AVAudioPCMBuffer(pcmFormat: format,
+                                        frameCapacity: AVAudioFrameCount(samples.count)) else {
+        return nil
+    }
+    buffer.frameLength = AVAudioFrameCount(samples.count)
+    samples.withUnsafeBufferPointer { src in
+        buffer.floatChannelData![0].update(from: src.baseAddress!, count: samples.count)
+    }
+    return buffer
+}
+
+let args = Args.parse()
+let sampleRate = 48_000.0
+
+print("[spike] server = \(args.serverURL)")
+print("[spike] room   = \(args.docID)")
+print("[spike] tone   = \(args.frequency) Hz")
+
+// 1) Fetch an organizer token (same contract as the browser broadcast page).
+let tokenClient = LiveKitTokenClient(serverURL: args.serverURL)
+let token: LiveKitToken
+do {
+    token = try await tokenClient.fetchToken(room: args.docID)
+    print("[spike] got token; livekit serverUrl = \(token.serverUrl)")
+} catch {
+    FileHandle.standardError.write(Data("[spike] token fetch failed: \(error)\n".utf8))
+    exit(1)
+}
+
+// 2) Connect to the room.
+let room = Room()
+do {
+    try await room.connect(url: token.serverUrl, token: token.token)
+    print("[spike] connected to room \(args.docID) as \(LiveKitTokenClient.organizerIdentity)")
+} catch {
+    FileHandle.standardError.write(Data("[spike] room connect failed: \(error)\n".utf8))
+    exit(1)
+}
+
+// 3) ----- CUSTOM-AUDIO PATH (the thing under test) -----------------------------------
+//    Put the engine in manual rendering mode so the physical mic is never opened, then
+//    publish a local audio track that the mixer feeds from our buffers.
+do {
+    try AudioManager.shared.setManualRenderingMode(true)
+    print("[spike] manual rendering mode ON")
+} catch {
+    FileHandle.standardError.write(Data("[spike] setManualRenderingMode failed: \(error)\n".utf8))
+    // Keep going — on some versions publishing still works; the point is to learn.
+}
+
+// Publish the local audio track. In manual rendering mode this creates the published
+// track without accessing the microphone; the mixer supplies its audio.
+do {
+    try await room.localParticipant.setMicrophone(enabled: true)
+    print("[spike] local audio track published")
+} catch {
+    FileHandle.standardError.write(Data("[spike] publish track failed: \(error)\n".utf8))
+    exit(1)
+}
+
+// 4) Feed a continuous sine tone, ~100 ms per push, on a background task.
+var generator = ToneGenerator(frequency: args.frequency, amplitude: 0.25, sampleRate: sampleRate)
+let framesPerPush = Int(sampleRate * 0.1)
+
+let feeder = Task {
+    while !Task.isCancelled {
+        let samples = generator.next(framesPerPush)
+        if let buffer = makeBuffer(samples, sampleRate: sampleRate) {
+            // <<< API UNDER TEST >>> feed app audio to the publish mixer.
+            AudioManager.shared.mixer.capture(appAudio: buffer)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000) // 100 ms
+    }
+}
+
+print("[spike] publishing tone. Join \(args.docID) in a browser as a listener to verify.")
+print("[spike] press Ctrl-C to stop.")
+
+// Keep the process alive until interrupted.
+let interrupted = DispatchSemaphore(value: 0)
+let sigintSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .global())
+signal(SIGINT, SIG_IGN)
+sigintSource.setEventHandler { interrupted.signal() }
+sigintSource.resume()
+interrupted.wait()
+
+print("\n[spike] shutting down…")
+feeder.cancel()
+try? await room.disconnect()
+print("[spike] done.")

--- a/macos-audio-feeder/Tests/AudioFeederCoreTests/ChannelExtractorTests.swift
+++ b/macos-audio-feeder/Tests/AudioFeederCoreTests/ChannelExtractorTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import AudioFeederCore
+
+final class ChannelExtractorTests: XCTestCase {
+
+    func testPicksRequestedChannel() {
+        let channels: [[Float]] = [[0, 0, 0], [1, 2, 3], [9, 9, 9]]
+        XCTAssertEqual(ChannelExtractor.pickChannel(channels, 1), [1, 2, 3])
+    }
+
+    func testOutOfRangeReturnsEmpty() {
+        let channels: [[Float]] = [[1, 2, 3]]
+        XCTAssertEqual(ChannelExtractor.pickChannel(channels, 5), [])
+        XCTAssertEqual(ChannelExtractor.pickChannel(channels, -1), [])
+    }
+
+    func testEmptyInputReturnsEmpty() {
+        XCTAssertEqual(ChannelExtractor.pickChannel([], 0), [])
+    }
+}

--- a/macos-audio-feeder/Tests/AudioFeederCoreTests/ConfigTests.swift
+++ b/macos-audio-feeder/Tests/AudioFeederCoreTests/ConfigTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import AudioFeederCore
+
+final class ConfigTests: XCTestCase {
+
+    private var utc: Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }
+
+    func testResolvedDocIDDefaultsToDatedDoc() {
+        var c = DateComponents(); c.year = 2025; c.month = 3; c.day = 5
+        let now = utc.date(from: c)!
+        let cfg = FeederConfig(docIDOverride: nil)
+        XCTAssertEqual(cfg.resolvedDocID(now: now, calendar: utc), "doc-2025-03-05")
+    }
+
+    func testResolvedDocIDHonorsOverride() {
+        let cfg = FeederConfig(docIDOverride: "doc-special")
+        XCTAssertEqual(cfg.resolvedDocID(), "doc-special")
+    }
+
+    func testBlankOverrideFallsBackToDated() {
+        var c = DateComponents(); c.year = 2025; c.month = 12; c.day = 31
+        let now = utc.date(from: c)!
+        let cfg = FeederConfig(docIDOverride: "   ")
+        XCTAssertEqual(cfg.resolvedDocID(now: now, calendar: utc), "doc-2025-12-31")
+    }
+
+    func testHHMMRoundTrip() {
+        XCTAssertEqual(Schedule.formatHHMM(10 * 60 + 5), "10:05")
+        XCTAssertEqual(Schedule.parseHHMM("10:05"), 10 * 60 + 5)
+        XCTAssertNil(Schedule.parseHHMM("24:00"))
+        XCTAssertNil(Schedule.parseHHMM("bad"))
+        XCTAssertNil(Schedule.parseHHMM("10:60"))
+    }
+
+    func testConfigCodableRoundTrip() throws {
+        let cfg = FeederConfig(serverURL: "https://example.org",
+                               docIDOverride: "doc-x",
+                               deviceUID: "AppleUSBAudioEngine:...:1",
+                               channelIndex: 7,
+                               schedule: Schedule(enabled: true, days: [1, 4], startMinute: 600, stopMinute: 720),
+                               manualOverride: .forceOn)
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(FeederConfig.self, from: data)
+        XCTAssertEqual(cfg, decoded)
+    }
+}

--- a/macos-audio-feeder/Tests/AudioFeederCoreTests/LevelMeterTests.swift
+++ b/macos-audio-feeder/Tests/AudioFeederCoreTests/LevelMeterTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import AudioFeederCore
+
+final class LevelMeterTests: XCTestCase {
+
+    func testSilenceIsZero() {
+        XCTAssertEqual(LevelMeter.rms([Float](repeating: 0, count: 128)), 0, accuracy: 1e-6)
+    }
+
+    func testEmptyIsZero() {
+        XCTAssertEqual(LevelMeter.rms([]), 0, accuracy: 1e-6)
+    }
+
+    func testFullScaleConstantIsOne() {
+        XCTAssertEqual(LevelMeter.rms([Float](repeating: 1, count: 64)), 1, accuracy: 1e-6)
+    }
+
+    func testSineRMSIsAmplitudeOverRootTwo() {
+        var gen = ToneGenerator(frequency: 1000, amplitude: 1.0, sampleRate: 48_000)
+        let samples = gen.next(48_000) // a full second -> many periods
+        XCTAssertEqual(LevelMeter.rms(samples), Float(1.0 / 2.0.squareRoot()), accuracy: 0.01)
+    }
+
+    func testDisplayLevelClampsToUnitRange() {
+        XCTAssertEqual(LevelMeter.displayLevel(rms: 0), 0, accuracy: 1e-6)
+        XCTAssertEqual(LevelMeter.displayLevel(rms: 5.0, gain: 5.0), 1, accuracy: 1e-6)
+        XCTAssertEqual(LevelMeter.displayLevel(rms: 0.1, gain: 5.0), 0.5, accuracy: 1e-6)
+    }
+
+    func testDBFSFloorsAtMinus120() {
+        XCTAssertEqual(LevelMeter.dBFS(rms: 0), -120, accuracy: 1e-6)
+        XCTAssertEqual(LevelMeter.dBFS(rms: 1), 0, accuracy: 1e-6)
+    }
+}

--- a/macos-audio-feeder/Tests/AudioFeederCoreTests/LiveKitTokenClientTests.swift
+++ b/macos-audio-feeder/Tests/AudioFeederCoreTests/LiveKitTokenClientTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import AudioFeederCore
+
+final class LiveKitTokenClientTests: XCTestCase {
+
+    func testRequestBodyMatchesBroadcastContract() {
+        let body = LiveKitTokenClient.requestBody(room: "doc-2025-06-30")
+        XCTAssertEqual(body["room"], "doc-2025-06-30")
+        XCTAssertEqual(body["identity"], "organizer-host")
+        XCTAssertEqual(body["role"], "organizer")
+    }
+
+    func testOrganizerIdentityConstant() {
+        XCTAssertEqual(LiveKitTokenClient.organizerIdentity, "organizer-host")
+    }
+
+    func testTokenDecoding() throws {
+        let json = Data(#"{"token":"jwt.abc","serverUrl":"wss://lk.example.com"}"#.utf8)
+        let token = try JSONDecoder().decode(LiveKitToken.self, from: json)
+        XCTAssertEqual(token.token, "jwt.abc")
+        XCTAssertEqual(token.serverUrl, "wss://lk.example.com")
+    }
+}

--- a/macos-audio-feeder/Tests/AudioFeederCoreTests/SchedulerTests.swift
+++ b/macos-audio-feeder/Tests/AudioFeederCoreTests/SchedulerTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import AudioFeederCore
+
+final class SchedulerTests: XCTestCase {
+
+    private var utc: Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }
+
+    /// Build a Date at a given UTC weekday/time. 2024-01-07 is a Sunday.
+    private func date(weekday: Int, hour: Int, minute: Int) -> Date {
+        // 2024-01-07 = Sunday(1) ... 2024-01-13 = Saturday(7).
+        let day = 7 + (weekday - 1)
+        var c = DateComponents()
+        c.year = 2024; c.month = 1; c.day = day; c.hour = hour; c.minute = minute
+        return utc.date(from: c)!
+    }
+
+    func testManualForceOnAlwaysRuns() {
+        let s = Schedule(enabled: false)
+        XCTAssertTrue(Scheduler.shouldRun(now: date(weekday: 1, hour: 3, minute: 0),
+                                          schedule: s, manualOverride: .forceOn, calendar: utc))
+    }
+
+    func testManualForceOffAlwaysStops() {
+        let s = Schedule(enabled: true, days: [1], startMinute: 0, stopMinute: 24 * 60 - 1)
+        XCTAssertFalse(Scheduler.shouldRun(now: date(weekday: 1, hour: 12, minute: 0),
+                                           schedule: s, manualOverride: .forceOff, calendar: utc))
+    }
+
+    func testDisabledScheduleNeverRuns() {
+        let s = Schedule(enabled: false, days: [1], startMinute: 0, stopMinute: 1440 - 1)
+        XCTAssertFalse(Scheduler.shouldRun(now: date(weekday: 1, hour: 12, minute: 0),
+                                           schedule: s, manualOverride: .off, calendar: utc))
+    }
+
+    func testInsideSameDayWindow() {
+        let s = Schedule(enabled: true, days: [1], startMinute: 10 * 60, stopMinute: 12 * 60)
+        XCTAssertTrue(Scheduler.shouldRun(now: date(weekday: 1, hour: 10, minute: 0),
+                                          schedule: s, manualOverride: .off, calendar: utc))
+        XCTAssertTrue(Scheduler.shouldRun(now: date(weekday: 1, hour: 11, minute: 59),
+                                          schedule: s, manualOverride: .off, calendar: utc))
+    }
+
+    func testWindowBoundariesAreHalfOpen() {
+        let s = Schedule(enabled: true, days: [1], startMinute: 10 * 60, stopMinute: 12 * 60)
+        // start inclusive
+        XCTAssertTrue(Scheduler.shouldRun(now: date(weekday: 1, hour: 10, minute: 0),
+                                          schedule: s, manualOverride: .off, calendar: utc))
+        // stop exclusive
+        XCTAssertFalse(Scheduler.shouldRun(now: date(weekday: 1, hour: 12, minute: 0),
+                                           schedule: s, manualOverride: .off, calendar: utc))
+        // before start
+        XCTAssertFalse(Scheduler.shouldRun(now: date(weekday: 1, hour: 9, minute: 59),
+                                           schedule: s, manualOverride: .off, calendar: utc))
+    }
+
+    func testWrongDayDoesNotRun() {
+        let s = Schedule(enabled: true, days: [1], startMinute: 10 * 60, stopMinute: 12 * 60)
+        XCTAssertFalse(Scheduler.shouldRun(now: date(weekday: 2, hour: 11, minute: 0),
+                                           schedule: s, manualOverride: .off, calendar: utc))
+    }
+
+    func testEmptyWindowNeverRuns() {
+        let s = Schedule(enabled: true, days: [1], startMinute: 600, stopMinute: 600)
+        XCTAssertFalse(Scheduler.shouldRun(now: date(weekday: 1, hour: 10, minute: 0),
+                                           schedule: s, manualOverride: .off, calendar: utc))
+    }
+
+    func testWrapPastMidnight() {
+        // Sunday 23:00 -> Monday 01:00, anchored to Sunday(1).
+        let s = Schedule(enabled: true, days: [1], startMinute: 23 * 60, stopMinute: 1 * 60)
+        // Sunday late night: inside.
+        XCTAssertTrue(Scheduler.shouldRun(now: date(weekday: 1, hour: 23, minute: 30),
+                                          schedule: s, manualOverride: .off, calendar: utc))
+        // Monday early morning: belongs to Sunday's window.
+        XCTAssertTrue(Scheduler.shouldRun(now: date(weekday: 2, hour: 0, minute: 30),
+                                          schedule: s, manualOverride: .off, calendar: utc))
+        // Monday after stop: out.
+        XCTAssertFalse(Scheduler.shouldRun(now: date(weekday: 2, hour: 1, minute: 0),
+                                           schedule: s, manualOverride: .off, calendar: utc))
+        // Sunday before start: out.
+        XCTAssertFalse(Scheduler.shouldRun(now: date(weekday: 1, hour: 22, minute: 59),
+                                           schedule: s, manualOverride: .off, calendar: utc))
+    }
+
+    func testPreviousWeekdayWraps() {
+        XCTAssertEqual(Scheduler.previousWeekday(1), 7)
+        XCTAssertEqual(Scheduler.previousWeekday(2), 1)
+        XCTAssertEqual(Scheduler.previousWeekday(7), 6)
+    }
+}


### PR DESCRIPTION
## Summary

The macOS audio feeder's menu-bar popup was fiddly: clicking the device selector made the whole popup disappear, and the device dropdown only showed up on the second try.

Root cause: `MenuBarExtra(.window)` is a transient `NSPanel` that auto-dismisses the instant any child menu/sheet steals key focus — so opening a `Picker`'s dropdown killed the popup before it could render.

This switches the menu bar to an `AppDelegate`-owned **`NSStatusItem` + `NSPopover`** (transient) hosting the existing `MenuContentView`, and moves Settings to the standard SwiftUI `Settings` scene. `NSPopover` keeps its container while a Picker's dropdown floats over it (the "Dropbox" behavior), so the device Picker works on the first click.

## Changes

- `AudioFeederApp.swift` — `@NSApplicationDelegateAdaptor` + `AppDelegate` that owns the status item and popover; `.accessory` activation policy (no Dock icon); menu-bar glyph tracks `controller.$status`.
- `MenuContentView.swift` — `Settings…` opens the `Settings` scene via `@Environment(\.openSettings)` and calls `NSApp.activate(ignoringOtherApps:)` so the accessory app raises the window to the front (fixes it opening behind other windows).
- `AppController.swift` / `ConfigView.swift` — unchanged.
- README status line updated to reflect NSStatusItem + NSPopover.

## Testing

- `swift build` passes.
- Manually verified on macOS: popup opens from the status item, device Picker opens on first click, and the Settings window comes to the front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)