### PR TITLE
Add live-transcript liveness tiles to the session status view

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -82,3 +82,42 @@ would be cheap to surface for a health/liveness view:
 
 Because in-process state is per-instance and lost on restart, anything meant for alerting should be
 mirrored to PostHog (or another external sink) as periodic gauges, not just the edge events above.
+
+## Web status view (StatusView) — current status
+
+The session status page ([src/StatusView.tsx](../src/StatusView.tsx), reachable via the `status`
+layout component) is where these signals surface for an operator. Current state:
+
+- **Live transcripts (built).** [src/TranscriptHealth.tsx](../src/TranscriptHealth.tsx) renders one
+  tile per `liveTranscript-<code>` language present in the doc — source (`en`) first — showing char
+  count, a tail preview, and a staleness dot. This is source #4 (transcript growth), the end-to-end
+  "translation is actually flowing" heartbeat, read straight from Yjs with no backend change.
+  - Discovery + labeling live in [src/transcriptKeys.ts](../src/transcriptKeys.ts) (`liveTranscriptCodes`,
+    `liveTranscriptLabel`, and the key-namespace constants), shared with the session export
+    ([sessionExport.ts](../sessionExport.ts)) so both agree on the namespace. Kept dependency-free
+    (type-only Yjs import) so the client doesn't pull the server export path into its bundle.
+  - **Freshness is client-relative.** Y.Text carries no timestamp, so "updated Ns ago" is measured
+    from when a delta is observed *while the page is open* — it can't recover the last-write time
+    from before you loaded. The initial sync populate is deliberately ignored so a stale backlog
+    doesn't read as "just updated." Good for "is it moving now"; not an absolute liveness clock.
+- **Component health tiles (skeleton).** The Server / Proclaim / bridges / broadcaster tiles are
+  still placeholders — nothing writes the `status` Y.Map yet (that's the #72 heartbeat producers).
+- **Preflight canary (skeleton).** Placeholder; no end-to-end check runs yet.
+
+## Next steps (roughly in order of effort)
+
+1. **Live-audio bridges tile** — cheapest real health signal. Poll the existing
+   `GET /api/livekit/translate/status?sessionId=…` (source #2) the way
+   [src/BroadcastControl.tsx](../src/BroadcastControl.tsx) already does, and render a tile per
+   `translator-*` with `status` + `subscriberCount`. Pair it visually with the transcript tiles,
+   since bridge `status: active` can read healthy while deaf (see Questions above). No backend work.
+2. **Absolute transcript freshness** — if the client-relative clock isn't enough, have
+   [transcript-writer.ts](../live-audio/transcript-writer.ts) stamp `lastWrittenAt` per code into the
+   `status` Y.Map. Survives reloads and gives the tiles a real wall-clock age; this is the first
+   `status`-map producer and sets the pattern for the rest.
+3. **Component heartbeats (#72)** — server, Proclaim service, and broadcaster each write a periodic
+   heartbeat into the `status` Y.Map so the skeleton health tiles turn real. Broadcaster presence
+   specifically needs LiveKit `listParticipants` (source #3); the current status endpoint lists only
+   translators, so this wants a small new endpoint or field.
+4. **Preflight canary** — a ~30 s end-to-end check run before a service; the `simulateScenario` hook
+   on the session manager is a starting point, but wiring a real canary is a feature, not a wire-up.

--- a/sessionExport.ts
+++ b/sessionExport.ts
@@ -25,6 +25,11 @@ import {
   type SlideTranslationEntry,
   type ResolvedSlideTranslation,
 } from './src/slideTranslation.ts';
+import {
+  LIVE_TRANSCRIPT_PREFIX,
+  LIVE_TRANSCRIPT_SOURCE_CODE,
+  liveTranscriptLabel,
+} from './src/transcriptKeys.ts';
 
 // --- Structured, render-agnostic representation -------------------------------
 
@@ -78,11 +83,6 @@ export interface SessionExport {
   /** Legacy Web Speech API transcript (`transcriptDoc`); empty in current sessions. */
   transcript: string;
 }
-
-/** Prefix the live-audio pipeline uses for per-language transcript Y.Text keys. */
-const LIVE_TRANSCRIPT_PREFIX = 'liveTranscript-';
-/** Code of the English source transcript (matches TranslationBridge.SOURCE_CODE). */
-const LIVE_TRANSCRIPT_SOURCE_CODE = 'en';
 
 // --- Y.Doc extraction ---------------------------------------------------------
 
@@ -223,7 +223,6 @@ function extractTranscript(ydoc: Y.Doc): string {
  * English source is listed first; the rest are sorted by localized label.
  */
 function extractLiveTranscripts(ydoc: Y.Doc): ExportedLiveTranscript[] {
-  const displayNames = new Intl.DisplayNames(['en'], { type: 'language' });
   const transcripts: ExportedLiveTranscript[] = [];
 
   for (const key of ydoc.share.keys()) {
@@ -232,13 +231,7 @@ function extractLiveTranscripts(ydoc: Y.Doc): ExportedLiveTranscript[] {
     if (text === '') continue;
     const code = key.slice(LIVE_TRANSCRIPT_PREFIX.length);
     const isSource = code === LIVE_TRANSCRIPT_SOURCE_CODE;
-    let label: string;
-    try {
-      label = displayNames.of(code) ?? code;
-    } catch {
-      label = code;
-    }
-    transcripts.push({ code, label, isSource, text });
+    transcripts.push({ code, label: liveTranscriptLabel(code), isSource, text });
   }
 
   return transcripts.sort((a, b) => {

--- a/src/StatusView.tsx
+++ b/src/StatusView.tsx
@@ -1,6 +1,8 @@
+import type { ReactNode } from 'react';
 import { useMap, useYDoc } from '@y-sweet/react';
 import { useStrings } from './useLocale';
 import { getDocId } from './getDocId';
+import { TranscriptHealth } from './TranscriptHealth';
 
 /**
  * Session status / admin page.
@@ -30,9 +32,14 @@ export interface StatusViewProps {
    * components start heartbeating; the skeleton only reports the count for now.
    */
   statusEntries: Record<string, unknown>;
+  /**
+   * Live-transcript liveness tiles, injected by the container (they need per-Y.Text
+   * observers). Kept as a slot so the pure component stays testable without Yjs.
+   */
+  liveTranscripts?: ReactNode;
 }
 
-export function StatusView({ docId, statusEntries }: StatusViewProps) {
+export function StatusView({ docId, statusEntries, liveTranscripts }: StatusViewProps) {
   const s = useStrings();
   const exportHref = `/api/session/export?doc=${encodeURIComponent(docId)}`;
   const reportingCount = Object.keys(statusEntries).length;
@@ -73,6 +80,14 @@ export function StatusView({ docId, statusEntries }: StatusViewProps) {
           </p>
         </section>
 
+        {/* Live transcripts — real end-to-end liveness, read from the transcript Y.Texts. */}
+        <section className={sectionClass}>
+          <h2 className={sectionTitleClass}>{s.statusTranscriptsTitle}</h2>
+          {liveTranscripts ?? (
+            <p className={placeholderClass}>{s.statusTranscriptsEmpty}</p>
+          )}
+        </section>
+
         {/* Preflight canary — placeholder until #72. */}
         <section className={sectionClass}>
           <h2 className={sectionTitleClass}>{s.statusCanaryTitle}</h2>
@@ -111,7 +126,13 @@ export function StatusViewContainer() {
   statusMap.forEach((value, key) => {
     statusEntries[key] = value;
   });
-  return <StatusView docId={getDocId()} statusEntries={statusEntries} />;
+  return (
+    <StatusView
+      docId={getDocId()}
+      statusEntries={statusEntries}
+      liveTranscripts={<TranscriptHealth />}
+    />
+  );
 }
 
 export default StatusView;

--- a/src/TranscriptHealth.tsx
+++ b/src/TranscriptHealth.tsx
@@ -1,0 +1,146 @@
+// TranscriptHealth: an operator-facing liveness view of the live speech-translation
+// transcripts, for the session status page. It answers "is translation actually
+// flowing right now, and into which languages?" by reading the same
+// `liveTranscript-{code}` Y.Text streams the product itself renders (see
+// LiveTranscript.tsx and OBSERVABILITY.md §4 — transcript growth is the one
+// end-to-end heartbeat no single component can fake).
+//
+// Two things worth knowing about the freshness signal:
+//   - Yjs Y.Text carries no timestamp, so "updated Ns ago" is measured client-side
+//     from when a delta is observed while this view is mounted. It's relative to the
+//     page, not absolute wall-clock — you can't recover the last-write time from
+//     before you opened the page. For "is it moving now" that's the right signal.
+//   - The initial sync populate fires one observe with the full backlog; that isn't
+//     a live delta, so each tile ignores its first observed value.
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useYDoc } from '@y-sweet/react';
+import type * as Y from 'yjs';
+import { useAsPlainText } from './yjsUtils';
+import { useStrings, resolveLocale } from './useLocale';
+import {
+  LIVE_TRANSCRIPT_PREFIX,
+  LIVE_TRANSCRIPT_SOURCE_CODE,
+  liveTranscriptCodes,
+  liveTranscriptLabel,
+} from './transcriptKeys';
+
+/** Freshness thresholds (ms) for the staleness dot. */
+const FRESH_MS = 8_000;
+const RECENT_MS = 30_000;
+/** How much of the transcript tail to preview. */
+const TAIL_CHARS = 90;
+
+/**
+ * The transcript codes present in the doc, kept in sync as new languages appear
+ * mid-session. Root types show up in `doc.share` once integrated, so we re-scan on
+ * every doc update; the snapshot is a plain comma-joined string so an unchanged set
+ * of languages doesn't re-render even as text streams in.
+ */
+function useLiveTranscriptCodes(doc: Y.Doc): string[] {
+  const [codesKey, setCodesKey] = useState(() => liveTranscriptCodes(doc).join(','));
+  useEffect(() => {
+    const update = () => setCodesKey(liveTranscriptCodes(doc).join(','));
+    update(); // doc identity may have changed since the initializer ran
+    doc.on('update', update);
+    return () => doc.off('update', update);
+  }, [doc]);
+  return useMemo(() => (codesKey === '' ? [] : codesKey.split(',')), [codesKey]);
+}
+
+/** A monotonically re-rendering "now", ticking once a second while `active`. */
+function useNow(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [active]);
+  return now;
+}
+
+/** Collapse whitespace and take the last TAIL_CHARS for a compact preview. */
+function tail(text: string): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  return collapsed.length > TAIL_CHARS ? `…${collapsed.slice(-TAIL_CHARS)}` : collapsed;
+}
+
+function TranscriptHealthTile({ code }: { code: string }) {
+  const s = useStrings();
+  const [text] = useAsPlainText(`${LIVE_TRANSCRIPT_PREFIX}${code}`);
+  const isSource = code === LIVE_TRANSCRIPT_SOURCE_CODE;
+
+  // Record when a *live* delta arrives. The first observed value is the initial
+  // sync backlog, not a live update, so seed the ref with it without stamping a time.
+  const prevRef = useRef<string | null>(null);
+  const [lastChangeAt, setLastChangeAt] = useState<number | null>(null);
+  useEffect(() => {
+    if (prevRef.current === null) {
+      prevRef.current = text;
+      return;
+    }
+    if (text !== prevRef.current) {
+      prevRef.current = text;
+      setLastChangeAt(Date.now());
+    }
+  }, [text]);
+
+  const now = useNow(lastChangeAt !== null);
+  const ageMs = lastChangeAt === null ? null : now - lastChangeAt;
+
+  const dotClass =
+    ageMs === null
+      ? 'bg-gray-300 dark:bg-gray-600'
+      : ageMs < FRESH_MS
+        ? 'bg-green-500'
+        : ageMs < RECENT_MS
+          ? 'bg-amber-500'
+          : 'bg-red-500';
+
+  const freshness =
+    ageMs === null
+      ? s.statusTranscriptNoUpdates
+      : new Intl.RelativeTimeFormat(resolveLocale(), { numeric: 'auto' }).format(
+          -Math.round(ageMs / 1000),
+          'second',
+        );
+
+  const preview = tail(text);
+  const label = liveTranscriptLabel(code);
+
+  return (
+    <div className="rounded border border-gray-200 dark:border-gray-700 p-3 flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span className={`inline-block w-2.5 h-2.5 rounded-full shrink-0 ${dotClass}`} />
+        <span className="text-sm font-medium">{label}</span>
+        {isSource && (
+          <span className="text-xs text-gray-500 dark:text-gray-400">({s.statusTranscriptSource})</span>
+        )}
+        <span className="ml-auto text-xs tabular-nums text-gray-500 dark:text-gray-400">
+          {text.length.toLocaleString()} chars · {freshness}
+        </span>
+      </div>
+      <p className="text-xs text-gray-600 dark:text-gray-300 line-clamp-2 min-h-8">
+        {preview || <span className="italic text-gray-400 dark:text-gray-500">—</span>}
+      </p>
+    </div>
+  );
+}
+
+/** Live liveness tiles for every transcript language present in the session doc. */
+export function TranscriptHealth() {
+  const s = useStrings();
+  const doc = useYDoc();
+  const codes = useLiveTranscriptCodes(doc);
+
+  if (codes.length === 0) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400">{s.statusTranscriptsEmpty}</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {codes.map((code) => (
+        <TranscriptHealthTile key={code} code={code} />
+      ))}
+    </div>
+  );
+}

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -86,6 +86,10 @@ export interface AppStrings {
   statusCanaryPlaceholder: string;
   statusExportTitle: string;
   statusExportDescription: string;
+  statusTranscriptsTitle: string;
+  statusTranscriptsEmpty: string;
+  statusTranscriptSource: string;
+  statusTranscriptNoUpdates: string;
 
   // Layout diagram component labels
   componentSourceText: string;
@@ -180,6 +184,10 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     statusExportTitle: 'Session export',
     statusExportDescription:
       'Download this session’s notes, slide translations, and live transcripts as a single readable HTML file.',
+    statusTranscriptsTitle: 'Live transcripts',
+    statusTranscriptsEmpty: 'No live transcripts in this session yet.',
+    statusTranscriptSource: 'source',
+    statusTranscriptNoUpdates: 'No updates since page load',
     componentSourceText: 'Source Text',
     componentTranslatedText: 'Translated Text',
     componentBilingual: 'Bilingual View',
@@ -267,6 +275,10 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     statusExportTitle: 'Exporter la session',
     statusExportDescription:
       'Téléchargez les notes, les traductions de diapositives et les transcriptions en direct de cette session dans un seul fichier HTML lisible.',
+    statusTranscriptsTitle: 'Transcriptions en direct',
+    statusTranscriptsEmpty: 'Aucune transcription en direct dans cette session pour l’instant.',
+    statusTranscriptSource: 'source',
+    statusTranscriptNoUpdates: 'Aucune mise à jour depuis le chargement de la page',
     componentSourceText: 'Texte source',
     componentTranslatedText: 'Texte traduit',
     componentBilingual: 'Vue bilingue',
@@ -354,6 +366,10 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     statusExportTitle: 'Exportar sesión',
     statusExportDescription:
       'Descargue las notas, las traducciones de diapositivas y las transcripciones en vivo de esta sesión en un solo archivo HTML legible.',
+    statusTranscriptsTitle: 'Transcripciones en vivo',
+    statusTranscriptsEmpty: 'Aún no hay transcripciones en vivo en esta sesión.',
+    statusTranscriptSource: 'fuente',
+    statusTranscriptNoUpdates: 'Sin actualizaciones desde que se cargó la página',
     componentSourceText: 'Texto fuente',
     componentTranslatedText: 'Texto traducido',
     componentBilingual: 'Vista biling\u00fce',
@@ -441,6 +457,10 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     statusExportTitle: 'Ekspòte sesyon an',
     statusExportDescription:
       'Telechaje nòt yo, tradiksyon dyapozitiv yo, ak transkripsyon an dirèk sesyon sa a nan yon sèl fichye HTML ki fasil pou li.',
+    statusTranscriptsTitle: 'Transkripsyon an dirèk',
+    statusTranscriptsEmpty: 'Poko gen transkripsyon an dirèk nan sesyon sa a.',
+    statusTranscriptSource: 'sous',
+    statusTranscriptNoUpdates: 'Pa gen mizajou depi paj la chaje',
     componentSourceText: 'Teks sous',
     componentTranslatedText: 'Teks tradui',
     componentBilingual: 'Vi Bileng',

--- a/src/transcriptKeys.test.ts
+++ b/src/transcriptKeys.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { liveTranscriptCodes } from './transcriptKeys';
+
+describe('liveTranscriptCodes', () => {
+  it('discovers only liveTranscript-* root types, English source first', () => {
+    const doc = new Y.Doc();
+    // Touching a Y.Text registers the root type in doc.share, mirroring what the
+    // transcript writer does on the server as each language comes online.
+    doc.getText('liveTranscript-fr').insert(0, 'bonjour');
+    doc.getText('liveTranscript-en').insert(0, 'hello');
+    doc.getText('liveTranscript-es').insert(0, 'hola');
+    doc.getText('sourceBlocks'); // unrelated root type — must be ignored
+    doc.getMap('proclaimStatus');
+
+    // en is the source, so it sorts first; the rest by localized label
+    // (English "French" < "Spanish").
+    expect(liveTranscriptCodes(doc)).toEqual(['en', 'fr', 'es']);
+  });
+
+  it('returns an empty list when no transcripts exist yet', () => {
+    const doc = new Y.Doc();
+    doc.getArray('sourceBlocks');
+    expect(liveTranscriptCodes(doc)).toEqual([]);
+  });
+
+  it('picks up a language that appears after the first scan', () => {
+    const doc = new Y.Doc();
+    doc.getText('liveTranscript-en').insert(0, 'hello');
+    expect(liveTranscriptCodes(doc)).toEqual(['en']);
+
+    doc.getText('liveTranscript-ht').insert(0, 'bonjou');
+    expect(liveTranscriptCodes(doc)).toEqual(['en', 'ht']);
+  });
+});

--- a/src/transcriptKeys.ts
+++ b/src/transcriptKeys.ts
@@ -1,0 +1,41 @@
+// Shared primitives for the live speech-translation transcripts. The pipeline
+// publishes each language into a `liveTranscript-{code}` Y.Text (see
+// live-audio/transcript-writer.ts); both the client (LiveTranscript,
+// TranscriptHealth) and the server-side session export need to agree on that
+// namespace and on how to label a code. Kept free of any runtime dependency (the
+// Y import is type-only) so either side can import it without pulling the other's
+// bundle in.
+import type * as Y from 'yjs';
+
+/** Prefix the live-audio pipeline uses for per-language transcript Y.Text keys. */
+export const LIVE_TRANSCRIPT_PREFIX = 'liveTranscript-';
+
+/** Code of the English source transcript (matches TranslationBridge.SOURCE_CODE). */
+export const LIVE_TRANSCRIPT_SOURCE_CODE = 'en';
+
+const liveTranscriptDisplayNames = new Intl.DisplayNames(['en'], { type: 'language' });
+
+/** Localized display name for a transcript's BCP-47 code, falling back to the code itself. */
+export function liveTranscriptLabel(code: string): string {
+  try {
+    return liveTranscriptDisplayNames.of(code) ?? code;
+  } catch {
+    return code;
+  }
+}
+
+/** Scan a doc's root types for the transcript codes present, English source first. */
+export function liveTranscriptCodes(doc: Y.Doc): string[] {
+  const codes: string[] = [];
+  for (const key of doc.share.keys()) {
+    if (key.startsWith(LIVE_TRANSCRIPT_PREFIX)) {
+      codes.push(key.slice(LIVE_TRANSCRIPT_PREFIX.length));
+    }
+  }
+  return codes.sort((a, b) => {
+    const aSource = a === LIVE_TRANSCRIPT_SOURCE_CODE;
+    const bSource = b === LIVE_TRANSCRIPT_SOURCE_CODE;
+    if (aSource !== bSource) return aSource ? -1 : 1;
+    return liveTranscriptLabel(a).localeCompare(liveTranscriptLabel(b));
+  });
+}


### PR DESCRIPTION
## What

Wires **source #4 (transcript growth)** from [docs/OBSERVABILITY.md](../blob/status-view-transcript-liveness/docs/OBSERVABILITY.md) into the session status page. `StatusView` now shows a **Live transcripts** section: one tile per `liveTranscript-<code>` language present in the doc (English source first), with char count, a whitespace-collapsed tail preview, and an "updated Ns ago" staleness dot. It reads straight from Yjs — no backend change — so it answers "is translation actually flowing right now, and into which languages?" for an operator.

## Notes

- **Shared, dependency-free key module.** Transcript key namespace, labeling, and doc discovery move into new `src/transcriptKeys.ts` (`LIVE_TRANSCRIPT_PREFIX`, `LIVE_TRANSCRIPT_SOURCE_CODE`, `liveTranscriptLabel`, `liveTranscriptCodes`). `sessionExport.ts` (server) imports from it, so both sides agree on the namespace **without the client pulling the server export path into its bundle** — the Yjs import is type-only. (Named `transcriptKeys` to avoid a macOS casing collision with `LiveTranscript.tsx`.)
- **Freshness is client-relative.** `Y.Text` carries no timestamp, so "updated Ns ago" is measured from deltas observed *while the page is open*; it can't recover the last-write time from before load. The initial sync populate is deliberately ignored so a stale backlog doesn't read as "just updated". Localized via `Intl.RelativeTimeFormat`.
- **Pure component stays testable.** The tiles are injected into `StatusView` via a `liveTranscripts?` slot prop; the existing `StatusView` tests still pass with no Yjs setup.
- New strings added for all four locales (en/fr/es/ht).

## Still skeleton (unchanged)

Component-health tiles and the preflight canary remain placeholders — nothing writes the `status` Y.Map yet (#72). Next steps documented in OBSERVABILITY.md: the live-audio **bridges tile** off the existing `/api/livekit/translate/status` endpoint (no backend work), absolute freshness via a `lastWrittenAt` stamp, then the #72 heartbeat producers and canary.

## Testing

- `npm run typecheck`, `npm run lint` (changed files), full `npm test` — **269 passed**.
- New `src/transcriptKeys.test.ts` drives `liveTranscriptCodes` against a real `Y.Doc`: source-first ordering, empty-doc case, and a language appearing mid-session.

**Smoke test:** touches **§4 Live audio translation** (the transcript signal it reads) only indirectly — this is a read-only operator view over existing `liveTranscript-*` Y.Text, no change to the audio/translation path itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)