### PR TITLE
Self-heal lost translator bots: client re-requests, bridge fails recreatably

### DIFF
--- a/live-audio/translation-bridge.e2e.test.ts
+++ b/live-audio/translation-bridge.e2e.test.ts
@@ -96,6 +96,9 @@ class FakeAudioStream {
 
 class FakePublication {
   subscribed = false;
+  // undefined by default, like the SDK's `muted?: boolean` — the bridge must treat
+  // unknown as live, so only an explicit `true` reads as a muted mic.
+  muted: boolean | undefined = undefined;
   constructor(
     readonly track: FakeRemoteTrack,
     readonly participant: FakeParticipant,
@@ -140,7 +143,11 @@ class FakeRoom extends EventEmitter {
   }
 
   async connect(): Promise<void> {}
-  async disconnect(): Promise<void> {}
+  // The real SDK emits Disconnected (CLIENT_INITIATED) on a manual disconnect, so every
+  // test that calls bridge.stop() also exercises the "deliberate disconnect" guard.
+  async disconnect(): Promise<void> {
+    this.emit(RoomEvent.Disconnected, 0);
+  }
 
   /** Put a participant in the room with a live mic, as if they were already publishing. */
   seatOrganizer(identity: string): FakeRemoteTrack {
@@ -461,6 +468,80 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     await speak(newMic, 3);
 
     expect(framesToGemini()).toBe(4);
+    await bridge.stop();
+  });
+
+  it("is recreatable, not a zombie, after an unexpected room disconnect", async () => {
+    // A room Disconnected the bridge didn't ask for (duplicate identity, LiveKit server
+    // restart, lost connectivity). Before the fix this set status="closed" and nothing
+    // else: the bridge stayed in the manager's map looking deliberately stopped, held
+    // its Gemini socket open, and the language was dead until a brand-new listener
+    // happened to request it. Now it must read as failed ("error", which ensureBridge
+    // treats as stale) with the Gemini side torn down.
+    const events: string[] = [];
+    const { bridge, room, seated: mic } = await boot((r) => r.seatOrganizer(ORGANIZER), {
+      recordEvent: (event: string) => events.push(event),
+    });
+    await speak(mic, 2);
+    expect(framesToGemini()).toBe(2);
+
+    room.emit(RoomEvent.Disconnected, 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(bridge.status).toBe("error");
+    expect(events).toContain("livekit_disconnected");
+    // No paid-for zombie: every Gemini socket is closed.
+    for (const socket of FakeGeminiSocket.instances) {
+      expect(socket.readyState).not.toBe(FakeGeminiSocket.OPEN);
+    }
+
+    // A deliberate stop stays "closed" — the disconnect its room.disconnect() emits
+    // must not be mistaken for a failure.
+    await bridge.stop();
+    expect(bridge.status).toBe("closed");
+  });
+
+  it("escalates to teardown when reconcile cannot bring a dead input back", async () => {
+    // The watchdog's level-1 recovery (reconcile) assumes re-subscribing fixes the pipe.
+    // Here it doesn't: the publication still exists and claims to be subscribed, but its
+    // stream is dead and no replacement ever appears. Before the fix the bridge
+    // reconciled forever, deaf but "active". Now, after repeated fruitless recoveries,
+    // it must tear itself down — leaving the room so listeners see the translator gone
+    // and re-request the language, which recreates the bridge from scratch.
+    const events: string[] = [];
+    const { bridge, seated: mic } = await boot((r) => r.seatOrganizer(ORGANIZER), {
+      recordEvent: (event: string) => events.push(event),
+    });
+    await speak(mic, 2);
+    expect(framesToGemini()).toBe(2);
+
+    // The stream dies; the publication stays, already-subscribed, so reconcile is a no-op.
+    mic.end();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(events).toContain("organizer_audio_stalled"); // level 1 was tried...
+    expect(events).toContain("organizer_audio_unrecoverable"); // ...and gave way to level 2
+    expect(bridge.status).toBe("closed"); // stop(): out of the room, recreatable on demand
+  });
+
+  it("never escalates against a muted mic — that silence is expected", async () => {
+    // Same dead-frames signal, opposite meaning: the organizer muted their mic. Frames
+    // stopping is correct behavior, and recreating the bridge wouldn't (and shouldn't)
+    // end it — escalation here would churn a Gemini session every ~45s for the whole
+    // mute. The mute state on the publication is what tells the two apart.
+    const events: string[] = [];
+    const { bridge, room, seated: mic } = await boot((r) => r.seatOrganizer(ORGANIZER), {
+      recordEvent: (event: string) => events.push(event),
+    });
+    await speak(mic, 2);
+
+    mic.end();
+    const organizer = room.remoteParticipants.get(ORGANIZER) as FakeParticipant;
+    for (const [, pub] of organizer.trackPublications) pub.muted = true;
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    expect(events).not.toContain("organizer_audio_unrecoverable");
+    expect(bridge.status).toBe("active");
     await bridge.stop();
   });
 

--- a/live-audio/translation-bridge.ts
+++ b/live-audio/translation-bridge.ts
@@ -73,6 +73,13 @@ export type ReconnectTrigger = "goaway" | "close" | "resume";
 // not merely quiet. Recovery is attempted no more than once per stall window.
 const INPUT_STALL_MS = 15_000;
 const STALL_CHECK_INTERVAL_MS = 5_000;
+// Reconcile is the watchdog's level-1 recovery; this is level 2. If this many
+// consecutive stall windows pass with an apparently-live (unmuted, published) organizer
+// mic and still no frames, reconcile isn't fixing it — tear the bridge down so demand
+// (a listener re-requesting the language) recreates it from scratch, which is what the
+// manual redeploy did in the 2026-07-12 outage. A muted or unpublished mic never
+// escalates: that silence is expected, and recreating wouldn't (and shouldn't) end it.
+const STALL_ESCALATE_AFTER = 3;
 
 // Exponential-backoff bounds for failed Gemini reconnect attempts (mirrors the
 // Proclaim service's convention; see PROCLAIM_INTEGRATION.md).
@@ -340,6 +347,9 @@ export class TranslationBridge {
   private lastOrganizerFrameAt: number = 0;
   private lastStallRecoveryAt: number = 0;
   private stallWatchdog: ReturnType<typeof setInterval> | null = null;
+  // Stall windows in a row where reconcile didn't bring frames back (see
+  // STALL_ESCALATE_AFTER). Reset whenever frames arrive or the mic reads muted.
+  private consecutiveStallRecoveries: number = 0;
 
   // Persists finalized transcript segments into the shared Yjs doc.
   private readonly writer: TranscriptWriter | null;
@@ -473,7 +483,26 @@ export class TranslationBridge {
     }
     this.pipedTracks.clear();
 
-    // Stop any in-flight reconnect so it doesn't resurrect the socket after teardown.
+    this.teardownGeminiSide();
+
+    if (this.room) {
+      await this.room.disconnect();
+      this.room = null;
+    }
+
+    this.audioSource = null;
+    this.localTrack = null;
+    this.suspended = false;
+  }
+
+  /**
+   * Close the Gemini side completely: the active socket, any pending replacement, any
+   * scheduled retry, and the gap buffer. Used by stop() and by failure paths (room
+   * disconnect, watchdog escalation) where the bridge is done but must not leave a
+   * paid-for socket behind. The sockets' close handlers see a non-active status (or
+   * suspended) and won't reconnect.
+   */
+  private teardownGeminiSide(): void {
     this.reconnecting = false;
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
@@ -483,21 +512,11 @@ export class TranslationBridge {
       this.pendingWs.close();
       this.pendingWs = null;
     }
-
     if (this.geminiWs) {
       this.geminiWs.close();
       this.geminiWs = null;
     }
-
-    if (this.room) {
-      await this.room.disconnect();
-      this.room = null;
-    }
-
-    this.audioSource = null;
-    this.localTrack = null;
     this.geminiSetupComplete = false;
-    this.suspended = false;
     this.pendingFrames = [];
     this.bufferedSilenceRun = 0;
   }
@@ -528,7 +547,15 @@ export class TranslationBridge {
         `[TranslationBridge:${this.targetLanguage}] Disconnected from room (reason: ${DisconnectReason[reason] ?? reason})`
       );
       this.record("livekit_disconnected", { reason: DisconnectReason[reason] ?? String(reason) });
-      this.status = "closed";
+      // stop() disconnects the room deliberately, with status already "closed" — done.
+      if (this.status === "closed") return;
+      // Any other disconnect (duplicate identity, LiveKit server restart, connectivity
+      // loss past the SDK's resume) is a failure. "error" marks the bridge recreatable —
+      // ensureBridge treats it as stale, and listeners re-request the language when they
+      // see the translator gone. Drop the Gemini side too, so the bridge can't linger as
+      // a zombie holding a paid-for session that no audio will ever reach.
+      this.status = "error";
+      this.teardownGeminiSide();
     });
 
     this.room.on(RoomEvent.Reconnecting, () => {
@@ -1123,7 +1150,7 @@ export class TranslationBridge {
    * Safe to call at any time, from any trigger, as often as we like.
    */
   private reconcile(trigger: string): void {
-    if (!this.room || this.status === "closed") return;
+    if (!this.room || this.status === "closed" || this.status === "error") return;
     const subscribed = reconcileOrganizerAudio({
       organizerIdentity: this.organizerIdentity,
       participants: this.room.remoteParticipants.values(),
@@ -1143,6 +1170,10 @@ export class TranslationBridge {
     this.stallWatchdog = setInterval(() => {
       if (this.status !== "active") return;
       const now = Date.now();
+      // Frames since the last recovery mean it worked — the escalation clock resets.
+      if (this.lastOrganizerFrameAt > this.lastStallRecoveryAt) {
+        this.consecutiveStallRecoveries = 0;
+      }
       if (
         !shouldRecoverStalledInput({
           now,
@@ -1155,6 +1186,29 @@ export class TranslationBridge {
       }
       this.lastStallRecoveryAt = now;
       const stalledMs = now - this.lastOrganizerFrameAt;
+
+      // Level 2: reconcile has had its chances and frames never came back. Only when
+      // the organizer's mic *looks* live — a muted/unpublished mic is expected silence,
+      // and recreating the bridge wouldn't end it (just churn a Gemini session).
+      if (this.organizerHasUnmutedAudio()) {
+        this.consecutiveStallRecoveries++;
+        if (this.consecutiveStallRecoveries >= STALL_ESCALATE_AFTER) {
+          console.error(
+            `[TranslationBridge:${this.targetLanguage}] No organizer audio for ${stalledMs}ms after ${this.consecutiveStallRecoveries} reconcile attempts — tearing down for recreation`
+          );
+          this.record("organizer_audio_unrecoverable", {
+            stalledMs,
+            recoveries: this.consecutiveStallRecoveries,
+          });
+          // stop() leaves the room, so listeners see the translator vanish and
+          // re-request the language, which recreates the bridge from scratch.
+          void this.stop();
+          return;
+        }
+      } else {
+        this.consecutiveStallRecoveries = 0;
+      }
+
       console.warn(
         `[TranslationBridge:${this.targetLanguage}] No organizer audio for ${stalledMs}ms — reconciling subscription`
       );
@@ -1163,6 +1217,24 @@ export class TranslationBridge {
     }, STALL_CHECK_INTERVAL_MS);
     // Don't hold the process open on this timer alone.
     this.stallWatchdog.unref?.();
+  }
+
+  /**
+   * Does the organizer currently have an audio publication that isn't muted? Frames
+   * should be flowing from such a mic, so their sustained absence marks the input
+   * pipe as broken rather than merely quiet. `muted` can be undefined on some SDK
+   * paths; treat unknown as live so a broken pipe is never mistaken for a muted mic.
+   */
+  private organizerHasUnmutedAudio(): boolean {
+    if (!this.room) return false;
+    for (const participant of this.room.remoteParticipants.values()) {
+      if (participant.identity !== this.organizerIdentity) continue;
+      for (const [, pub] of participant.trackPublications) {
+        if (pub.kind !== TrackKind.KIND_AUDIO) continue;
+        if (pub.muted !== true) return true;
+      }
+    }
+    return false;
   }
 
   private pipeTrackToGemini(track: RemoteAudioTrack): void {

--- a/src/ListenViewer.test.tsx
+++ b/src/ListenViewer.test.tsx
@@ -1,12 +1,17 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ListenViewer } from "./ListenViewer";
 
 interface MockProps {
   children: React.ReactNode;
   className?: string;
 }
+
+// Who useRemoteParticipants reports; tests set this before rendering.
+const roomState = vi.hoisted(() => ({
+  participants: [] as Array<{ identity: string; trackPublications: Map<string, never> }>,
+}));
 
 vi.mock("./useLocale", () => ({
   LANGUAGE_BCP47: { French: "fr", English: "en" },
@@ -15,6 +20,7 @@ vi.mock("./useLocale", () => ({
     stopAudio: "Stop audio",
     liveListening: "Live listening",
     waitingForSpeaker: "Waiting for speaker",
+    restartingTranslation: "Restarting translation",
     retry: "Retry",
     connecting: "Connecting",
     liveAudioError: "Live audio error",
@@ -41,18 +47,31 @@ vi.mock("@livekit/components-react", () => {
     ),
     RoomAudioRenderer: () => null,
     useRoomContext: () => null,
-    useRemoteParticipants: () => [],
+    useRemoteParticipants: () => roomState.participants,
   };
 });
 
+const participant = (identity: string) => ({
+  identity,
+  trackPublications: new Map<string, never>(),
+});
+
 describe("ListenViewer", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  // How many times the client has asked the server for a translator bot. Exact-path
+  // match: the unsubscribe beacon and token requests must not count.
+  const translateRequests = () =>
+    fetchMock.mock.calls.filter(([input]) => input === "/api/livekit/translate").length;
+
   beforeEach(() => {
+    roomState.participants = [];
     Object.defineProperty(window.navigator, "sendBeacon", {
       configurable: true,
       value: vi.fn(() => true),
     });
 
-    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+    fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/api/livekit/translate")) {
         return Promise.resolve({
@@ -73,6 +92,10 @@ describe("ListenViewer", () => {
     vi.stubGlobal("fetch", fetchMock);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("keeps the LiveKit room from forcing the whole pane to full height", async () => {
     const user = userEvent.setup();
     render(<ListenViewer language="fr" />);
@@ -84,5 +107,45 @@ describe("ListenViewer", () => {
     expect(screen.getByTestId("livekit-room")).toHaveClass("w-full");
     expect(screen.getByTestId("livekit-room")).toHaveClass("shrink-0");
     expect(screen.getByTestId("livekit-room")).toHaveClass("h-auto");
+  });
+
+  it("re-requests a missing translator while the speaker is broadcasting", async () => {
+    // The self-heal loop: the server lost our bot (restart, reap, room drop) and nothing
+    // server-side recreates it — the client must ask again. Speaker present, bot absent.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    roomState.participants = [participant("organizer-host")];
+    render(<ListenViewer language="French" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /listen live/i }));
+    await waitFor(() => expect(screen.getByTestId("livekit-room")).toBeInTheDocument());
+    expect(translateRequests()).toBe(1); // the opt-in request
+
+    // The degraded state is visible, not just silent retrying.
+    expect(screen.getByText(/restarting translation/i)).toBeInTheDocument();
+
+    // Past the grace window, the ensure loop asks the server again.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_500);
+    });
+    expect(translateRequests()).toBe(2);
+  });
+
+  it("does not churn against the reaper while waiting for the broadcast to start", async () => {
+    // The waiting-room case (2026-07-19): pre-broadcast, the server reaps translator-less
+    // sessions, so re-requesting in a loop would fight it. With no organizer in the room,
+    // the ensure loop must stay quiet — it fires only once the speaker appears.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    roomState.participants = []; // nobody broadcasting yet
+    render(<ListenViewer language="French" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /listen live/i }));
+    await waitFor(() => expect(screen.getByTestId("livekit-room")).toBeInTheDocument());
+    expect(translateRequests()).toBe(1);
+    expect(screen.getByText(/waiting for speaker/i)).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(35_000);
+    });
+    expect(translateRequests()).toBe(1); // still just the opt-in request
   });
 });

--- a/src/ListenViewer.tsx
+++ b/src/ListenViewer.tsx
@@ -10,7 +10,7 @@
 // healthy. The tradeoff (accepted deliberately) is that the transcript stays dark
 // until the first listener in a session opts in — no viewer holds a LiveKit
 // connection just to read. In other words: read for free, opt in to hear.
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   LiveKitRoom,
   RoomAudioRenderer,
@@ -25,6 +25,10 @@ import { LiveTranscript } from "./LiveTranscript";
 import { getDocId } from "./getDocId";
 
 const ORGANIZER_PREFIX = "organizer-";
+
+// How often to re-request a missing translator bot (and the grace we give a
+// just-requested one to appear before the first re-request).
+const ENSURE_TRANSLATOR_INTERVAL_MS = 10_000;
 
 interface ConnectInfo {
   token: string;
@@ -71,6 +75,43 @@ function ListenAudio({
   const speakerPresent = remoteParticipants.some((p) =>
     p.identity.startsWith(ORGANIZER_PREFIX)
   );
+  // The bot we depend on (for translated audio, or just the transcript when
+  // listening to the original). Identities are deterministic: translator-<code>.
+  const translatorPresent = remoteParticipants.some(
+    (p) => p.identity === `translator-${releaseTarget}`
+  );
+
+  // Self-heal: the server can lose our translator (restart, presence reap, its room
+  // connection dropping) and nothing server-side recreates it — so while the speaker
+  // is broadcasting without our bot, periodically re-request it. Gated on speaker
+  // presence so a pre-broadcast wait doesn't churn against the server's presence
+  // reaper (docs/live-audio-state-architecture.md, "the waiting-room reap"): the
+  // re-request then fires exactly when the session becomes healthy, so it sticks.
+  const needsTranslator = speakerPresent && !translatorPresent;
+  const lastEnsureRef = useRef(0);
+  // Stamp mount time (not in render — Date.now is impure there) so the bot the parent
+  // just requested gets one full interval to appear before the first re-request.
+  useEffect(() => {
+    lastEnsureRef.current = Date.now();
+  }, []);
+  useEffect(() => {
+    if (!needsTranslator) return;
+    const ensure = () => {
+      const now = Date.now();
+      if (now - lastEnsureRef.current < ENSURE_TRANSLATOR_INTERVAL_MS) return;
+      lastEnsureRef.current = now;
+      void fetch("/api/livekit/translate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: docId, targetLanguage: releaseTarget }),
+      }).catch(() => {
+        // Transient; the next tick retries.
+      });
+    };
+    ensure();
+    const id = setInterval(ensure, ENSURE_TRANSLATOR_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [needsTranslator, docId, releaseTarget]);
 
   // Subscribe to the audio we want only while audio is enabled: the translator
   // bot for a translation, or the speaker's raw mic for "Original / English".
@@ -109,18 +150,28 @@ function ListenAudio({
     };
   }, [docId, releaseTarget]);
 
+  // Three-light status: gray = no speaker, amber = speaker is live but our
+  // translator is missing (being re-requested above), green = fully wired. For
+  // original audio the translator only carries the transcript, so its absence
+  // doesn't demote the light — the audio the listener chose is unaffected.
+  const degraded = needsTranslator && !isOriginal;
+  const dotClass = !speakerPresent
+    ? "bg-gray-400"
+    : degraded
+      ? "bg-amber-500 animate-pulse"
+      : "bg-green-500 animate-pulse";
+  const statusText = !speakerPresent
+    ? s.waitingForSpeaker
+    : degraded
+      ? s.restartingTranslation
+      : s.liveListening;
+
   return (
     <>
       <RoomAudioRenderer />
       <div className="flex items-center gap-2 text-xs">
-        <span
-          className={`inline-block w-2 h-2 rounded-full ${
-            speakerPresent ? "bg-green-500 animate-pulse" : "bg-gray-400"
-          }`}
-        />
-        <span className="text-gray-600 dark:text-gray-300">
-          {speakerPresent ? s.liveListening : s.waitingForSpeaker}
-        </span>
+        <span className={`inline-block w-2 h-2 rounded-full ${dotClass}`} />
+        <span className="text-gray-600 dark:text-gray-300">{statusText}</span>
         <div className="flex-1" />
         <button
           type="button"

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -59,6 +59,7 @@ export interface AppStrings {
   englishTranscript: string;
   liveListening: string;
   waitingForSpeaker: string;
+  restartingTranslation: string;
   waitingForSpeech: string;
   liveAudioError: string;
   retry: string;
@@ -150,6 +151,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     englishTranscript: 'English transcript',
     liveListening: 'Listening live',
     waitingForSpeaker: 'Waiting for the speaker…',
+    restartingTranslation: 'Restarting translation…',
     waitingForSpeech: 'Waiting for translated speech…',
     liveAudioError: 'Live audio unavailable',
     retry: 'Retry',
@@ -237,6 +239,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     englishTranscript: 'Transcription anglaise',
     liveListening: 'Écoute en direct',
     waitingForSpeaker: 'En attente de l’orateur…',
+    restartingTranslation: 'Redémarrage de la traduction…',
     waitingForSpeech: 'En attente de la traduction vocale…',
     liveAudioError: 'Audio en direct indisponible',
     retry: 'Réessayer',
@@ -324,6 +327,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     englishTranscript: 'Transcripción en inglés',
     liveListening: 'Escuchando en vivo',
     waitingForSpeaker: 'Esperando al orador…',
+    restartingTranslation: 'Reiniciando la traducción…',
     waitingForSpeech: 'Esperando la traducción hablada…',
     liveAudioError: 'Audio en vivo no disponible',
     retry: 'Reintentar',
@@ -411,6 +415,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     englishTranscript: 'Transkripsyon anglè',
     liveListening: 'Ap koute an dirèk',
     waitingForSpeaker: 'N ap tann moun k ap pale a…',
+    restartingTranslation: 'N ap redemare tradiksyon an…',
     waitingForSpeech: 'N ap tann tradiksyon vokal la…',
     liveAudioError: 'Odyo an dirèk pa disponib',
     retry: 'Reeseye',


### PR DESCRIPTION
Hot fixes 1–3 from [docs/live-audio-state-architecture.md](https://github.com/kcarnold/live-notes/pull/85) (the state audit PR). Together they close every "listener hears silence forever" case in the catalog — server restart (#1), zombie bridge after room disconnect (#2), premature teardown (#3), watchdog dead-end (#4), and the waiting-room reap observed 2026-07-19 (#13) — by completing the escalation ladder the resilience doc promised: the client asks again, and the server treats a broken bridge as recreatable.

## The three fixes

**1. `ListenViewer` ensure loop (client, ~30 lines).** While the listener has opted in: if the speaker is broadcasting but our deterministic `translator-<code>` bot is not among the remote participants, re-POST `/api/livekit/translate` every 10s until it returns (idempotent — `getOrCreate` reuses live bridges). Gated on **organizer presence** so a pre-broadcast wait doesn't churn against the presence reaper; the re-request then fires exactly when the session becomes healthy, so it sticks. The status line becomes three-light: gray "waiting for speaker" / amber "Restarting translation…" (new string, all four locales) / green "listening live". For original-audio listeners the translator only carries the transcript, so its absence doesn't demote the light.

**2. Room `Disconnected` → `error`, not `closed` (bridge).** An unexpected disconnect (duplicate identity, LiveKit restart, lost connectivity) previously set `status="closed"` and nothing else — a zombie holding an open Gemini socket, dead until a brand-new listener happened to request the language. Now it reads as failed (`ensureBridge` treats `error` as stale and recreates on demand) and the Gemini side is torn down via a new shared `teardownGeminiSide()`. A deliberate `stop()` still reads as `closed`; the e2e fake room now emits `Disconnected` on `disconnect()` like the real SDK, so every existing test exercises that guard.

**3. Stall-watchdog escalation (bridge).** After 3 consecutive stall windows (~45s) where reconcile brought no frames back **while the organizer's mic reads unmuted/published**, the bridge tears itself down and leaves the room — so listeners see the translator vanish and fix 1 recreates it, which is what the manual redeploy did in the 2026-07-12 outage. A muted or unpublished mic never escalates (that silence is expected, and recreating wouldn't end it); `muted === undefined` is treated as live so a broken pipe is never mistaken for a muted mic.

## Testing

- 3 new e2e tests (recreatable-after-disconnect, escalation, muted-mic-never-escalates) + 2 new `ListenViewer` tests (re-request fires when speaker present without bot; stays quiet pre-broadcast).
- Per the house rule, the behavior tests were **verified to fail against the pre-fix code** (`git stash` run: exactly the 3 behavior tests go red; the 2 "must not" guards pass either way, by design).
- Full suite: 272 tests / 23 files pass; `npm run typecheck` and `npm run lint` clean.

## Smoke test sections touched

**§4 Live audio translation** — specifically: listener opt-in before broadcast (translator should now appear once the broadcast starts), and translated audio resuming after a server restart mid-listen. No other sections affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XQh3xXo9Yk2B5iHtzWR2B

---
_Generated by [Claude Code](https://claude.ai/code/session_014XQh3xXo9Yk2B5iHtzWR2B)_