### PR TITLE
Live translation architecture: presence-driven supervisor replaces refcount + beacon + reaper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Required environment variables (`.env`):
 Optional environment variables:
 - `TTS_MAX_CONCURRENT` - Max concurrent TTS requests (default: 2)
 - `GEMINI_STRONG_MODEL` - Stronger Gemini model for whole-item slide drafting via `/api/translateItem` (default: `gemini-3.5-flash`)
-- `LIVE_AUDIO_SILENCE_THRESHOLD_DBFS` - dBFS voice bar for the live-audio cost path; a bridge suspends its Gemini session after ~30s below it (`-30` is the tuned value). Unset = off, no suspending. Beware the sign: dBFS is negative, so `0` gates hardest, not least. goaway/reconnect fixes and the always-on default translator are independent of this. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
+- `LIVE_AUDIO_SILENCE_THRESHOLD_DBFS` - dBFS voice bar for the live-audio cost path; a bridge suspends its Gemini session after ~30s below it (`-30` is a guess, never validated against a real room). Unset = off, no suspending. Beware the sign: dBFS is negative, so `0` gates hardest, not least. goaway/reconnect fixes and the always-on default translator are independent of this. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
 - `VITE_PUBLIC_POSTHOG_KEY` - PostHog analytics key (for usage tracking)
 - `VITE_PUBLIC_POSTHOG_HOST` - PostHog host URL (default: https://us.i.posthog.com)
 - `POSTHOG_CLI_TOKEN` - PostHog CLI token (for sourcemap uploads during Docker build)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Required environment variables (`.env`):
 Optional environment variables:
 - `TTS_MAX_CONCURRENT` - Max concurrent TTS requests (default: 2)
 - `GEMINI_STRONG_MODEL` - Stronger Gemini model for whole-item slide drafting via `/api/translateItem` (default: `gemini-3.5-flash`)
-- `LIVE_AUDIO_SILENCE_GATING` - Enable the live-audio cost path: silence suspend/resume + always-on default translator (default: off). goaway/reconnect fixes are independent and always on. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
+- `LIVE_AUDIO_SILENCE_THRESHOLD_DBFS` - dBFS voice bar for the live-audio cost path; a bridge suspends its Gemini session after ~30s below it (`-30` is the tuned value). Unset = off, no suspending. Beware the sign: dBFS is negative, so `0` gates hardest, not least. goaway/reconnect fixes and the always-on default translator are independent of this. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
 - `VITE_PUBLIC_POSTHOG_KEY` - PostHog analytics key (for usage tracking)
 - `VITE_PUBLIC_POSTHOG_HOST` - PostHog host URL (default: https://us.i.posthog.com)
 - `POSTHOG_CLI_TOKEN` - PostHog CLI token (for sourcemap uploads during Docker build)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,8 +34,10 @@ derived data) drives the testing/replay strategy.
   Layouts are URL-encoded (see `App.tsx`); `#editor` gates write access.
 - **Express server** (`server.ts`): Y-Sweet token issuing (the auth chokepoint), translation
   endpoints, TTS with disk cache, `/api/config`; hosts the live-audio subsystem in-process.
-- **live-audio** (`live-audio/`): `translation-session-manager` spawns one
-  `translation-bridge` per (session, language) on listener demand and reaps idle ones. Each
+- **live-audio** (`live-audio/`): `translation-session-manager` runs a supervisor loop that
+  reconciles running `translation-bridge`s against LiveKit room presence — listeners carry a
+  `listen=<lang>` participant attribute in their token, and the loop starts, recreates, or
+  winds down one bridge per (session, language) to match (no refcounts or beacons). Each
   bridge subscribes to the organizer's LiveKit track (16 kHz in), streams to Gemini Live,
   publishes translated audio (24 kHz out), and writes the transcript into Yjs via
   `transcript-writer`. When a Gemini session is swapped (goaway/reconnect), input frames are
@@ -73,14 +75,19 @@ writer once each component announces its clientID (planned: via the status heart
 
 ## Lifecycle notes that surprise people
 
-- **Bridges are demand-driven**: a translation bridge exists only while the session has at
-  least one human listener AND a broadcaster (`translation-session-manager.ts`), so connecting
-  clients *change* system behavior — preflight checks must include a synthetic listener, and
-  "nothing is translating" is often just "nobody is listening yet." With the cost path
-  (`LIVE_AUDIO_SILENCE_GATING`) enabled this shifts: the default bridge becomes presence-driven
-  (runs for any broadcaster, zero listeners OK) and a silent mic suspends the socket rather
-  than tearing it down, so "nothing is translating" can also mean "nobody is speaking" —
-  preflight then needs non-silent audio, not just a connection.
+- **Bridges are presence-driven**: the supervisor (`translation-session-manager.ts`) derives
+  the desired bridge set from who is in the LiveKit room — nothing runs without a broadcaster
+  (a listener waiting for the talk costs nothing; bridges start the moment the organizer
+  joins), and with a broadcaster present each language named by a listener's `listen`
+  attribute runs, plus the default/English-transcript bridge while anyone listens. So
+  connecting clients *change* system behavior — preflight checks must include a synthetic
+  listener, and "nothing is translating" is often just "nobody is listening yet." Because the
+  loop reconciles (every ~10 s, plus pokes), bridges also *come back* by themselves after a
+  server restart or a failed bridge, as long as demand persists. With the cost path
+  (`LIVE_AUDIO_SILENCE_GATING`) enabled: the default bridge runs for any broadcaster (zero
+  listeners OK) and a silent mic suspends the socket rather than tearing it down, so "nothing
+  is translating" can also mean "nobody is speaking" — preflight then needs non-silent audio,
+  not just a connection.
 - **Doc IDs are date-anchored** (`getDocId.ts`, and the Proclaim service anchors to the
   show's scheduled date), so a service's state lives in one doc per date.
 - **Editor vs viewer** is enforced server-side via Y-Sweet token scope, keyed off the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,10 +43,12 @@ derived data) drives the testing/replay strategy.
   `transcript-writer`. When a Gemini session is swapped (goaway/reconnect), input frames are
   buffered across the gap and flushed into the fresh session, so a swap costs a little
   latency rather than dropped words (always on). A **cost path** — off unless
-  `LIVE_AUDIO_SILENCE_GATING` is set — additionally suspends a bridge's Gemini socket after
-  ~30 s below −30 dBFS (reopening on the first non-silent frame; the LiveKit participant/track
-  stay live so listeners never resubscribe) and, because silence is then free, keeps the
-  default/English bridge running for any present broadcaster so there's always a transcript.
+  `LIVE_AUDIO_SILENCE_THRESHOLD_DBFS` names a level (−30 is a guess) — additionally
+  suspends a bridge's Gemini socket after ~30 s below that level, reopening on the first
+  non-silent frame; the LiveKit participant/track stay live so listeners never resubscribe.
+  That threshold is the feature's only switch: unset, it is −Infinity, every frame reads as
+  voice, and nothing can suspend. It affects only what a bridge does while nobody speaks —
+  *which* bridges exist is decided independently (see the supervisor below).
 - **proclaim_service.py**: polls Proclaim's local HTTP API (~1 s) and reads its SQLite DB,
   pushes presentations + slide status into Yjs. Installed as a macOS LaunchAgent.
 - **Y-Sweet**: persistence and fan-out for the per-service Y.Doc (`doc-YYYY-MM-DD`).
@@ -78,16 +80,17 @@ writer once each component announces its clientID (planned: via the status heart
 - **Bridges are presence-driven**: the supervisor (`translation-session-manager.ts`) derives
   the desired bridge set from who is in the LiveKit room — nothing runs without a broadcaster
   (a listener waiting for the talk costs nothing; bridges start the moment the organizer
-  joins), and with a broadcaster present each language named by a listener's `listen`
-  attribute runs, plus the default/English-transcript bridge while anyone listens. So
-  connecting clients *change* system behavior — preflight checks must include a synthetic
-  listener, and "nothing is translating" is often just "nobody is listening yet." Because the
-  loop reconciles (every ~10 s, plus pokes), bridges also *come back* by themselves after a
-  server restart or a failed bridge, as long as demand persists. With the cost path
-  (`LIVE_AUDIO_SILENCE_GATING`) enabled: the default bridge runs for any broadcaster (zero
-  listeners OK) and a silent mic suspends the socket rather than tearing it down, so "nothing
-  is translating" can also mean "nobody is speaking" — preflight then needs non-silent audio,
-  not just a connection.
+  joins), and with a broadcaster present the default/English-transcript bridge runs
+  unconditionally, plus each language named by a listener's `listen` attribute. So connecting
+  clients *change* system behavior — preflight checks for a *translation* must include a
+  synthetic listener, and "no French audio" is often just "nobody asked for French yet." The
+  English transcript is the exception and needs no listener: a talk is transcribed from the
+  moment the broadcaster goes live, so the first listener to arrive gets history rather than
+  a mid-sentence start. Because the loop reconciles (every ~10 s, plus pokes), bridges also
+  *come back* by themselves after a server restart or a failed bridge, as long as demand
+  persists. With the cost path enabled, a silent mic suspends the socket rather than tearing
+  it down, so "nothing is translating" can also mean "nobody is speaking" — preflight then
+  needs non-silent audio, not just a connection.
 - **Doc IDs are date-anchored** (`getDocId.ts`, and the Proclaim service anchors to the
   show's scheduled date), so a service's state lives in one doc per date.
 - **Editor vs viewer** is enforced server-side via Y-Sweet token scope, keyed off the

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -15,21 +15,23 @@ most of these signals.
    session. Best for *history and rates* ("how often do sessions drop", "how long are the gaps").
    Off when telemetry is unconfigured (dev/tests); logs still print each event.
 2. **In-process manager/bridge state** — live, authoritative for "what is running right now",
-   but in-memory only (lost on restart; single server instance). Exposed today by
-   `GET /api/livekit/translate/status?sessionId=…` → `getActiveTranslations()`
-   (`{ language, translatorIdentity, status, subscriberCount }[]`). More state exists on the
-   objects than the endpoint returns (see gaps below).
+   but in-memory only (single server instance; rebuilt from presence after a restart by the
+   supervisor). Exposed by `GET /api/livekit/translate/status?sessionId=…` →
+   `getActiveTranslations()` (`{ language, translatorIdentity, status, subscriberCount,
+   health }[]`, where `health` is the bridge's composite snapshot: per-leg Gemini state,
+   last input/output frame ages, reconnect count, gap-buffer depth).
 3. **LiveKit RoomService** — source of truth for *room/participant presence* (who's actually
-   connected: `organizer-*`, `translator-*`, listeners; their track publications). Pull with
-   `RoomServiceClient.listParticipants(sessionId)` against the `LIVEKIT_URL` (ws→http). The reaper
-   already polls this every 30 s; it does not depend on any client-side beacon.
+   connected: `organizer-*`, `translator-*`, listeners; their track publications, and each
+   listener's `listen=<lang>` attribute — the demand signal). Pull with
+   `RoomServiceClient.listParticipants(sessionId)` against the `LIVEKIT_URL` (ws→http). The
+   supervisor polls this every 10 s; it does not depend on any client-side beacon.
 4. **Y-Sweet / Yjs transcript doc** — the `liveTranscript-<code>` Y.Text per language is the
    product itself; its steady growth is a good end-to-end "translation is actually flowing"
    heartbeat that no single component can fake (written by `transcript-writer.ts`).
 
 Server logs are the fifth, lowest-friction source: bridges log `[TranslationBridge:<lang>] …`
 and the manager logs `[SessionManager] …`, including every telemetry event, suspend/resume, and
-reap decision.
+supervisor start/stop decision.
 
 ## PostHog events (from `translation-bridge.ts`)
 
@@ -62,20 +64,24 @@ Server-level exceptions go through `phClient.captureException(...)` in
   (output hang). Both should be rare and short.
 - **Is the cost path behaving?** Rates of `gemini_suspended_silence` / `gemini_resumed_voice`
   and the `silentMs` distribution; cross-check that suspends don't correlate with lost transcript.
-- **Who's paying for what?** `getActiveTranslations()` (`subscriberCount` per language) + LiveKit
-  listener counts; a `translator-*` with 0 listeners that isn't the default bridge is waste.
+- **Who's paying for what?** `getActiveTranslations()` (`subscriberCount` per language, stamped
+  by the supervisor from `listen` attributes) + LiveKit listener counts; a `translator-*` with
+  0 listeners that isn't the default bridge should be within its 60 s stop grace, or is a bug.
+- **Is the supervisor converging?** `supervisor_bridge_started` / `supervisor_bridge_stopped` /
+  `supervisor_bridge_start_failed` events (distinctId = sessionId). A start/stop cycle repeating
+  for one language means demand is flapping or a bridge can't hold; `start_failed` repeating
+  means LiveKit/Gemini won't accept the bridge at all.
 
 ## Gaps worth filling (not yet exposed)
 
-The status endpoint returns only `status` + `subscriberCount`. These live on the objects and
-would be cheap to surface for a health/liveness view:
+The status endpoint now returns each bridge's `health` snapshot (`status`, per-leg `gemini`
+state, `lastInputFrameAt`/`lastOutputFrameAt`, `reconnects`, `bufferedFrames`). Still cheap and
+worth surfacing:
 
-- Per bridge: `suspended`, `geminiSetupComplete`, `pendingFrames.length` (backlog depth = current
-  added latency), `reconnectCount`, `framesSentToGemini` / `framesReceivedFromGemini`,
-  `lastVoiceAt` / `sessionConnectedAt` ages, `framesDroppedWhileDown`.
-- Per session: `lastHealthyAt` age and the last reaper verdict; `getAllSessions()` for a fleet view.
-- Server: `isSilenceGatingEnabled()` and whether LiveKit is configured, so a dashboard can explain
-  why behavior differs between environments.
+- Per bridge: `framesSentToGemini` / `framesReceivedFromGemini`, `lastVoiceAt` /
+  `sessionConnectedAt` ages, `framesDroppedWhileDown`.
+- Server: whether the cost path is enabled and whether LiveKit is configured, so a dashboard can
+  explain why behavior differs between environments.
 - A cheap **liveness heartbeat**: "frames received from Gemini in the last N s" per active bridge
   distinguishes "active" from "active but silent/stuck" without waiting for the 2 s `gemini_audio_gap`
   threshold. Consider a periodic gauge rather than only edge events.

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -66,13 +66,17 @@ an incident happens that this list would not have caught, add a line.
       fails, so it can't be provoked by running longer. `scenario` also accepts
       `signalReconnect`, `nodeFailure`, `migration`, `serverLeave`.
 
-Cost path (only when `LIVE_AUDIO_SILENCE_GATING` is enabled — off by default):
-
 - [ ] With **no listener yet**, the English transcript still flows — the default translator
-      runs whenever the broadcaster is present.
+      runs whenever the broadcaster is present, whatever the cost path is set to.
+
+Cost path (only when `LIVE_AUDIO_SILENCE_THRESHOLD_DBFS` names a level — off by default; the
+startup log line reports which):
+
 - [ ] **Silence suspend/resume**: stay silent >30 s (server logs "Suspending Gemini after…");
       then speak — the first words resume translation ("resuming Gemini after…") without the
       listener resubscribing.
+- [ ] With the threshold **unset**, the opposite: stay silent >30 s and confirm no
+      "Suspending Gemini" line appears, with the mic both open-but-quiet and fully muted.
 
 ## 5. TTS (text-to-speech on translated notes)
 

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -39,9 +39,15 @@ an incident happens that this list would not have caught, add a line.
 - [ ] Start broadcasting (mic level meter moves).
 - [ ] On the viewer device, join Listen for one language **after** broadcast started:
       transcript deltas appear, translated audio plays after tapping play.
-- [ ] **The #69 race**: start the Listen client *first*, then start broadcasting — bridge
-      must still pick up the source audio (transcript flows).
+- [ ] **The #69 race / waiting room**: start the Listen client *first*, then start
+      broadcasting. Before the broadcast the supervisor runs no bridges (the listener just
+      waits); within ~10 s of the organizer joining, the translator appears and the
+      transcript flows. The listener's amber "Restarting translation…" state may flash
+      briefly — it must go green without a reload.
 - [ ] Stop and restart the broadcaster mid-session; transcript resumes without a reload.
+- [ ] **Server-restart recovery**: with a listener connected and the speaker talking,
+      restart the Node server. Within ~15 s the supervisor rebuilds the bridges from room
+      presence and the transcript resumes — no reload, no re-tap on any client.
 - [ ] **The LiveKit full reconnect** (the 2026-07-12 outage — see
       [live-audio-resilience.md](live-audio-resilience.md)). With a bridge running and the
       speaker talking, force the reconnect that once deafened every translator for six
@@ -75,7 +81,8 @@ Cost path (only when `LIVE_AUDIO_SILENCE_GATING` is enabled — off by default):
 
 ## 6. Teardown sanity
 
-- [ ] Close all listener tabs; confirm translator bots get reaped (server logs) — no orphaned
-      Gemini sessions burning quota. (With the cost path enabled, closing listeners is not
-      enough: the default translator stays up for the transcript until the broadcaster also
-      leaves.)
+- [ ] Close all listener tabs; confirm the supervisor winds the translator bots down within
+      ~2 minutes (60 s demand grace + a reconcile tick; watch for `[SessionManager] Supervisor
+      stopping …` in server logs) — no orphaned Gemini sessions burning quota. (With the cost
+      path enabled, closing listeners is not enough: the default translator stays up for the
+      transcript until the broadcaster also leaves.)

--- a/live-audio/translation-bridge.e2e.test.ts
+++ b/live-audio/translation-bridge.e2e.test.ts
@@ -524,6 +524,32 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     expect(bridge.status).toBe("closed"); // stop(): out of the room, recreatable on demand
   });
 
+  it("drops a setupComplete that lost a race with stop() — no socket resurrection", async () => {
+    // The epoch guard. A goAway starts a make-before-break replacement; the bridge is
+    // stopped before that socket finishes setup, but its setupComplete is already in
+    // flight. Pre-fix, onSocketReady swapped the dead-on-arrival socket in anyway —
+    // an open, paid-for Gemini session strapped to a closed bridge, invisible to
+    // every monitor. The guard must drop it instead.
+    const events: string[] = [];
+    const { bridge, seated: mic } = await boot((r) => r.seatOrganizer(ORGANIZER), {
+      recordEvent: (event: string) => events.push(event),
+    });
+    await speak(mic, 1);
+
+    // Gemini warns it will terminate → the bridge opens a pending replacement...
+    FakeGeminiSocket.instances[0].emit(
+      "message",
+      Buffer.from(JSON.stringify({ goAway: { timeLeft: "5s" } }))
+    );
+    // ...and the bridge is stopped before that replacement completes setup.
+    await bridge.stop();
+    await vi.advanceTimersByTimeAsync(100); // the replacement's setupComplete lands now
+
+    expect(events.filter((e) => e === "gemini_session_setup_complete")).toHaveLength(1); // initial only
+    expect(events).toContain("gemini_stale_socket_dropped");
+    expect(bridge.status).toBe("closed");
+  });
+
   it("never escalates against a muted mic — that silence is expected", async () => {
     // Same dead-frames signal, opposite meaning: the organizer muted their mic. Frames
     // stopping is correct behavior, and recreating the bridge wouldn't (and shouldn't)

--- a/live-audio/translation-bridge.e2e.test.ts
+++ b/live-audio/translation-bridge.e2e.test.ts
@@ -285,7 +285,9 @@ vi.mock("ws", () => ({ default: FakeGeminiSocket }));
 
 // ---------------------------------------------------------------------------
 
-const { TranslationBridge } = await import("./translation-bridge.ts");
+const { TranslationBridge, SILENCE_THRESHOLD_DBFS, SILENCE_GATING_OFF_DBFS } = await import(
+  "./translation-bridge.ts"
+);
 
 const ORGANIZER = "organizer-host";
 
@@ -590,7 +592,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
   it("a long pause suspends Gemini WITHOUT the watchdog tearing down the live input", async () => {
     const events: string[] = [];
     const { bridge, seated: mic } = await boot((room) => room.seatOrganizer(ORGANIZER), {
-      silenceGatingEnabled: true,
+      silenceThresholdDbfs: SILENCE_THRESHOLD_DBFS,
       recordEvent: (event: string) => events.push(event),
     });
 
@@ -628,7 +630,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     // can notice. (Same failure as the "unknown-unknown" test, now with gating enabled.)
     const events: string[] = [];
     const { bridge, room, seated: mic } = await boot((r) => r.seatOrganizer(ORGANIZER), {
-      silenceGatingEnabled: true,
+      silenceThresholdDbfs: SILENCE_THRESHOLD_DBFS,
       recordEvent: (event: string) => events.push(event),
     });
 
@@ -653,6 +655,45 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     const before = framesToGemini();
     await speakVoice(newMic, 3);
     expect(framesToGemini()).toBeGreaterThan(before);
+    await bridge.stop();
+  });
+
+  // Gating off is expressed as a voice bar of -Infinity rather than a separate flag, so
+  // these two pin down that the bar alone really does mean "never suspends" — across both
+  // routes into suspendForSilence. Without that, "off" would be a config that runs half
+  // the gating machinery, which is exactly the shape that made this hard to reason about.
+
+  it("with the voice bar off, open-mic room tone never suspends Gemini", async () => {
+    // The per-frame route. Room tone is digital silence here (-Infinity dBFS), the worst
+    // case for a `>=` test — it still has to read as voice at the off bar, or the quietest
+    // possible input would be the one thing that suspends a bridge with gating disabled.
+    const events: string[] = [];
+    const { bridge, seated: mic } = await boot((room) => room.seatOrganizer(ORGANIZER), {
+      silenceThresholdDbfs: SILENCE_GATING_OFF_DBFS,
+      recordEvent: (event: string) => events.push(event),
+    });
+
+    await speakVoice(mic, 3);
+    await holdSilence(mic, 90_000); // 3x the suspend window
+    expect(events).not.toContain("gemini_suspended_silence");
+    expect(bridge.status).toBe("active");
+    await bridge.stop();
+  });
+
+  it("with the voice bar off, a muted mic sending nothing never suspends Gemini", async () => {
+    // The timer route, and the reason the off bar is checked when starting the monitor
+    // instead of being left to fall out of the per-frame test: with no frames arriving
+    // there is nothing to read as voice, `lastVoiceAt` just stops advancing, and the
+    // window elapses on a bridge that is supposed to stay up. The stall watchdog may
+    // fire here — a genuinely dead input is its job — but suspending is not.
+    const events: string[] = [];
+    const { bridge } = await boot((room) => room.seatOrganizer(ORGANIZER), {
+      silenceThresholdDbfs: SILENCE_GATING_OFF_DBFS,
+      recordEvent: (event: string) => events.push(event),
+    });
+
+    await vi.advanceTimersByTimeAsync(45_000); // past the 30s suspend window, no frames at all
+    expect(events).not.toContain("gemini_suspended_silence");
     await bridge.stop();
   });
 });

--- a/live-audio/translation-bridge.e2e.test.ts
+++ b/live-audio/translation-bridge.e2e.test.ts
@@ -96,6 +96,9 @@ class FakeAudioStream {
 
 class FakePublication {
   subscribed = false;
+  // undefined by default, like the SDK's `muted?: boolean` — the bridge must treat
+  // unknown as live, so only an explicit `true` reads as a muted mic.
+  muted: boolean | undefined = undefined;
   constructor(
     readonly track: FakeRemoteTrack,
     readonly participant: FakeParticipant,
@@ -140,7 +143,11 @@ class FakeRoom extends EventEmitter {
   }
 
   async connect(): Promise<void> {}
-  async disconnect(): Promise<void> {}
+  // The real SDK emits Disconnected (CLIENT_INITIATED) on a manual disconnect, so every
+  // test that calls bridge.stop() also exercises the "deliberate disconnect" guard.
+  async disconnect(): Promise<void> {
+    this.emit(RoomEvent.Disconnected, 0);
+  }
 
   /** Put a participant in the room with a live mic, as if they were already publishing. */
   seatOrganizer(identity: string): FakeRemoteTrack {
@@ -461,6 +468,80 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     await speak(newMic, 3);
 
     expect(framesToGemini()).toBe(4);
+    await bridge.stop();
+  });
+
+  it("is recreatable, not a zombie, after an unexpected room disconnect", async () => {
+    // A room Disconnected the bridge didn't ask for (duplicate identity, LiveKit server
+    // restart, lost connectivity). Before the fix this set status="closed" and nothing
+    // else: the bridge stayed in the manager's map looking deliberately stopped, held
+    // its Gemini socket open, and the language was dead until a brand-new listener
+    // happened to request it. Now it must read as failed ("error", which ensureBridge
+    // treats as stale) with the Gemini side torn down.
+    const events: string[] = [];
+    const { bridge, room, seated: mic } = await boot((r) => r.seatOrganizer(ORGANIZER), {
+      recordEvent: (event: string) => events.push(event),
+    });
+    await speak(mic, 2);
+    expect(framesToGemini()).toBe(2);
+
+    room.emit(RoomEvent.Disconnected, 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(bridge.status).toBe("error");
+    expect(events).toContain("livekit_disconnected");
+    // No paid-for zombie: every Gemini socket is closed.
+    for (const socket of FakeGeminiSocket.instances) {
+      expect(socket.readyState).not.toBe(FakeGeminiSocket.OPEN);
+    }
+
+    // A deliberate stop stays "closed" — the disconnect its room.disconnect() emits
+    // must not be mistaken for a failure.
+    await bridge.stop();
+    expect(bridge.status).toBe("closed");
+  });
+
+  it("escalates to teardown when reconcile cannot bring a dead input back", async () => {
+    // The watchdog's level-1 recovery (reconcile) assumes re-subscribing fixes the pipe.
+    // Here it doesn't: the publication still exists and claims to be subscribed, but its
+    // stream is dead and no replacement ever appears. Before the fix the bridge
+    // reconciled forever, deaf but "active". Now, after repeated fruitless recoveries,
+    // it must tear itself down — leaving the room so listeners see the translator gone
+    // and re-request the language, which recreates the bridge from scratch.
+    const events: string[] = [];
+    const { bridge, seated: mic } = await boot((r) => r.seatOrganizer(ORGANIZER), {
+      recordEvent: (event: string) => events.push(event),
+    });
+    await speak(mic, 2);
+    expect(framesToGemini()).toBe(2);
+
+    // The stream dies; the publication stays, already-subscribed, so reconcile is a no-op.
+    mic.end();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(events).toContain("organizer_audio_stalled"); // level 1 was tried...
+    expect(events).toContain("organizer_audio_unrecoverable"); // ...and gave way to level 2
+    expect(bridge.status).toBe("closed"); // stop(): out of the room, recreatable on demand
+  });
+
+  it("never escalates against a muted mic — that silence is expected", async () => {
+    // Same dead-frames signal, opposite meaning: the organizer muted their mic. Frames
+    // stopping is correct behavior, and recreating the bridge wouldn't (and shouldn't)
+    // end it — escalation here would churn a Gemini session every ~45s for the whole
+    // mute. The mute state on the publication is what tells the two apart.
+    const events: string[] = [];
+    const { bridge, room, seated: mic } = await boot((r) => r.seatOrganizer(ORGANIZER), {
+      recordEvent: (event: string) => events.push(event),
+    });
+    await speak(mic, 2);
+
+    mic.end();
+    const organizer = room.remoteParticipants.get(ORGANIZER) as FakeParticipant;
+    for (const [, pub] of organizer.trackPublications) pub.muted = true;
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    expect(events).not.toContain("organizer_audio_unrecoverable");
+    expect(bridge.status).toBe("active");
     await bridge.stop();
   });
 

--- a/live-audio/translation-bridge.test.ts
+++ b/live-audio/translation-bridge.test.ts
@@ -5,7 +5,9 @@ import {
   isSilentFrame,
   nextBackoffMs,
   parseGoAwayTimeLeftMs,
+  parseSilenceThresholdDbfs,
   SILENCE_FLOOR_DBFS,
+  SILENCE_GATING_OFF_DBFS,
   SILENCE_THRESHOLD_DBFS,
   reconcileOrganizerAudio,
   shouldRecoverStalledInput,
@@ -59,6 +61,37 @@ describe("isSilentFrame", () => {
     const frame = toneFrame(2048); // ~-24 dBFS
     expect(isSilentFrame(frame, -20)).toBe(true);
     expect(isSilentFrame(frame, -30)).toBe(false);
+  });
+
+  it("calls nothing silent at the off bar, including digital silence", () => {
+    // The bar doubles as the feature's switch, so this is the property the whole
+    // "no separate flag" simplification rests on: at -Infinity even an all-zeros
+    // frame (which reads -Infinity dBFS) must come out non-silent.
+    expect(isSilentFrame(new Int16Array(1600), SILENCE_GATING_OFF_DBFS)).toBe(false);
+    expect(isSilentFrame(toneFrame(64), SILENCE_GATING_OFF_DBFS)).toBe(false);
+  });
+});
+
+// The env knob. dBFS is negative below full scale, so the direction is easy to get
+// backwards: 0 is not "off", it's the most aggressive gate possible (everything but a
+// clipping-loud frame reads as silence). Off has to be its own value, and the default.
+describe("parseSilenceThresholdDbfs", () => {
+  it("defaults to off when unset or blank", () => {
+    expect(parseSilenceThresholdDbfs(undefined)).toBe(SILENCE_GATING_OFF_DBFS);
+    expect(parseSilenceThresholdDbfs("")).toBe(SILENCE_GATING_OFF_DBFS);
+    expect(parseSilenceThresholdDbfs("   ")).toBe(SILENCE_GATING_OFF_DBFS);
+  });
+
+  it("reads a finite level, so gating is opted into by naming one", () => {
+    expect(parseSilenceThresholdDbfs("-30")).toBe(-30);
+    expect(parseSilenceThresholdDbfs(" -42.5 ")).toBe(-42.5);
+    expect(parseSilenceThresholdDbfs(String(SILENCE_THRESHOLD_DBFS))).toBe(SILENCE_THRESHOLD_DBFS);
+  });
+
+  it("falls back to off rather than gating on a value it can't read", () => {
+    // A typo'd env var must not silently start suspending sessions mid-talk.
+    expect(parseSilenceThresholdDbfs("loud")).toBe(SILENCE_GATING_OFF_DBFS);
+    expect(parseSilenceThresholdDbfs("-Infinity")).toBe(SILENCE_GATING_OFF_DBFS);
   });
 });
 

--- a/live-audio/translation-bridge.ts
+++ b/live-audio/translation-bridge.ts
@@ -73,6 +73,13 @@ export type ReconnectTrigger = "goaway" | "close" | "resume";
 // not merely quiet. Recovery is attempted no more than once per stall window.
 const INPUT_STALL_MS = 15_000;
 const STALL_CHECK_INTERVAL_MS = 5_000;
+// Reconcile is the watchdog's level-1 recovery; this is level 2. If this many
+// consecutive stall windows pass with an apparently-live (unmuted, published) organizer
+// mic and still no frames, reconcile isn't fixing it — tear the bridge down so demand
+// (a listener re-requesting the language) recreates it from scratch, which is what the
+// manual redeploy did in the 2026-07-12 outage. A muted or unpublished mic never
+// escalates: that silence is expected, and recreating wouldn't (and shouldn't) end it.
+const STALL_ESCALATE_AFTER = 3;
 
 // Exponential-backoff bounds for failed Gemini reconnect attempts (mirrors the
 // Proclaim service's convention; see PROCLAIM_INTEGRATION.md).
@@ -340,6 +347,9 @@ export class TranslationBridge {
   private lastOrganizerFrameAt: number = 0;
   private lastStallRecoveryAt: number = 0;
   private stallWatchdog: ReturnType<typeof setInterval> | null = null;
+  // Stall windows in a row where reconcile didn't bring frames back (see
+  // STALL_ESCALATE_AFTER). Reset whenever frames arrive or the mic reads muted.
+  private consecutiveStallRecoveries: number = 0;
 
   // Persists finalized transcript segments into the shared Yjs doc.
   private readonly writer: TranscriptWriter | null;
@@ -473,7 +483,26 @@ export class TranslationBridge {
     }
     this.pipedTracks.clear();
 
-    // Stop any in-flight reconnect so it doesn't resurrect the socket after teardown.
+    this.teardownGeminiSide();
+
+    if (this.room) {
+      await this.room.disconnect();
+      this.room = null;
+    }
+
+    this.audioSource = null;
+    this.localTrack = null;
+    this.suspended = false;
+  }
+
+  /**
+   * Close the Gemini side completely: the active socket, any pending replacement, any
+   * scheduled retry, and the gap buffer. Used by stop() and by failure paths (room
+   * disconnect, watchdog escalation) where the bridge is done but must not leave a
+   * paid-for socket behind. The sockets' close handlers see a non-active status (or
+   * suspended) and won't reconnect.
+   */
+  private teardownGeminiSide(): void {
     this.reconnecting = false;
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
@@ -483,21 +512,11 @@ export class TranslationBridge {
       this.pendingWs.close();
       this.pendingWs = null;
     }
-
     if (this.geminiWs) {
       this.geminiWs.close();
       this.geminiWs = null;
     }
-
-    if (this.room) {
-      await this.room.disconnect();
-      this.room = null;
-    }
-
-    this.audioSource = null;
-    this.localTrack = null;
     this.geminiSetupComplete = false;
-    this.suspended = false;
     this.pendingFrames = [];
     this.bufferedSilenceRun = 0;
   }
@@ -528,7 +547,15 @@ export class TranslationBridge {
         `[TranslationBridge:${this.targetLanguage}] Disconnected from room (reason: ${DisconnectReason[reason] ?? reason})`
       );
       this.record("livekit_disconnected", { reason: DisconnectReason[reason] ?? String(reason) });
-      this.status = "closed";
+      // stop() disconnects the room deliberately, with status already "closed" — done.
+      if (this.status === "closed") return;
+      // Any other disconnect (duplicate identity, LiveKit server restart, connectivity
+      // loss past the SDK's resume) is a failure. "error" marks the bridge recreatable —
+      // ensureBridge treats it as stale, and listeners re-request the language when they
+      // see the translator gone. Drop the Gemini side too, so the bridge can't linger as
+      // a zombie holding a paid-for session that no audio will ever reach.
+      this.status = "error";
+      this.teardownGeminiSide();
     });
 
     this.room.on(RoomEvent.Reconnecting, () => {
@@ -1123,7 +1150,7 @@ export class TranslationBridge {
    * Safe to call at any time, from any trigger, as often as we like.
    */
   private reconcile(trigger: string): void {
-    if (!this.room || this.status === "closed") return;
+    if (!this.room || this.status === "closed" || this.status === "error") return;
     const subscribed = reconcileOrganizerAudio({
       organizerIdentity: this.organizerIdentity,
       participants: this.room.remoteParticipants.values(),
@@ -1143,6 +1170,10 @@ export class TranslationBridge {
     this.stallWatchdog = setInterval(() => {
       if (this.status !== "active") return;
       const now = Date.now();
+      // Frames since the last recovery mean it worked — the escalation clock resets.
+      if (this.lastOrganizerFrameAt > this.lastStallRecoveryAt) {
+        this.consecutiveStallRecoveries = 0;
+      }
       if (
         !shouldRecoverStalledInput({
           now,
@@ -1155,6 +1186,29 @@ export class TranslationBridge {
       }
       this.lastStallRecoveryAt = now;
       const stalledMs = now - this.lastOrganizerFrameAt;
+
+      // Level 2: reconcile has had its chances and frames never came back. Only when
+      // the organizer's mic *looks* live — a muted/unpublished mic is expected silence,
+      // and recreating the bridge wouldn't end it (just churn a Gemini session).
+      if (this.organizerHasUnmutedAudio()) {
+        this.consecutiveStallRecoveries++;
+        if (this.consecutiveStallRecoveries >= STALL_ESCALATE_AFTER) {
+          console.error(
+            `[TranslationBridge:${this.targetLanguage}] No organizer audio for ${stalledMs}ms after ${this.consecutiveStallRecoveries} reconcile attempts — tearing down for recreation`
+          );
+          this.record("organizer_audio_unrecoverable", {
+            stalledMs,
+            recoveries: this.consecutiveStallRecoveries,
+          });
+          // stop() leaves the room, so listeners see the translator vanish and
+          // re-request the language, which recreates the bridge from scratch.
+          void this.stop();
+          return;
+        }
+      } else {
+        this.consecutiveStallRecoveries = 0;
+      }
+
       console.warn(
         `[TranslationBridge:${this.targetLanguage}] No organizer audio for ${stalledMs}ms — reconciling subscription`
       );
@@ -1163,6 +1217,24 @@ export class TranslationBridge {
     }, STALL_CHECK_INTERVAL_MS);
     // Don't hold the process open on this timer alone.
     this.stallWatchdog.unref?.();
+  }
+
+  /**
+   * Does the organizer currently have an audio publication that isn't muted? Frames
+   * should be flowing from such a mic, so their sustained absence marks the input
+   * pipe as broken rather than merely quiet. `muted` can be undefined on some SDK
+   * paths; treat unknown as live so a broken pipe is never mistaken for a muted mic.
+   */
+  private organizerHasUnmutedAudio(): boolean {
+    if (!this.room) return false;
+    for (const participant of this.room.remoteParticipants.values()) {
+      if (participant.identity !== this.organizerIdentity) continue;
+      for (const [, pub] of participant.trackPublications) {
+        if (pub.kind !== TrackKind.KIND_AUDIO) continue;
+        if (pub.muted !== true) return true;
+      }
+    }
+    return false;
   }
 
   private pipeTrackToGemini(track: RemoteAudioTrack): void {

--- a/live-audio/translation-bridge.ts
+++ b/live-audio/translation-bridge.ts
@@ -108,16 +108,25 @@ const RECONNECT_BACKOFF = { initialMs: 1_000, maxMs: 30_000 };
 // Silence gating uses two thresholds, because "have we been silent long enough to
 // stop paying?" and "is there any sound here worth keeping?" want opposite biases.
 //
-// SILENCE_THRESHOLD_DBFS (the strict *voice* bar) drives the suspend clock and the
-// resume trigger: only clear speech keeps the session alive / wakes it, so room tone
-// doesn't burn money and faint noise doesn't wake it to hallucinate on nothing.
+// The *voice* bar (per-bridge, `silenceThresholdDbfs`) drives the suspend clock and
+// the resume trigger: only clear speech keeps the session alive / wakes it, so room
+// tone doesn't burn money and faint noise doesn't wake it to hallucinate on nothing.
+// That bar is also the feature's only switch. At SILENCE_GATING_OFF_DBFS every frame
+// reads as voice, so the suspend clock can never elapse and the bridge is a plain
+// always-on session — there is no second boolean to keep in sync with it, and no
+// configuration in which some of the gating machinery is live and the rest isn't.
+// SILENCE_THRESHOLD_DBFS is the level to use when you do want gating.
 //
 // SILENCE_FLOOR_DBFS (the *dead-air* floor, well below the voice bar) is the only
 // thing the gap-collapse is allowed to drop. An unvoiced consonant (/s/, /f/, a
 // plosive burst diluted across a 100 ms frame) can read below the voice bar but sits
 // far above this floor, so it is always kept — we never trade a clipped consonant
-// for lower latency. Only genuine near-digital dead air collapses.
+// for lower latency. Only genuine near-digital dead air collapses. It belongs to the
+// reconnect buffer, not to gating, so it stays fixed however the voice bar is set.
 export const SILENCE_THRESHOLD_DBFS = -30;
+// Gating off. `frameRmsDbfs` bottoms out at -Infinity for pure digital silence, and
+// the voice test is `>=`, so at this bar even a frame of zeroes counts as voice.
+export const SILENCE_GATING_OFF_DBFS = -Infinity;
 export const SILENCE_FLOOR_DBFS = -50;
 const SILENCE_SUSPEND_MS = 30_000;
 const SILENCE_CHECK_INTERVAL_MS = 5_000;
@@ -175,6 +184,20 @@ export function isSilentFrame(
   thresholdDbfs: number = SILENCE_THRESHOLD_DBFS
 ): boolean {
   return frameRmsDbfs(data) < thresholdDbfs;
+}
+
+/**
+ * Read the voice bar from its env value (`LIVE_AUDIO_SILENCE_THRESHOLD_DBFS`), in
+ * dBFS. Unset — or anything non-finite, including a literal "-Infinity" — means
+ * gating off, so the cost path is opted into by naming a level (e.g. `-30`) and
+ * never arrives by accident. Note the sign: dBFS is negative below full scale, so
+ * a *higher* bar gates more aggressively and `0` would treat all real speech as
+ * silence. That's the opposite of off.
+ */
+export function parseSilenceThresholdDbfs(raw: string | undefined): number {
+  if (raw == null || raw.trim() === "") return SILENCE_GATING_OFF_DBFS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : SILENCE_GATING_OFF_DBFS;
 }
 
 /**
@@ -388,12 +411,11 @@ export class TranslationBridge {
   private readonly writesSourceTranscript: boolean;
   // Telemetry sink (PostHog, injected by the server). Null in tests / when unset.
   private readonly recordEvent: RecordEvent | null;
-  // Cost optimization: when off (the default) the bridge never suspends its Gemini
-  // socket for silence — the silence monitor isn't started, so it behaves exactly as
-  // before this feature (always-on session). The goaway/reconnect buffering below is
-  // independent and always active. Gated so the reliability fixes can ship while the
-  // suspend/resume cost path is still being validated.
-  private readonly silenceGatingEnabled: boolean;
+  // The voice bar, in dBFS — the cost path's only knob. At SILENCE_GATING_OFF_DBFS
+  // (the default) every frame reads as voice, so the bridge never suspends and is a
+  // plain always-on session. The goaway/reconnect buffering is independent of this
+  // and always active.
+  private readonly silenceThresholdDbfs: number;
 
   // The source (input) transcript is published under this language code.
   static readonly SOURCE_CODE = "en";
@@ -410,7 +432,7 @@ export class TranslationBridge {
       writer?: TranscriptWriter | null;
       writesSourceTranscript?: boolean;
       recordEvent?: RecordEvent | null;
-      silenceGatingEnabled?: boolean;
+      silenceThresholdDbfs?: number;
     }
   ) {
     this.sessionId = sessionId;
@@ -424,7 +446,7 @@ export class TranslationBridge {
     this.writer = config.writer ?? null;
     this.writesSourceTranscript = config.writesSourceTranscript ?? false;
     this.recordEvent = config.recordEvent ?? null;
-    this.silenceGatingEnabled = config.silenceGatingEnabled ?? false;
+    this.silenceThresholdDbfs = config.silenceThresholdDbfs ?? SILENCE_GATING_OFF_DBFS;
   }
 
   /**
@@ -479,10 +501,10 @@ export class TranslationBridge {
 
       this.status = "active";
       // Start the silence clock now so an organizer who joins but never speaks
-      // still suspends after the grace window rather than immediately. Only when the
-      // cost path is enabled — otherwise the socket stays up for the whole session.
+      // still suspends after the grace window rather than immediately. Unconditional:
+      // the monitor itself no-ops when the voice bar is off.
       this.lastVoiceAt = Date.now();
-      if (this.silenceGatingEnabled) this.startSilenceMonitor();
+      this.startSilenceMonitor();
       console.log(
         `[TranslationBridge:${this.targetLanguage}] Bridge is active`
       );
@@ -941,9 +963,15 @@ export class TranslationBridge {
    * driven per-frame (the first non-silent frame reopens the socket), but this
    * timer also catches the case where the mic is muted and no frames arrive at
    * all — then `lastVoiceAt` simply stops advancing and the window elapses.
+   *
+   * That muted-mic path is why an off voice bar is checked here and not left to
+   * fall out of the per-frame test: with no frames at all there is nothing to read
+   * as voice, so the clock would elapse on a bridge that is meant never to suspend.
+   * This is the one place the switch is read; everywhere else the bar is just a bar.
    */
   private startSilenceMonitor(): void {
     if (this.silenceTimer) return;
+    if (this.silenceThresholdDbfs === SILENCE_GATING_OFF_DBFS) return;
     this.silenceTimer = setInterval(() => {
       if (this.status !== "active" || this.suspended) return;
       if (this.lastVoiceAt && Date.now() - this.lastVoiceAt > SILENCE_SUSPEND_MS) {
@@ -1361,7 +1389,7 @@ export class TranslationBridge {
     // raw level is passed on so the gap-collapse can tell a faint consonant (kept)
     // from genuine dead air (droppable).
     const dbfs = frameRmsDbfs(frame.data);
-    const isVoice = dbfs >= SILENCE_THRESHOLD_DBFS;
+    const isVoice = dbfs >= this.silenceThresholdDbfs;
     if (isVoice) {
       this.lastVoiceAt = Date.now();
       if (this.suspended) this.resumeFromSilence();

--- a/live-audio/translation-bridge.ts
+++ b/live-audio/translation-bridge.ts
@@ -55,6 +55,26 @@ import type { TranscriptWriter } from "./transcript-writer.ts";
 
 export type BridgeStatus = "starting" | "active" | "error" | "closed";
 
+/** The Gemini leg's state, derived for reporting (see health()). */
+export type GeminiLegState = "ready" | "connecting" | "backoff" | "suspended" | "down";
+
+/**
+ * Composite health snapshot. `status` alone is a single word that has twice read
+ * "active" through an outage; this is the honest version, surfaced by the status
+ * endpoint so dashboards and the supervisor can see which leg is actually unwell.
+ */
+export interface BridgeHealth {
+  status: BridgeStatus;
+  gemini: GeminiLegState;
+  /** Last time an organizer audio frame entered the bridge (0 = never). */
+  lastInputFrameAt: number;
+  /** Last time translated audio was published to LiveKit (0 = never). */
+  lastOutputFrameAt: number;
+  reconnects: number;
+  /** Gap-buffer depth right now — current added latency in frames. */
+  bufferedFrames: number;
+}
+
 /** Records a telemetry event. Implemented in the server over the PostHog client. */
 export type RecordEvent = (
   event: string,
@@ -327,6 +347,15 @@ export class TranslationBridge {
   // collapse dead air (see MAX_GAP_SILENCE_FRAMES).
   private bufferedSilenceRun: number = 0;
 
+  // Teardown epoch. Incremented whenever the Gemini side is torn down (stop, room
+  // failure, silence suspend), and captured by every socket's handlers when the
+  // socket is wired. A handler whose epoch is stale — its socket belongs to a life
+  // the bridge has already left — is dropped instead of acting, which closes the
+  // whole "async callback fires in a state it wasn't written for" class (e.g. a
+  // setupComplete racing a suspend and swapping a paid-for socket into a bridge
+  // that believes it has none).
+  private epoch: number = 0;
+
   // Reconnect state. `pendingWs` is a replacement socket being established (during
   // a make-before-break swap or a backoff retry); `reconnecting` guards against
   // launching two overlapping reconnects (e.g. goAway then the actual close).
@@ -396,6 +425,30 @@ export class TranslationBridge {
     this.writesSourceTranscript = config.writesSourceTranscript ?? false;
     this.recordEvent = config.recordEvent ?? null;
     this.silenceGatingEnabled = config.silenceGatingEnabled ?? false;
+  }
+
+  /**
+   * The Gemini leg's current state, derived from the connection fields rather than
+   * stored — so it can't drift from them. Reporting only; no behavior reads this.
+   */
+  private geminiLegState(): GeminiLegState {
+    if (this.suspended) return "suspended";
+    if (this.geminiWs && this.geminiSetupComplete) return "ready";
+    if (this.pendingWs) return "connecting";
+    if (this.reconnectTimer) return "backoff";
+    return "down";
+  }
+
+  /** Composite health snapshot for the status endpoint / supervisor / dashboards. */
+  health(): BridgeHealth {
+    return {
+      status: this.status,
+      gemini: this.geminiLegState(),
+      lastInputFrameAt: this.lastOrganizerFrameAt,
+      lastOutputFrameAt: this.lastAudioFrameTime,
+      reconnects: this.reconnectCount,
+      bufferedFrames: this.pendingFrames.length,
+    };
   }
 
   /** Emit a telemetry event tagged with this bridge's language and identity. */
@@ -503,6 +556,7 @@ export class TranslationBridge {
    * suspended) and won't reconnect.
    */
   private teardownGeminiSide(): void {
+    this.epoch++;
     this.reconnecting = false;
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
@@ -690,6 +744,8 @@ export class TranslationBridge {
   ): void {
     let openedAt = 0;
     let ready = false;
+    // The life of the bridge this socket belongs to; see the epoch field.
+    const wiredEpoch = this.epoch;
 
     ws.on("open", () => {
       openedAt = Date.now();
@@ -719,6 +775,27 @@ export class TranslationBridge {
       }
 
       if (message.setupComplete) {
+        // The bridge may have moved on while this socket was setting up — suspended
+        // for silence, stopped, or failed with its room. Swapping in then would strand
+        // an open, paid-for socket in a bridge that believes it has none. (status
+        // "starting" is fine: that's the initial socket completing during start().)
+        if (
+          wiredEpoch !== this.epoch ||
+          this.suspended ||
+          this.status === "closed" ||
+          this.status === "error"
+        ) {
+          console.log(
+            `[TranslationBridge:${this.targetLanguage}] Dropping stale setupComplete (${opts.role})`
+          );
+          this.record("gemini_stale_socket_dropped", { role: opts.role, trigger: opts.trigger });
+          try {
+            ws.close();
+          } catch {
+            // already closing
+          }
+          return;
+        }
         ready = true;
         this.onSocketReady(ws, opts.role, openedAt ? Date.now() - openedAt : 0, opts.trigger);
         return;
@@ -846,7 +923,7 @@ export class TranslationBridge {
   /** Open a replacement socket; it swaps in once its setup completes. */
   private openReplacement(trigger: ReconnectTrigger, attempt: number): void {
     this.reconnectTimer = null;
-    if (this.status !== "active") {
+    if (this.status !== "active" || this.suspended) {
       this.reconnecting = false;
       return;
     }
@@ -890,26 +967,12 @@ export class TranslationBridge {
       `[TranslationBridge:${this.targetLanguage}] Suspending Gemini after ${silentMs}ms of silence`
     );
     // Set suspended before closing so the socket's close handler treats this as an
-    // intentional teardown rather than a session drop to reconnect from.
+    // intentional teardown rather than a session drop to reconnect from. The shared
+    // teardown also drops any stale gap buffer (from here we only keep a short
+    // silence pre-roll) and bumps the epoch, so an in-flight setupComplete from
+    // before the suspend can't swap a socket back in.
     this.suspended = true;
-    this.geminiSetupComplete = false;
-    // Drop any stale gap buffer; from here we only keep a short silence pre-roll.
-    this.pendingFrames = [];
-    this.bufferedSilenceRun = 0;
-
-    this.reconnecting = false;
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
-    }
-    if (this.pendingWs) {
-      this.pendingWs.close();
-      this.pendingWs = null;
-    }
-    if (this.geminiWs) {
-      this.geminiWs.close();
-      this.geminiWs = null;
-    }
+    this.teardownGeminiSide();
 
     this.record("gemini_suspended_silence", {
       silentMs,

--- a/live-audio/translation-session-manager.test.ts
+++ b/live-audio/translation-session-manager.test.ts
@@ -23,7 +23,7 @@ const listener = (id: string, listen?: string): PresentParticipant => ({
 });
 
 describe("computeDesiredLanguages", () => {
-  const opts = { defaultLanguage: "fr", silenceGatingEnabled: false };
+  const opts = { defaultLanguage: "fr" };
 
   it("wants nothing without a broadcaster — the waiting room costs nothing", () => {
     // The 2026-07-19 outage shape: a listener waiting for the talk to start must not
@@ -44,19 +44,20 @@ describe("computeDesiredLanguages", () => {
     expect(computeDesiredLanguages([organizer, listener("a")], opts)).toEqual(new Set(["fr"]));
   });
 
-  it("wants nothing for a broadcaster alone with the cost path off", () => {
-    // An idle bridge burns a Gemini session; without silence-suspend, don't.
-    expect(computeDesiredLanguages([organizer], opts).size).toBe(0);
-  });
-
-  it("keeps the default bridge for a lone broadcaster with the cost path on", () => {
-    // Silence is ~free, so a live talk always gets its English transcript.
-    const desired = computeDesiredLanguages([organizer], { ...opts, silenceGatingEnabled: true });
-    expect(desired).toEqual(new Set(["fr"]));
+  it("runs the default bridge for a lone broadcaster, whatever the cost setting", () => {
+    // The default bridge is the sole writer of the English transcript, so it can't be
+    // conditional on listeners: a talk that starts before anyone tunes in must still be
+    // transcribed, or the first listener arrives mid-sentence with no history. Cost is
+    // the bridge's own concern (silenceThresholdDbfs), not a reason to not exist.
+    expect(computeDesiredLanguages([organizer], opts)).toEqual(new Set(["fr"]));
   });
 
   it("never counts translator bots as listeners", () => {
-    expect(computeDesiredLanguages([organizer, bot("es"), bot("fr")], opts).size).toBe(0);
+    // Only the default — the bots' own languages must not keep themselves alive, or a
+    // bridge nobody wants would justify its own existence and never wind down.
+    expect(computeDesiredLanguages([organizer, bot("es"), bot("fr")], opts)).toEqual(
+      new Set(["fr"])
+    );
   });
 });
 
@@ -138,7 +139,7 @@ class FakeBridge {
   async simulateScenario(): Promise<void> {}
 }
 
-function makeManager(rooms: Map<string, PresentParticipant[]>, opts?: { silenceGatingEnabled?: boolean }) {
+function makeManager(rooms: Map<string, PresentParticipant[]>) {
   const created: FakeBridge[] = [];
   const directory: RoomDirectory = {
     listRooms: async () => [...rooms.keys()],
@@ -154,7 +155,6 @@ function makeManager(rooms: Map<string, PresentParticipant[]>, opts?: { silenceG
     // only constructed lazily per session and these tests never await its sync.
     documentManager: null as unknown as DocumentManager,
     livekit: { url: "ws://fake", apiKey: "k", apiSecret: "s" },
-    silenceGatingEnabled: opts?.silenceGatingEnabled ?? false,
     directory,
     bridgeFactory: (sessionId, targetLanguage) => {
       const bridge = new FakeBridge(sessionId, targetLanguage);

--- a/live-audio/translation-session-manager.test.ts
+++ b/live-audio/translation-session-manager.test.ts
@@ -1,63 +1,296 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { isSessionHealthy } from "./translation-session-manager.ts";
+import type { DocumentManager } from "@y-sweet/sdk";
 
-// The presence reaper tears a session down once it is unhealthy past a grace
-// window. `isSessionHealthy` is that decision, and it depends on whether the cost
-// path is enabled.
-describe("isSessionHealthy", () => {
-  // Cost path ON (requireListener: false): keep running while a broadcaster is
-  // present, so a live talk always has at least an English transcript even with zero
-  // listeners. Silence suspension keeps an idle broadcaster cheap.
-  describe("with the cost path enabled (requireListener: false)", () => {
-    const healthy = (ids: string[]) => isSessionHealthy(ids, { requireListener: false });
+import {
+  computeDesiredLanguages,
+  planRoomActions,
+  TranslationSessionManager,
+  type PresentParticipant,
+  type RoomDirectory,
+} from "./translation-session-manager.ts";
+import type { TranslationBridge, BridgeStatus } from "./translation-bridge.ts";
 
-    it("is healthy with a listener and the broadcaster present", () => {
-      expect(healthy(["organizer-host", "translator-fr", "attendee-abc123"])).toBe(true);
-    });
+// ---------------------------------------------------------------------------
+// Pure decisions: the whole demand model and the reconcile diff.
+// ---------------------------------------------------------------------------
 
-    it("stays healthy with the broadcaster present but no listeners", () => {
-      // The always-on transcript case: the default translator keeps running so the
-      // organizer sees their English transcript even before anyone joins.
-      expect(healthy(["organizer-host", "translator-fr", "translator-es"])).toBe(true);
-    });
+const organizer: PresentParticipant = { identity: "organizer-host", attributes: { role: "organizer" } };
+const bot = (code: string): PresentParticipant => ({ identity: `translator-${code}` });
+const listener = (id: string, listen?: string): PresentParticipant => ({
+  identity: `attendee-${id}`,
+  attributes: listen ? { listen } : undefined,
+});
 
-    it("is unhealthy when the broadcaster has left (no source audio)", () => {
-      expect(healthy(["translator-fr", "attendee-abc123"])).toBe(false);
-    });
+describe("computeDesiredLanguages", () => {
+  const opts = { defaultLanguage: "fr", silenceGatingEnabled: false };
 
-    it("does not count translator bots as a broadcaster", () => {
-      expect(healthy(["translator-fr", "translator-es"])).toBe(false);
-    });
+  it("wants nothing without a broadcaster — the waiting room costs nothing", () => {
+    // The 2026-07-19 outage shape: a listener waiting for the talk to start must not
+    // spin bridges that immediately look idle; they start when the organizer appears.
+    expect(computeDesiredLanguages([listener("a", "es")], opts).size).toBe(0);
+    expect(computeDesiredLanguages([], opts).size).toBe(0);
   });
 
-  // Cost path OFF (the default): the original rule — a human listener AND a
-  // broadcaster must both be present, since without silence-suspend an idle bot would
-  // burn a Gemini session.
-  describe("with the cost path disabled (default, requireListener: true)", () => {
-    const healthy = (ids: string[]) => isSessionHealthy(ids, { requireListener: true });
-
-    it("is healthy with a listener and the broadcaster present", () => {
-      expect(healthy(["organizer-host", "translator-fr", "attendee-abc123"])).toBe(true);
-    });
-
-    it("is unhealthy with a broadcaster but no listeners (only bots remain)", () => {
-      expect(healthy(["organizer-host", "translator-fr", "translator-es"])).toBe(false);
-    });
-
-    it("is unhealthy when the broadcaster has left", () => {
-      expect(healthy(["translator-fr", "attendee-abc123"])).toBe(false);
-    });
-
-    it("defaults to requiring a listener when no options are passed", () => {
-      // The exported default is the conservative (cost-path-off) behavior.
-      expect(isSessionHealthy(["organizer-host", "translator-fr"])).toBe(false);
-      expect(isSessionHealthy(["organizer-host", "attendee-abc"])).toBe(true);
-    });
+  it("wants each listener's language plus the default (source-transcript) bridge", () => {
+    const desired = computeDesiredLanguages(
+      [organizer, listener("a", "es"), listener("b", "ht")],
+      opts
+    );
+    expect(desired).toEqual(new Set(["es", "ht", "fr"]));
   });
 
-  it("is unhealthy for an empty room in either mode", () => {
-    expect(isSessionHealthy([], { requireListener: false })).toBe(false);
-    expect(isSessionHealthy([], { requireListener: true })).toBe(false);
+  it("runs the default bridge for attribute-less listeners (older clients)", () => {
+    expect(computeDesiredLanguages([organizer, listener("a")], opts)).toEqual(new Set(["fr"]));
+  });
+
+  it("wants nothing for a broadcaster alone with the cost path off", () => {
+    // An idle bridge burns a Gemini session; without silence-suspend, don't.
+    expect(computeDesiredLanguages([organizer], opts).size).toBe(0);
+  });
+
+  it("keeps the default bridge for a lone broadcaster with the cost path on", () => {
+    // Silence is ~free, so a live talk always gets its English transcript.
+    const desired = computeDesiredLanguages([organizer], { ...opts, silenceGatingEnabled: true });
+    expect(desired).toEqual(new Set(["fr"]));
+  });
+
+  it("never counts translator bots as listeners", () => {
+    expect(computeDesiredLanguages([organizer, bot("es"), bot("fr")], opts).size).toBe(0);
+  });
+});
+
+describe("planRoomActions", () => {
+  const plan = (over: Partial<Parameters<typeof planRoomActions>[0]>) =>
+    planRoomActions({
+      desired: new Set<string>(),
+      running: [],
+      lastDesiredAt: new Map(),
+      now: 100_000,
+      stopGraceMs: 60_000,
+      ...over,
+    });
+
+  it("starts what is desired but missing", () => {
+    expect(plan({ desired: new Set(["es", "fr"]) })).toEqual({ start: ["es", "fr"], stop: [] });
+  });
+
+  it("restarts a bridge that died (error or closed) while still desired", () => {
+    const p = plan({
+      desired: new Set(["es", "fr"]),
+      running: [
+        { language: "es", status: "error" as BridgeStatus },
+        { language: "fr", status: "active" as BridgeStatus },
+      ],
+    });
+    expect(p.start).toEqual(["es"]);
+  });
+
+  it("holds an undesired bridge through the grace window, then stops it", () => {
+    const running = [{ language: "es", status: "active" as BridgeStatus }];
+    const lastDesiredAt = new Map([["es", 70_000]]);
+    expect(plan({ running, lastDesiredAt, now: 100_000 }).stop).toEqual([]); // 30s ago: hold
+    expect(plan({ running, lastDesiredAt, now: 140_000 }).stop).toEqual(["es"]); // 70s ago: stop
+  });
+
+  it("leaves a desired, active bridge alone", () => {
+    const p = plan({
+      desired: new Set(["es"]),
+      running: [{ language: "es", status: "active" as BridgeStatus }],
+    });
+    expect(p).toEqual({ start: [], stop: [] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The supervisor loop, wired: fake directory + fake bridges. These prove the
+// reconcile *runs and converges* — starts what presence demands (including from a
+// cold start, the server-restart case), recreates failures, and winds down
+// abandoned rooms. The pure tests above can't prove any of that.
+// ---------------------------------------------------------------------------
+
+class FakeBridge {
+  status: BridgeStatus = "starting";
+  subscriberCount = 0;
+  readonly identity: string;
+  constructor(
+    readonly sessionId: string,
+    readonly targetLanguage: string
+  ) {
+    this.identity = `translator-${targetLanguage}`;
+  }
+  async start(): Promise<void> {
+    this.status = "active";
+  }
+  async stop(): Promise<void> {
+    this.status = "closed";
+  }
+  health() {
+    return {
+      status: this.status,
+      gemini: "ready" as const,
+      lastInputFrameAt: 0,
+      lastOutputFrameAt: 0,
+      reconnects: 0,
+      bufferedFrames: 0,
+    };
+  }
+  async simulateScenario(): Promise<void> {}
+}
+
+function makeManager(rooms: Map<string, PresentParticipant[]>, opts?: { silenceGatingEnabled?: boolean }) {
+  const created: FakeBridge[] = [];
+  const directory: RoomDirectory = {
+    listRooms: async () => [...rooms.keys()],
+    listParticipants: async (room) => {
+      const p = rooms.get(room);
+      if (!p) throw new Error("room not found");
+      return p;
+    },
+  };
+  const manager = new TranslationSessionManager();
+  manager.init({
+    // The writer needs a real DocumentManager; null-object it — TranscriptWriter is
+    // only constructed lazily per session and these tests never await its sync.
+    documentManager: null as unknown as DocumentManager,
+    livekit: { url: "ws://fake", apiKey: "k", apiSecret: "s" },
+    silenceGatingEnabled: opts?.silenceGatingEnabled ?? false,
+    directory,
+    bridgeFactory: (sessionId, targetLanguage) => {
+      const bridge = new FakeBridge(sessionId, targetLanguage);
+      created.push(bridge);
+      return bridge as unknown as TranslationBridge;
+    },
+  });
+  return { manager, created, rooms };
+}
+
+const runningLanguages = (manager: TranslationSessionManager, sessionId: string) =>
+  manager
+    .getActiveTranslations(sessionId)
+    .filter((t) => t.status === "active")
+    .map((t) => t.language)
+    .sort();
+
+describe("TranslationSessionManager supervisor", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("builds bridges from presence alone — the server-restart recovery", async () => {
+    // Cold manager (empty maps), populated room: exactly the state after a redeploy
+    // mid-talk. One tick must rebuild everything the participants imply.
+    const { manager } = makeManager(
+      new Map([["doc-1", [organizer, listener("a", "es")]]])
+    );
+    await manager.reconcileAll();
+    expect(runningLanguages(manager, "doc-1")).toEqual(["es", "fr"]);
+  });
+
+  it("starts nothing for a waiting room, then everything when the broadcaster arrives", async () => {
+    const { manager, rooms } = makeManager(new Map([["doc-1", [listener("a", "es")]]]));
+    await manager.reconcileAll();
+    expect(manager.getActiveTranslations("doc-1")).toEqual([]);
+
+    rooms.set("doc-1", [organizer, listener("a", "es")]);
+    await manager.reconcileAll();
+    expect(runningLanguages(manager, "doc-1")).toEqual(["es", "fr"]);
+  });
+
+  it("recreates a bridge that failed while demand persists", async () => {
+    const { manager, created } = makeManager(
+      new Map([["doc-1", [organizer, listener("a", "es")]]])
+    );
+    await manager.reconcileAll();
+    const es = created.find((b) => b.targetLanguage === "es")!;
+    es.status = "error"; // e.g. its room connection dropped
+
+    // The start damper (START_RETRY_MS) keys off the last attempt; step past it.
+    await vi.advanceTimersByTimeAsync(31_000);
+    await manager.reconcileAll();
+
+    const esBridges = created.filter((b) => b.targetLanguage === "es");
+    expect(esBridges).toHaveLength(2);
+    expect(esBridges[1].status).toBe("active");
+    expect(runningLanguages(manager, "doc-1")).toEqual(["es", "fr"]);
+  });
+
+  it("winds a language down only after the demand grace", async () => {
+    const rooms = new Map([["doc-1", [organizer, listener("a", "es")]]]);
+    const { manager, created } = makeManager(rooms);
+    await manager.reconcileAll();
+
+    // The es listener leaves (page refresh, say) — bridge survives the grace...
+    rooms.set("doc-1", [organizer, listener("b", "fr")]);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await manager.reconcileAll();
+    expect(runningLanguages(manager, "doc-1")).toContain("es");
+
+    // ...and is stopped once demand has been gone for over a minute.
+    await vi.advanceTimersByTimeAsync(70_000);
+    await manager.reconcileAll();
+    expect(runningLanguages(manager, "doc-1")).toEqual(["fr"]);
+    expect(created.find((b) => b.targetLanguage === "es")!.status).toBe("closed");
+  });
+
+  it("tears the whole session down after everyone leaves", async () => {
+    const rooms = new Map([["doc-1", [organizer, listener("a", "es")]]]);
+    const { manager, created } = makeManager(rooms);
+    await manager.reconcileAll();
+
+    rooms.delete("doc-1"); // room gone from LiveKit entirely
+    await vi.advanceTimersByTimeAsync(70_000);
+    await manager.reconcileAll();
+
+    expect(manager.getActiveTranslations("doc-1")).toEqual([]);
+    for (const bridge of created) expect(bridge.status).toBe("closed");
+  });
+
+  it("skips the tick — no mass teardown — when LiveKit itself is unreadable", async () => {
+    const { manager } = makeManager(new Map([["doc-1", [organizer, listener("a", "es")]]]));
+    await manager.reconcileAll();
+
+    const blind: RoomDirectory = {
+      listRooms: async () => {
+        throw new Error("livekit down");
+      },
+      listParticipants: async () => [],
+    };
+    manager.init({
+      documentManager: null as unknown as DocumentManager,
+      livekit: { url: "ws://fake", apiKey: "k", apiSecret: "s" },
+      directory: blind,
+    });
+    await vi.advanceTimersByTimeAsync(300_000);
+    await manager.reconcileAll();
+
+    // A blind spot must read as "can't see", never as "rooms are empty".
+    expect(runningLanguages(manager, "doc-1")).toEqual(["es", "fr"]);
+  });
+
+  it("stamps per-language listener counts for the dashboard", async () => {
+    const { manager } = makeManager(
+      new Map([["doc-1", [organizer, listener("a", "es"), listener("b", "es"), listener("c", "fr")]]])
+    );
+    await manager.reconcileAll();
+    const infos = manager.getActiveTranslations("doc-1");
+    expect(infos.find((t) => t.language === "es")?.subscriberCount).toBe(2);
+    expect(infos.find((t) => t.language === "fr")?.subscriberCount).toBe(1);
+  });
+
+  it("getOrCreate stamps demand so a nudged language survives until presence shows it", async () => {
+    // A listener whose token predates the `listen` attribute nudges via /translate;
+    // the stamp must hold the bridge through the grace even though no attribute
+    // matches, and the supervisor must not stop it on its next tick.
+    const rooms = new Map([["doc-1", [organizer, listener("old-client")]]]);
+    const { manager } = makeManager(rooms);
+    const bridge = await manager.getOrCreate("doc-1", "es", "organizer-host");
+    expect(bridge.status).toBe("active");
+
+    await manager.reconcileAll();
+    expect(runningLanguages(manager, "doc-1")).toEqual(["es", "fr"]);
   });
 });

--- a/live-audio/translation-session-manager.ts
+++ b/live-audio/translation-session-manager.ts
@@ -1,7 +1,15 @@
 /**
- * TranslationSessionManager: Singleton that enforces "max 1 Gemini Live API
- * session per language per room" constraint, owns the per-session Yjs transcript
- * writer, and reaps idle translator bots.
+ * TranslationSessionManager: supervises translator bridges by reconciling the set of
+ * running bridges against LiveKit room presence — the single source of truth for demand.
+ *
+ * There is no listener refcount and no client beacon. Who is in the room, and what they
+ * asked to hear (the `listen` participant attribute their token carries), IS the demand
+ * signal; the supervisor loop diffs that against the bridges actually running and
+ * starts, stops, or recreates bridges to close the gap. The loop runs on an interval
+ * and on pokes (a token issued, a listener's /translate request), so every failure mode
+ * that loses a bridge — server restart, room disconnect, a crashed start — heals on the
+ * next tick as long as demand persists. Design rationale and the incident history are
+ * in docs/live-audio-state-architecture.md.
  *
  * Usage:
  *   const manager = TranslationSessionManager.getInstance();
@@ -15,7 +23,7 @@ import { RoomServiceClient } from "livekit-server-sdk";
 
 import { TranscriptWriter } from "./transcript-writer.ts";
 import { TranslationBridge } from "./translation-bridge.ts";
-import type { BridgeStatus } from "./translation-bridge.ts";
+import type { BridgeHealth, BridgeStatus } from "./translation-bridge.ts";
 
 /**
  * Minimal telemetry client (structurally satisfied by the PostHog node client).
@@ -34,12 +42,7 @@ export interface TranslationInfo {
   translatorIdentity: string;
   status: BridgeStatus;
   subscriberCount: number;
-}
-
-export interface SessionInfo {
-  sessionId: string;
-  organizerIdentity: string;
-  createdAt: Date;
+  health: BridgeHealth;
 }
 
 interface LiveKitConfig {
@@ -48,69 +51,156 @@ interface LiveKitConfig {
   apiSecret: string;
 }
 
-/**
- * Whether a translation session should stay alive (else the reaper tears it down).
- *
- * With the cost path enabled (`requireListener` false), a session is healthy while a
- * broadcaster (organizer) is present, so the default translator keeps running even
- * with zero listeners and a live talk always has at least an English transcript —
- * cheap because the bridge suspends its Gemini socket when the mic goes quiet.
- *
- * With the cost path off (`requireListener` true, the current default), we fall back
- * to the original rule: healthy only while a human listener AND a broadcaster are
- * both present, since without silence-suspend an idle bot would burn a Gemini session.
- *
- * Either way, no broadcaster means no source audio, so the session is always reaped.
- */
-export function isSessionHealthy(
-  participantIdentities: string[],
-  opts: { requireListener?: boolean } = {}
-): boolean {
-  // Default to the conservative (cost-path-off) rule so a caller that forgets the
-  // option doesn't accidentally keep listener-less sessions alive.
-  const requireListener = opts.requireListener ?? true;
-  const hasOrganizer = participantIdentities.some((id) => id.startsWith("organizer-"));
-  if (!hasOrganizer) return false;
-  if (!requireListener) return true;
-  return participantIdentities.some(
-    (id) => !id.startsWith("organizer-") && !id.startsWith("translator-")
-  );
+/** A room participant as the supervisor sees it: identity + token attributes. */
+export interface PresentParticipant {
+  identity: string;
+  attributes?: Record<string, string>;
 }
 
-class TranslationSessionManager {
+/**
+ * The supervisor's view of LiveKit — which rooms have participants, and who they are.
+ * Implemented over RoomServiceClient in production; injectable so the reconcile loop
+ * is testable without a LiveKit server.
+ */
+export interface RoomDirectory {
+  listRooms(): Promise<string[]>;
+  listParticipants(room: string): Promise<PresentParticipant[]>;
+}
+
+/** Participant attribute carrying a listener's requested translation language. */
+export const LISTEN_ATTRIBUTE = "listen";
+
+const ORGANIZER_PREFIX = "organizer-";
+const TRANSLATOR_PREFIX = "translator-";
+
+// The supervisor cadence, and the two dampers that keep it from thrashing:
+// a language keeps its bridge for STOP_GRACE_MS after demand last existed (so a page
+// refresh or a transient LiveKit read failure doesn't churn a Gemini session), and a
+// language whose bridge fails to start isn't retried for START_RETRY_MS (ensureBridge
+// already retries 3× internally per attempt).
+const RECONCILE_INTERVAL_MS = 10_000;
+const STOP_GRACE_MS = 60_000;
+const START_RETRY_MS = 30_000;
+
+/**
+ * Which translation languages should be running for a room, given who is present
+ * right now. The whole demand model in one pure function:
+ *
+ *   - No broadcaster → nothing runs. A listener waiting for the talk to start costs
+ *     nothing, and the bridge starts on the tick where the organizer appears — the
+ *     "waiting-room reap" outage (2026-07-19) is inexpressible in this shape.
+ *   - Broadcaster present → every language some listener's `listen` attribute names,
+ *     plus the default language (the source-transcript writer) while anyone is
+ *     listening — or unconditionally when the silence-gating cost path makes an idle
+ *     bridge ~free.
+ *
+ * Listeners without a `listen` attribute (older clients) still count as listeners, so
+ * the default bridge runs for them; their specific language arrives via the
+ * `/translate` nudge, which stamps demand directly.
+ */
+export function computeDesiredLanguages(
+  participants: PresentParticipant[],
+  opts: { defaultLanguage: string; silenceGatingEnabled: boolean }
+): Set<string> {
+  const desired = new Set<string>();
+  const hasBroadcaster = participants.some((p) => p.identity.startsWith(ORGANIZER_PREFIX));
+  if (!hasBroadcaster) return desired;
+
+  const listeners = participants.filter(
+    (p) => !p.identity.startsWith(ORGANIZER_PREFIX) && !p.identity.startsWith(TRANSLATOR_PREFIX)
+  );
+  for (const listener of listeners) {
+    const lang = listener.attributes?.[LISTEN_ATTRIBUTE];
+    if (lang) desired.add(lang);
+  }
+  if (opts.silenceGatingEnabled || listeners.length > 0) {
+    desired.add(opts.defaultLanguage);
+  }
+  return desired;
+}
+
+export interface RunningBridgeView {
+  language: string;
+  status: BridgeStatus;
+}
+
+/**
+ * Diff desired languages against running bridges into actions. Pure so the whole
+ * supervisor decision is unit-testable:
+ *
+ *   - start: desired but missing, or present in a dead state ("error"/"closed" —
+ *     ensureBridge cleans those up and recreates, so start doubles as recreate).
+ *   - stop: running but undesired for longer than the grace window.
+ */
+export function planRoomActions(params: {
+  desired: ReadonlySet<string>;
+  running: RunningBridgeView[];
+  lastDesiredAt: ReadonlyMap<string, number>;
+  now: number;
+  stopGraceMs: number;
+}): { start: string[]; stop: string[] } {
+  const start: string[] = [];
+  const stop: string[] = [];
+  const runningByLang = new Map(params.running.map((b) => [b.language, b]));
+
+  for (const lang of params.desired) {
+    const bridge = runningByLang.get(lang);
+    if (!bridge || bridge.status === "error" || bridge.status === "closed") start.push(lang);
+  }
+  for (const bridge of params.running) {
+    if (params.desired.has(bridge.language)) continue;
+    const last = params.lastDesiredAt.get(bridge.language) ?? 0;
+    if (params.now - last > params.stopGraceMs) stop.push(bridge.language);
+  }
+  return { start, stop };
+}
+
+/** Production RoomDirectory over the LiveKit server API. */
+function roomServiceDirectory(lk: LiveKitConfig): RoomDirectory {
+  const client = new RoomServiceClient(lk.url.replace(/^ws/, "http"), lk.apiKey, lk.apiSecret);
+  return {
+    listRooms: async () => (await client.listRooms()).map((r) => r.name),
+    listParticipants: async (room: string) =>
+      (await client.listParticipants(room)).map((p) => ({
+        identity: p.identity,
+        attributes: p.attributes,
+      })),
+  };
+}
+
+export class TranslationSessionManager {
   private static instance: TranslationSessionManager;
 
   // The primary/default translation language. It runs whenever anyone is
   // listening and is the sole writer of the source (English) transcript.
   static readonly DEFAULT_LANGUAGE = "fr";
 
-  private static readonly REAP_INTERVAL_MS = 30_000;
-  private static readonly REAP_GRACE_MS = 60_000;
-
   // Map<sessionId, Map<languageCode, TranslationBridge>>
   private translations: Map<string, Map<string, TranslationBridge>> = new Map();
-
-  // Map<sessionId, SessionInfo>
-  private sessions: Map<string, SessionInfo> = new Map();
 
   // Map<sessionId, TranscriptWriter> — one Yjs writer per session, shared by bridges.
   private writers: Map<string, TranscriptWriter> = new Map();
 
-  // Map<sessionId, epoch-ms> — last time the session had a listener AND a broadcaster.
-  private lastHealthyAt: Map<string, number> = new Map();
+  // Map<sessionId, Map<language, epoch-ms>> — when demand for a language last existed
+  // (a matching listener present, or a /translate nudge). Drives the stop grace.
+  private lastDesiredAt: Map<string, Map<string, number>> = new Map();
+
+  // Map<`${sessionId}:${language}`, epoch-ms> — last supervisor-initiated start
+  // attempt, so a language whose bridge won't start isn't retried every tick.
+  private lastStartAttemptAt: Map<string, number> = new Map();
 
   private documentManager: DocumentManager | null = null;
   private livekitConfig: LiveKitConfig | null = null;
   private telemetry: TelemetryClient | null = null;
-  private reaperTimer: ReturnType<typeof setInterval> | null = null;
+  private directory: RoomDirectory | null = null;
+  private bridgeFactory: typeof defaultBridgeFactory = defaultBridgeFactory;
+  private supervisorTimer: ReturnType<typeof setInterval> | null = null;
+  private reconciling = false;
 
   // Cost optimization master switch (default off). When off, bridges never suspend
-  // for silence and the session lifecycle keeps its original "listener + broadcaster"
-  // rule. When on, silence is free so the default translator stays up for any present
-  // broadcaster. See TranslationBridge.silenceGatingEnabled.
+  // for silence and the default bridge runs only while someone is listening. When on,
+  // silence is free so the default translator runs for any present broadcaster.
   private silenceGatingEnabled: boolean = false;
-
-  private constructor() {}
 
   static getInstance(): TranslationSessionManager {
     if (!TranslationSessionManager.instance) {
@@ -120,60 +210,55 @@ class TranslationSessionManager {
   }
 
   /**
-   * Provide the dependencies the manager needs to persist transcripts and reap
-   * idle bots. Called once from the server at boot.
+   * Provide the dependencies the manager needs to persist transcripts and supervise
+   * bridges. Called once from the server at boot; tests construct their own instance
+   * and inject a fake directory/bridge factory.
    */
   init(opts: {
     documentManager: DocumentManager;
     livekit: LiveKitConfig;
     telemetry?: TelemetryClient;
     silenceGatingEnabled?: boolean;
+    directory?: RoomDirectory;
+    bridgeFactory?: typeof defaultBridgeFactory;
   }): void {
     this.documentManager = opts.documentManager;
     this.livekitConfig = opts.livekit;
     this.telemetry = opts.telemetry ?? null;
     this.silenceGatingEnabled = opts.silenceGatingEnabled ?? false;
-    this.startReaper();
-  }
-
-  /** Whether the silence/cost path is enabled (drives lifecycle + bridge suspend). */
-  isSilenceGatingEnabled(): boolean {
-    return this.silenceGatingEnabled;
-  }
-
-  // Session management
-  createSession(sessionId: string, organizerIdentity: string): SessionInfo {
-    const info: SessionInfo = {
-      sessionId,
-      organizerIdentity,
-      createdAt: new Date(),
-    };
-    this.sessions.set(sessionId, info);
-    console.log(`[SessionManager] Created session ${sessionId} for organizer ${organizerIdentity}`);
-    return info;
-  }
-
-  getSession(sessionId: string): SessionInfo | undefined {
-    return this.sessions.get(sessionId);
+    this.directory = opts.directory ?? roomServiceDirectory(opts.livekit);
+    if (opts.bridgeFactory) this.bridgeFactory = opts.bridgeFactory;
+    this.startSupervisor();
   }
 
   /**
-   * Ensure translation is running for a language and return its bridge.
-   *
-   * Always keeps the English transcript available cheaply by ensuring the
-   * default/primary bridge (DEFAULT_LANGUAGE) runs while anyone is listening —
-   * it is the sole writer of the source transcript. The transcript is never
-   * cleared here: it accumulates in the day-scoped doc for accountability, so a
-   * transient drop-to-zero-listeners and rejoin can't wipe a live talk.
+   * Ask the supervisor to reconcile a room soon (fire-and-forget). Used by the token
+   * route so a broadcaster going live gets their bridges within seconds rather than
+   * on the next tick. Purely a latency optimization: the interval loop converges to
+   * the same state without it.
+   */
+  poke(sessionId: string): void {
+    void this.reconcileRoom(sessionId).catch((e) => {
+      console.error(`[SessionManager] poke reconcile failed for ${sessionId}:`, e);
+    });
+  }
+
+  /**
+   * Ensure translation is running for a language and return its bridge — the fast
+   * path behind POST /translate, so the response can carry the translator identity.
+   * Also stamps demand for the language, covering listeners whose token predates the
+   * `listen` attribute. The supervisor remains the authority on teardown; nothing
+   * here counts subscribers.
    */
   async getOrCreate(
     sessionId: string,
     targetLanguage: string,
     organizerIdentity: string
   ): Promise<TranslationBridge> {
-    // Protect a just-started session from being reaped before its first listener
-    // has finished joining the LiveKit room.
-    this.lastHealthyAt.set(sessionId, Date.now());
+    const now = Date.now();
+    const stamps = this.getStamps(sessionId);
+    stamps.set(targetLanguage, now);
+    stamps.set(TranslationSessionManager.DEFAULT_LANGUAGE, now);
 
     const writer = this.getOrCreateWriter(sessionId);
 
@@ -182,41 +267,21 @@ class TranslationSessionManager {
       sessionId,
       TranslationSessionManager.DEFAULT_LANGUAGE,
       organizerIdentity,
-      writer,
-      { countSubscriber: targetLanguage === TranslationSessionManager.DEFAULT_LANGUAGE, writesSourceTranscript: true }
+      writer
     );
-
     if (targetLanguage === TranslationSessionManager.DEFAULT_LANGUAGE) {
       return defaultBridge;
     }
-
-    return this.ensureBridge(sessionId, targetLanguage, organizerIdentity, writer, {
-      countSubscriber: true,
-      writesSourceTranscript: false,
-    });
+    return this.ensureBridge(sessionId, targetLanguage, organizerIdentity, writer);
   }
 
-  /**
-   * Ensure the default translator runs for a broadcasting session, independent of
-   * any listener. Called when the organizer starts broadcasting so there's always an
-   * English transcript. Doesn't count a subscriber — the reaper (broadcaster
-   * presence), not a listener count, keeps this bridge alive.
-   *
-   * No-op unless the cost path is enabled: without silence-suspend an always-on
-   * listener-less bridge would burn a Gemini session, so we keep the original
-   * demand-driven behavior until that's validated.
-   */
-  async ensureBroadcast(sessionId: string, organizerIdentity: string): Promise<void> {
-    if (!this.silenceGatingEnabled) return;
-    this.lastHealthyAt.set(sessionId, Date.now());
-    const writer = this.getOrCreateWriter(sessionId);
-    await this.ensureBridge(
-      sessionId,
-      TranslationSessionManager.DEFAULT_LANGUAGE,
-      organizerIdentity,
-      writer,
-      { countSubscriber: false, writesSourceTranscript: true }
-    );
+  private getStamps(sessionId: string): Map<string, number> {
+    let stamps = this.lastDesiredAt.get(sessionId);
+    if (!stamps) {
+      stamps = new Map();
+      this.lastDesiredAt.set(sessionId, stamps);
+    }
+    return stamps;
   }
 
   private getOrCreateWriter(sessionId: string): TranscriptWriter | null {
@@ -231,14 +296,14 @@ class TranslationSessionManager {
 
   /**
    * Create-or-reuse a single language's bridge, with a short retry on transient
-   * startup failures (LiveKit region discovery / Gemini WS can blip).
+   * startup failures (LiveKit region discovery / Gemini WS can blip). Only the
+   * default-language bridge transcribes the source audio.
    */
   private async ensureBridge(
     sessionId: string,
     targetLanguage: string,
     organizerIdentity: string,
-    writer: TranscriptWriter | null,
-    opts: { countSubscriber: boolean; writesSourceTranscript: boolean }
+    writer: TranscriptWriter | null
   ): Promise<TranslationBridge> {
     let languageMap = this.translations.get(sessionId);
     if (languageMap) {
@@ -246,7 +311,6 @@ class TranslationSessionManager {
       // Reuse active OR still-starting bridges so concurrent requests (common for
       // the default bridge) don't spin up duplicate Gemini sessions.
       if (existing && (existing.status === "active" || existing.status === "starting")) {
-        if (opts.countSubscriber) existing.subscriberCount++;
         return existing;
       }
       if (existing && (existing.status === "error" || existing.status === "closed")) {
@@ -275,7 +339,7 @@ class TranslationSessionManager {
       livekitApiKey: this.livekitConfig?.apiKey ?? process.env.LIVEKIT_API_KEY!,
       livekitApiSecret: this.livekitConfig?.apiSecret ?? process.env.LIVEKIT_API_SECRET!,
       writer,
-      writesSourceTranscript: opts.writesSourceTranscript,
+      writesSourceTranscript: targetLanguage === TranslationSessionManager.DEFAULT_LANGUAGE,
       recordEvent,
       silenceGatingEnabled: this.silenceGatingEnabled,
     };
@@ -285,13 +349,12 @@ class TranslationSessionManager {
     const MAX_START_ATTEMPTS = 3;
     let lastError: unknown;
     for (let attempt = 1; attempt <= MAX_START_ATTEMPTS; attempt++) {
-      const bridge = new TranslationBridge(sessionId, targetLanguage, organizerIdentity, config);
+      const bridge = this.bridgeFactory(sessionId, targetLanguage, organizerIdentity, config);
       // Store before starting so concurrent requests reuse this in-progress bridge.
       languageMap.set(targetLanguage, bridge);
 
       try {
         await bridge.start();
-        bridge.subscriberCount = opts.countSubscriber ? 1 : 0;
         return bridge;
       } catch (error) {
         lastError = error;
@@ -320,6 +383,7 @@ class TranslationSessionManager {
         translatorIdentity: bridge.identity,
         status: bridge.status,
         subscriberCount: bridge.subscriberCount,
+        health: bridge.health(),
       });
     }
     return result;
@@ -345,64 +409,6 @@ class TranslationSessionManager {
     return fired;
   }
 
-  /**
-   * Decrement subscriber count for a language (best-effort fast path). The
-   * presence reaper is the authoritative teardown, so this only needs to handle
-   * clean unsubscribes. The default bridge is intentionally left running here —
-   * it is torn down by the reaper when the session has no listeners at all.
-   */
-  async unsubscribe(sessionId: string, targetLanguage: string): Promise<void> {
-    const languageMap = this.translations.get(sessionId);
-    if (!languageMap) return;
-
-    const bridge = languageMap.get(targetLanguage);
-    if (!bridge) return;
-
-    bridge.subscriberCount = Math.max(0, bridge.subscriberCount - 1);
-    console.log(
-      `[SessionManager] Unsubscribed from ${targetLanguage} in session ${sessionId} (${bridge.subscriberCount} remaining)`
-    );
-
-    // With the cost path on, the default bridge is the always-on English-transcript
-    // source: keep it running while the broadcaster is present (the reaper tears it
-    // down once they leave). With the cost path off, fall through so it's torn down at
-    // zero subscribers like any other language (the original behavior).
-    if (this.silenceGatingEnabled && targetLanguage === TranslationSessionManager.DEFAULT_LANGUAGE) {
-      return;
-    }
-
-    if (bridge.subscriberCount === 0) {
-      console.log(`[SessionManager] No more subscribers for ${targetLanguage}, tearing down bridge`);
-      await bridge.stop();
-      languageMap.delete(targetLanguage);
-
-      if (languageMap.size === 0) {
-        await this.teardownSession(sessionId);
-      }
-    }
-  }
-
-  async removeTranslation(sessionId: string, targetLanguage: string): Promise<void> {
-    const languageMap = this.translations.get(sessionId);
-    if (!languageMap) return;
-
-    const bridge = languageMap.get(targetLanguage);
-    if (bridge) {
-      await bridge.stop();
-      languageMap.delete(targetLanguage);
-      console.log(`[SessionManager] Removed bridge for ${targetLanguage} in session ${sessionId}`);
-    }
-    if (languageMap.size === 0) {
-      await this.teardownSession(sessionId);
-    }
-  }
-
-  async removeAllTranslations(sessionId: string): Promise<void> {
-    await this.teardownSession(sessionId);
-    this.sessions.delete(sessionId);
-    console.log(`[SessionManager] Removed all bridges and session for ${sessionId}`);
-  }
-
   /** Stop every bridge for a session and close its transcript writer. */
   private async teardownSession(sessionId: string): Promise<void> {
     const languageMap = this.translations.get(sessionId);
@@ -420,70 +426,156 @@ class TranslationSessionManager {
       this.writers.delete(sessionId);
     }
 
-    this.lastHealthyAt.delete(sessionId);
-  }
-
-  getAllSessions(): SessionInfo[] {
-    return Array.from(this.sessions.values());
-  }
-
-  // ---------------------------------------------------------------------------
-  // Presence reaper: the authoritative teardown. A session whose broadcaster has
-  // left has no source audio to translate, so it's dead weight (still holding a
-  // Gemini session) and the whole session is torn down once it has been unhealthy
-  // past a grace window. With the cost path on, listener count no longer gates this —
-  // the default bridge stays up for the transcript while the broadcaster is present,
-  // and silence suspension keeps an idle broadcaster from costing anything. With it
-  // off, a session also needs a listener to stay healthy (the original rule).
-  // ---------------------------------------------------------------------------
-  private startReaper(): void {
-    if (this.reaperTimer) return;
-    this.reaperTimer = setInterval(() => {
-      void this.reapIdleSessions();
-    }, TranslationSessionManager.REAP_INTERVAL_MS);
-    // Don't keep the process alive solely for the reaper.
-    this.reaperTimer.unref?.();
-  }
-
-  async reapIdleSessions(): Promise<void> {
-    if (!this.livekitConfig || this.translations.size === 0) return;
-
-    const httpUrl = this.livekitConfig.url.replace(/^ws/, "http");
-    const client = new RoomServiceClient(
-      httpUrl,
-      this.livekitConfig.apiKey,
-      this.livekitConfig.apiSecret
-    );
-
-    const now = Date.now();
-    for (const sessionId of [...this.translations.keys()]) {
-      let healthy = false;
-      try {
-        const participants = await client.listParticipants(sessionId);
-        healthy = isSessionHealthy(participants.map((p) => p.identity), {
-          requireListener: !this.silenceGatingEnabled,
-        });
-      } catch {
-        // Room gone / not found → unhealthy.
-        healthy = false;
-      }
-
-      if (healthy) {
-        this.lastHealthyAt.set(sessionId, now);
-        continue;
-      }
-
-      const last = this.lastHealthyAt.get(sessionId) ?? now;
-      if (now - last > TranslationSessionManager.REAP_GRACE_MS) {
-        console.log(
-          `[SessionManager] Reaping session ${sessionId} — no broadcaster for ${Math.round(
-            (now - last) / 1000
-          )}s`
-        );
-        await this.teardownSession(sessionId);
-      }
+    this.lastDesiredAt.delete(sessionId);
+    for (const key of [...this.lastStartAttemptAt.keys()]) {
+      if (key.startsWith(`${sessionId}:`)) this.lastStartAttemptAt.delete(key);
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // The supervisor: a bidirectional reconciler. Every tick it drives the running
+  // set of bridges toward what room presence says should exist — creating what's
+  // missing (including after a server restart, when the in-memory maps are empty
+  // but the rooms are not), recreating what failed, and tearing down what nobody
+  // wants anymore. No single trigger is load-bearing, which is the same property
+  // the bridge's own input-side reconcile is built on.
+  // ---------------------------------------------------------------------------
+  private startSupervisor(): void {
+    if (this.supervisorTimer) return;
+    this.supervisorTimer = setInterval(() => {
+      void this.reconcileAll();
+    }, RECONCILE_INTERVAL_MS);
+    // Don't keep the process alive solely for the supervisor.
+    this.supervisorTimer.unref?.();
+  }
+
+  async reconcileAll(): Promise<void> {
+    if (!this.directory || this.reconciling) return;
+    this.reconciling = true;
+    try {
+      let roomNames: string[];
+      try {
+        roomNames = await this.directory.listRooms();
+      } catch (e) {
+        // Can't see LiveKit at all — skip the whole tick rather than mistake a
+        // blind spot for empty rooms and mass-teardown live sessions.
+        console.warn("[SessionManager] listRooms failed; skipping reconcile tick:", e);
+        return;
+      }
+      // Union: rooms with participants (may need bridges — the restart-recovery
+      // case) and rooms we hold bridges for (may need teardown).
+      const rooms = new Set([...roomNames, ...this.translations.keys()]);
+      for (const sessionId of rooms) {
+        await this.reconcileRoom(sessionId);
+      }
+    } finally {
+      this.reconciling = false;
+    }
+  }
+
+  async reconcileRoom(sessionId: string): Promise<void> {
+    if (!this.directory) return;
+    let participants: PresentParticipant[] = [];
+    try {
+      participants = await this.directory.listParticipants(sessionId);
+    } catch {
+      // Room gone or LiveKit briefly unreadable → no visible demand. The stop
+      // grace absorbs transient failures; a genuinely closed room winds down.
+    }
+
+    const desired = computeDesiredLanguages(participants, {
+      defaultLanguage: TranslationSessionManager.DEFAULT_LANGUAGE,
+      silenceGatingEnabled: this.silenceGatingEnabled,
+    });
+
+    const now = Date.now();
+    const stamps = this.getStamps(sessionId);
+    for (const lang of desired) stamps.set(lang, now);
+
+    const languageMap = this.translations.get(sessionId);
+    const running: RunningBridgeView[] = languageMap
+      ? [...languageMap.entries()].map(([language, b]) => ({ language, status: b.status }))
+      : [];
+
+    const plan = planRoomActions({
+      desired,
+      running,
+      lastDesiredAt: stamps,
+      now,
+      stopGraceMs: STOP_GRACE_MS,
+    });
+
+    for (const language of plan.stop) {
+      console.log(`[SessionManager] Supervisor stopping ${language} in ${sessionId} (no demand)`);
+      this.telemetry?.capture({
+        distinctId: sessionId,
+        event: "supervisor_bridge_stopped",
+        properties: { sessionId, language },
+      });
+      const bridge = languageMap?.get(language);
+      if (bridge) {
+        await bridge.stop().catch(() => {});
+        languageMap?.delete(language);
+      }
+    }
+    if (languageMap && languageMap.size === 0) this.translations.delete(sessionId);
+
+    // desired is non-empty only with a broadcaster present, so this is always set
+    // on the start path; the fallback only guards the type.
+    const organizerIdentity =
+      participants.find((p) => p.identity.startsWith(ORGANIZER_PREFIX))?.identity ??
+      "organizer-host";
+    const writer = plan.start.length > 0 ? this.getOrCreateWriter(sessionId) : null;
+    for (const language of plan.start) {
+      const key = `${sessionId}:${language}`;
+      if (now - (this.lastStartAttemptAt.get(key) ?? 0) < START_RETRY_MS) continue;
+      this.lastStartAttemptAt.set(key, now);
+      console.log(`[SessionManager] Supervisor starting ${language} in ${sessionId}`);
+      this.telemetry?.capture({
+        distinctId: sessionId,
+        event: "supervisor_bridge_started",
+        properties: { sessionId, language },
+      });
+      try {
+        await this.ensureBridge(sessionId, language, organizerIdentity, writer);
+      } catch (e) {
+        console.error(`[SessionManager] Supervisor start of ${language} in ${sessionId} failed:`, e);
+        this.telemetry?.capture({
+          distinctId: sessionId,
+          event: "supervisor_bridge_start_failed",
+          properties: { sessionId, language, message: (e as Error).message },
+        });
+      }
+    }
+
+    // Dashboard info: listeners per language, from the same presence snapshot.
+    // After the starts, so bridges created this tick get their count immediately.
+    for (const [language, bridge] of this.translations.get(sessionId) ?? []) {
+      bridge.subscriberCount = participants.filter(
+        (p) => p.attributes?.[LISTEN_ATTRIBUTE] === language
+      ).length;
+    }
+
+    // Session-level wind-down: nothing running, nothing wanted, nobody present.
+    if (
+      (this.translations.get(sessionId)?.size ?? 0) === 0 &&
+      desired.size === 0 &&
+      participants.length === 0 &&
+      (this.writers.has(sessionId) || this.lastDesiredAt.has(sessionId))
+    ) {
+      await this.teardownSession(sessionId);
+    }
+  }
+}
+
+/** Production bridge factory; tests inject a fake via init({ bridgeFactory }). */
+function defaultBridgeFactory(
+  sessionId: string,
+  targetLanguage: string,
+  organizerIdentity: string,
+  config: ConstructorParameters<typeof TranslationBridge>[3]
+): TranslationBridge {
+  return new TranslationBridge(sessionId, targetLanguage, organizerIdentity, config);
 }
 
 export default TranslationSessionManager;

--- a/live-audio/translation-session-manager.ts
+++ b/live-audio/translation-session-manager.ts
@@ -22,7 +22,7 @@ import type { DocumentManager } from "@y-sweet/sdk";
 import { RoomServiceClient } from "livekit-server-sdk";
 
 import { TranscriptWriter } from "./transcript-writer.ts";
-import { TranslationBridge } from "./translation-bridge.ts";
+import { SILENCE_GATING_OFF_DBFS, TranslationBridge } from "./translation-bridge.ts";
 import type { BridgeHealth, BridgeStatus } from "./translation-bridge.ts";
 
 /**
@@ -89,32 +89,34 @@ const START_RETRY_MS = 30_000;
  *   - No broadcaster → nothing runs. A listener waiting for the talk to start costs
  *     nothing, and the bridge starts on the tick where the organizer appears — the
  *     "waiting-room reap" outage (2026-07-19) is inexpressible in this shape.
- *   - Broadcaster present → every language some listener's `listen` attribute names,
- *     plus the default language (the source-transcript writer) while anyone is
- *     listening — or unconditionally when the silence-gating cost path makes an idle
- *     bridge ~free.
+ *   - Broadcaster present → the default language, always, plus every language some
+ *     listener's `listen` attribute names.
  *
- * Listeners without a `listen` attribute (older clients) still count as listeners, so
- * the default bridge runs for them; their specific language arrives via the
- * `/translate` nudge, which stamps demand directly.
+ * The default bridge is unconditional because it is not really a translation: it is
+ * the sole writer of the source (English) transcript, so tying it to listener count
+ * meant a talk with nobody yet listening transcribed nothing, and the first listener
+ * to arrive got a transcript starting mid-sentence. A live talk always gets its
+ * transcript; whether that bridge suspends itself through the quiet parts is the
+ * bridge's own business (see `silenceThresholdDbfs`), not a demand question.
+ *
+ * Listeners without a `listen` attribute (older clients, and anyone listening to the
+ * original audio) therefore need no special case: they read a transcript that is
+ * already being written.
  */
 export function computeDesiredLanguages(
   participants: PresentParticipant[],
-  opts: { defaultLanguage: string; silenceGatingEnabled: boolean }
+  opts: { defaultLanguage: string }
 ): Set<string> {
   const desired = new Set<string>();
   const hasBroadcaster = participants.some((p) => p.identity.startsWith(ORGANIZER_PREFIX));
   if (!hasBroadcaster) return desired;
 
-  const listeners = participants.filter(
-    (p) => !p.identity.startsWith(ORGANIZER_PREFIX) && !p.identity.startsWith(TRANSLATOR_PREFIX)
-  );
-  for (const listener of listeners) {
-    const lang = listener.attributes?.[LISTEN_ATTRIBUTE];
+  desired.add(opts.defaultLanguage);
+  for (const participant of participants) {
+    if (participant.identity.startsWith(ORGANIZER_PREFIX)) continue;
+    if (participant.identity.startsWith(TRANSLATOR_PREFIX)) continue;
+    const lang = participant.attributes?.[LISTEN_ATTRIBUTE];
     if (lang) desired.add(lang);
-  }
-  if (opts.silenceGatingEnabled || listeners.length > 0) {
-    desired.add(opts.defaultLanguage);
   }
   return desired;
 }
@@ -197,10 +199,10 @@ export class TranslationSessionManager {
   private supervisorTimer: ReturnType<typeof setInterval> | null = null;
   private reconciling = false;
 
-  // Cost optimization master switch (default off). When off, bridges never suspend
-  // for silence and the default bridge runs only while someone is listening. When on,
-  // silence is free so the default translator runs for any present broadcaster.
-  private silenceGatingEnabled: boolean = false;
+  // The voice bar handed to every bridge, in dBFS. Off by default, in which case
+  // bridges never suspend for silence. Purely a per-bridge cost setting — it has no
+  // say in which bridges exist (see computeDesiredLanguages).
+  private silenceThresholdDbfs: number = SILENCE_GATING_OFF_DBFS;
 
   static getInstance(): TranslationSessionManager {
     if (!TranslationSessionManager.instance) {
@@ -218,14 +220,14 @@ export class TranslationSessionManager {
     documentManager: DocumentManager;
     livekit: LiveKitConfig;
     telemetry?: TelemetryClient;
-    silenceGatingEnabled?: boolean;
+    silenceThresholdDbfs?: number;
     directory?: RoomDirectory;
     bridgeFactory?: typeof defaultBridgeFactory;
   }): void {
     this.documentManager = opts.documentManager;
     this.livekitConfig = opts.livekit;
     this.telemetry = opts.telemetry ?? null;
-    this.silenceGatingEnabled = opts.silenceGatingEnabled ?? false;
+    this.silenceThresholdDbfs = opts.silenceThresholdDbfs ?? SILENCE_GATING_OFF_DBFS;
     this.directory = opts.directory ?? roomServiceDirectory(opts.livekit);
     if (opts.bridgeFactory) this.bridgeFactory = opts.bridgeFactory;
     this.startSupervisor();
@@ -341,7 +343,7 @@ export class TranslationSessionManager {
       writer,
       writesSourceTranscript: targetLanguage === TranslationSessionManager.DEFAULT_LANGUAGE,
       recordEvent,
-      silenceGatingEnabled: this.silenceGatingEnabled,
+      silenceThresholdDbfs: this.silenceThresholdDbfs,
     };
 
     console.log(`[SessionManager] Creating new bridge for ${targetLanguage} in session ${sessionId}`);
@@ -485,7 +487,6 @@ export class TranslationSessionManager {
 
     const desired = computeDesiredLanguages(participants, {
       defaultLanguage: TranslationSessionManager.DEFAULT_LANGUAGE,
-      silenceGatingEnabled: this.silenceGatingEnabled,
     });
 
     const now = Date.now();

--- a/server.ts
+++ b/server.ts
@@ -236,12 +236,26 @@ app.post('/api/livekit/token', async (req, res) => {
     const room = req.body?.room as string | undefined;
     const identity = req.body?.identity as string | undefined;
     const role = (req.body?.role as string | undefined) ?? 'attendee';
+    // The language this listener wants translated (BCP-47). Carried as a participant
+    // attribute so the translation supervisor can read demand straight from room
+    // presence — no refcount, no beacon. Optional: attribute-less listeners still get
+    // the default bridge, and their /translate request stamps their language.
+    const listenLanguage = req.body?.listenLanguage as string | undefined;
     if (!room || !identity) {
       return res.status(400).json({ error: 'Missing room or identity' });
     }
 
     const isOrganizer = role === 'organizer';
-    const at = new AccessToken(lk.apiKey, lk.apiSecret, { identity, name: identity, ttl: '4h' });
+    const at = new AccessToken(lk.apiKey, lk.apiSecret, {
+      identity,
+      name: identity,
+      ttl: '4h',
+      attributes: isOrganizer
+        ? { role: 'organizer' }
+        : listenLanguage
+          ? { listen: listenLanguage }
+          : undefined,
+    });
     at.addGrant({
       roomJoin: true,
       room,
@@ -251,19 +265,11 @@ app.post('/api/livekit/token', async (req, res) => {
     });
     const token = await at.toJwt();
 
-    // A broadcaster requesting a publish token IS the signal that a talk is live, so
-    // ensure the default translator runs even before any listener joins — a live talk
-    // always has at least an English transcript. Fire-and-forget: don't block or fail
-    // token issuance on bridge startup; the bridge waits for the organizer's audio,
-    // and the reaper cleans up if they never actually connect.
-    if (isOrganizer) {
-      void TranslationSessionManager.getInstance()
-        .ensureBroadcast(room, ORGANIZER_IDENTITY)
-        .catch((e) => {
-          phClient.captureException(e);
-          console.error('ensureBroadcast failed:', e);
-        });
-    }
+    // A token request means room presence is about to change — poke the translation
+    // supervisor so it reconciles this room within seconds instead of on its next
+    // tick. Delayed a beat so the requester has actually joined by the time the
+    // supervisor looks. Latency-only: the interval loop converges regardless.
+    setTimeout(() => TranslationSessionManager.getInstance().poke(room), 2_000).unref?.();
 
     return res.json({ token, serverUrl: lk.url });
   } catch (error) {
@@ -314,18 +320,15 @@ app.get('/api/livekit/translate/status', (req, res) => {
   }
 });
 
-// Decrement a language's listener count; the bot tears down at zero.
-// POST so navigator.sendBeacon can call it on page unload.
-app.post('/api/livekit/translate/unsubscribe', async (req, res) => {
+// Legacy endpoint, kept for clients cached from before the presence supervisor.
+// Leaving the LiveKit room is now the real "unsubscribe" signal; a beacon here just
+// nudges the supervisor to notice sooner.
+app.post('/api/livekit/translate/unsubscribe', (req, res) => {
   try {
     if (!getLiveKitConfig()) return res.status(503).json({ error: 'LiveKit not configured' });
     const sessionId = req.body?.sessionId as string | undefined;
-    const targetLanguage = req.body?.targetLanguage as string | undefined;
-    if (!sessionId || !targetLanguage) {
-      return res.status(400).json({ error: 'Missing sessionId or targetLanguage' });
-    }
-    const manager = TranslationSessionManager.getInstance();
-    await manager.unsubscribe(sessionId, targetLanguage);
+    if (!sessionId) return res.status(400).json({ error: 'Missing sessionId' });
+    TranslationSessionManager.getInstance().poke(sessionId);
     return res.json({ success: true });
   } catch (error) {
     phClient.captureException(error);

--- a/server.ts
+++ b/server.ts
@@ -31,6 +31,7 @@ import { buildSessionExport, renderSessionHtml, sessionExportFilename } from './
 import { AccessToken } from 'livekit-server-sdk';
 import { SimulateScenarioKind } from '@livekit/rtc-node';
 import TranslationSessionManager from './live-audio/translation-session-manager.ts';
+import { parseSilenceThresholdDbfs } from './live-audio/translation-bridge.ts';
 
 // Get API keys from environment variables, crash if not set
 function getEnvOrCrash(name: string): string {
@@ -205,11 +206,12 @@ function getLiveKitConfig(): { url: string; apiKey: string; apiSecret: string } 
   return { url, apiKey, apiSecret };
 }
 
-// Cost optimization (silence suspend/resume + always-on default translator) is off
-// unless LIVE_AUDIO_SILENCE_GATING is truthy, so the goaway/reliability fixes can
-// ship while the cost path is still being validated. The goaway/reconnect buffering
-// is independent and always on.
-const SILENCE_GATING_ENABLED = /^(1|true|yes|on)$/i.test(process.env.LIVE_AUDIO_SILENCE_GATING ?? '');
+// The cost path's only knob: the dBFS level below which the organizer's mic counts as
+// silence, at which point a bridge suspends its Gemini socket. Unset (the default)
+// means bridges never suspend. The goaway/reconnect buffering is independent of this
+// and always on, as is the default translator — silence gating no longer decides
+// which bridges exist, only what an existing one does while nobody is speaking.
+const SILENCE_THRESHOLD_DBFS = parseSilenceThresholdDbfs(process.env.LIVE_AUDIO_SILENCE_THRESHOLD_DBFS);
 
 // Give the translation manager what it needs to persist transcripts into Yjs and
 // reap idle translator bots. No-op for transcript/reaper if LiveKit is unconfigured.
@@ -220,9 +222,13 @@ const SILENCE_GATING_ENABLED = /^(1|true|yes|on)$/i.test(process.env.LIVE_AUDIO_
       documentManager,
       livekit: lk,
       telemetry: phClient,
-      silenceGatingEnabled: SILENCE_GATING_ENABLED,
+      silenceThresholdDbfs: SILENCE_THRESHOLD_DBFS,
     });
-    console.log(`[server] Live-audio silence gating (cost path): ${SILENCE_GATING_ENABLED ? 'ENABLED' : 'disabled'}`);
+    console.log(
+      `[server] Live-audio silence gating (cost path): ${
+        Number.isFinite(SILENCE_THRESHOLD_DBFS) ? `${SILENCE_THRESHOLD_DBFS} dBFS` : 'disabled'
+      }`
+    );
   }
 }
 

--- a/src/ListenViewer.test.tsx
+++ b/src/ListenViewer.test.tsx
@@ -1,12 +1,17 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ListenViewer } from "./ListenViewer";
 
 interface MockProps {
   children: React.ReactNode;
   className?: string;
 }
+
+// Who useRemoteParticipants reports; tests set this before rendering.
+const roomState = vi.hoisted(() => ({
+  participants: [] as Array<{ identity: string; trackPublications: Map<string, never> }>,
+}));
 
 vi.mock("./useLocale", () => ({
   LANGUAGE_BCP47: { French: "fr", English: "en" },
@@ -15,6 +20,7 @@ vi.mock("./useLocale", () => ({
     stopAudio: "Stop audio",
     liveListening: "Live listening",
     waitingForSpeaker: "Waiting for speaker",
+    restartingTranslation: "Restarting translation",
     retry: "Retry",
     connecting: "Connecting",
     liveAudioError: "Live audio error",
@@ -41,18 +47,31 @@ vi.mock("@livekit/components-react", () => {
     ),
     RoomAudioRenderer: () => null,
     useRoomContext: () => null,
-    useRemoteParticipants: () => [],
+    useRemoteParticipants: () => roomState.participants,
   };
 });
 
+const participant = (identity: string) => ({
+  identity,
+  trackPublications: new Map<string, never>(),
+});
+
 describe("ListenViewer", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  // How many times the client has asked the server for a translator bot. Exact-path
+  // match: the unsubscribe beacon and token requests must not count.
+  const translateRequests = () =>
+    fetchMock.mock.calls.filter(([input]) => input === "/api/livekit/translate").length;
+
   beforeEach(() => {
+    roomState.participants = [];
     Object.defineProperty(window.navigator, "sendBeacon", {
       configurable: true,
       value: vi.fn(() => true),
     });
 
-    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+    fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.includes("/api/livekit/translate")) {
         return Promise.resolve({
@@ -73,6 +92,10 @@ describe("ListenViewer", () => {
     vi.stubGlobal("fetch", fetchMock);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("keeps the LiveKit room from forcing the whole pane to full height", async () => {
     const user = userEvent.setup();
     render(<ListenViewer language="fr" />);
@@ -84,5 +107,45 @@ describe("ListenViewer", () => {
     expect(screen.getByTestId("livekit-room")).toHaveClass("w-full");
     expect(screen.getByTestId("livekit-room")).toHaveClass("shrink-0");
     expect(screen.getByTestId("livekit-room")).toHaveClass("h-auto");
+  });
+
+  it("re-requests a missing translator while the speaker is broadcasting", async () => {
+    // The self-heal loop: the server lost our bot (restart, reap, room drop) and nothing
+    // server-side recreates it — the client must ask again. Speaker present, bot absent.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    roomState.participants = [participant("organizer-host")];
+    render(<ListenViewer language="French" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /listen live/i }));
+    await waitFor(() => expect(screen.getByTestId("livekit-room")).toBeInTheDocument());
+    expect(translateRequests()).toBe(1); // the opt-in request
+
+    // The degraded state is visible, not just silent retrying.
+    expect(screen.getByText(/restarting translation/i)).toBeInTheDocument();
+
+    // Past the grace window, the ensure loop asks the server again.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_500);
+    });
+    expect(translateRequests()).toBe(2);
+  });
+
+  it("does not churn against the reaper while waiting for the broadcast to start", async () => {
+    // The waiting-room case (2026-07-19): pre-broadcast, the server reaps translator-less
+    // sessions, so re-requesting in a loop would fight it. With no organizer in the room,
+    // the ensure loop must stay quiet — it fires only once the speaker appears.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    roomState.participants = []; // nobody broadcasting yet
+    render(<ListenViewer language="French" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /listen live/i }));
+    await waitFor(() => expect(screen.getByTestId("livekit-room")).toBeInTheDocument());
+    expect(translateRequests()).toBe(1);
+    expect(screen.getByText(/waiting for speaker/i)).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(35_000);
+    });
+    expect(translateRequests()).toBe(1); // still just the opt-in request
   });
 });

--- a/src/ListenViewer.tsx
+++ b/src/ListenViewer.tsx
@@ -10,7 +10,7 @@
 // healthy. The tradeoff (accepted deliberately) is that the transcript stays dark
 // until the first listener in a session opts in — no viewer holds a LiveKit
 // connection just to read. In other words: read for free, opt in to hear.
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   LiveKitRoom,
   RoomAudioRenderer,
@@ -25,6 +25,10 @@ import { LiveTranscript } from "./LiveTranscript";
 import { getDocId } from "./getDocId";
 
 const ORGANIZER_PREFIX = "organizer-";
+
+// How often to re-request a missing translator bot (and the grace we give a
+// just-requested one to appear before the first re-request).
+const ENSURE_TRANSLATOR_INTERVAL_MS = 10_000;
 
 interface ConnectInfo {
   token: string;
@@ -71,6 +75,43 @@ function ListenAudio({
   const speakerPresent = remoteParticipants.some((p) =>
     p.identity.startsWith(ORGANIZER_PREFIX)
   );
+  // The bot we depend on (for translated audio, or just the transcript when
+  // listening to the original). Identities are deterministic: translator-<code>.
+  const translatorPresent = remoteParticipants.some(
+    (p) => p.identity === `translator-${releaseTarget}`
+  );
+
+  // Self-heal: the server can lose our translator (restart, presence reap, its room
+  // connection dropping) and nothing server-side recreates it — so while the speaker
+  // is broadcasting without our bot, periodically re-request it. Gated on speaker
+  // presence so a pre-broadcast wait doesn't churn against the server's presence
+  // reaper (docs/live-audio-state-architecture.md, "the waiting-room reap"): the
+  // re-request then fires exactly when the session becomes healthy, so it sticks.
+  const needsTranslator = speakerPresent && !translatorPresent;
+  const lastEnsureRef = useRef(0);
+  // Stamp mount time (not in render — Date.now is impure there) so the bot the parent
+  // just requested gets one full interval to appear before the first re-request.
+  useEffect(() => {
+    lastEnsureRef.current = Date.now();
+  }, []);
+  useEffect(() => {
+    if (!needsTranslator) return;
+    const ensure = () => {
+      const now = Date.now();
+      if (now - lastEnsureRef.current < ENSURE_TRANSLATOR_INTERVAL_MS) return;
+      lastEnsureRef.current = now;
+      void fetch("/api/livekit/translate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: docId, targetLanguage: releaseTarget }),
+      }).catch(() => {
+        // Transient; the next tick retries.
+      });
+    };
+    ensure();
+    const id = setInterval(ensure, ENSURE_TRANSLATOR_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [needsTranslator, docId, releaseTarget]);
 
   // Subscribe to the audio we want only while audio is enabled: the translator
   // bot for a translation, or the speaker's raw mic for "Original / English".
@@ -109,18 +150,28 @@ function ListenAudio({
     };
   }, [docId, releaseTarget]);
 
+  // Three-light status: gray = no speaker, amber = speaker is live but our
+  // translator is missing (being re-requested above), green = fully wired. For
+  // original audio the translator only carries the transcript, so its absence
+  // doesn't demote the light — the audio the listener chose is unaffected.
+  const degraded = needsTranslator && !isOriginal;
+  const dotClass = !speakerPresent
+    ? "bg-gray-400"
+    : degraded
+      ? "bg-amber-500 animate-pulse"
+      : "bg-green-500 animate-pulse";
+  const statusText = !speakerPresent
+    ? s.waitingForSpeaker
+    : degraded
+      ? s.restartingTranslation
+      : s.liveListening;
+
   return (
     <>
       <RoomAudioRenderer />
       <div className="flex items-center gap-2 text-xs">
-        <span
-          className={`inline-block w-2 h-2 rounded-full ${
-            speakerPresent ? "bg-green-500 animate-pulse" : "bg-gray-400"
-          }`}
-        />
-        <span className="text-gray-600 dark:text-gray-300">
-          {speakerPresent ? s.liveListening : s.waitingForSpeaker}
-        </span>
+        <span className={`inline-block w-2 h-2 rounded-full ${dotClass}`} />
+        <span className="text-gray-600 dark:text-gray-300">{statusText}</span>
         <div className="flex-1" />
         <button
           type="button"

--- a/src/ListenViewer.tsx
+++ b/src/ListenViewer.tsx
@@ -5,11 +5,11 @@
 // this pane and never disturbs the outline / slide views.
 //
 // The transcript shows immediately and unconditionally (it reads the shared Yjs
-// doc, no LiveKit needed). Nothing touches LiveKit until the listener presses
-// "Listen Live": that join both spins up the translator bot and keeps the session
-// healthy. The tradeoff (accepted deliberately) is that the transcript stays dark
-// until the first listener in a session opts in — no viewer holds a LiveKit
-// connection just to read. In other words: read for free, opt in to hear.
+// doc, no LiveKit needed), and the server writes it for any live broadcaster
+// whether or not anyone is listening — so a viewer who never presses "Listen Live"
+// still reads the talk from its first word, and one who presses it late gets the
+// history. Nothing here touches LiveKit until they do press it. Read for free, opt
+// in to hear.
 import { useEffect, useRef, useState } from "react";
 import {
   LiveKitRoom,
@@ -20,11 +20,12 @@ import {
 import "@livekit/components-styles";
 import { Track } from "livekit-client";
 import { LANGUAGE_BCP47, useStrings } from "./useLocale";
-import { LISTEN_ORIGINAL_CODE, DEFAULT_LISTEN_CODE } from "./listenLanguages";
+import { LISTEN_ORIGINAL_CODE } from "./listenLanguages";
 import { LiveTranscript } from "./LiveTranscript";
 import { getDocId } from "./getDocId";
 
 const ORGANIZER_PREFIX = "organizer-";
+const TRANSLATOR_PREFIX = "translator-";
 
 // How often to re-request a missing translator bot (and the grace we give a
 // just-requested one to appear before the first re-request).
@@ -55,16 +56,14 @@ interface TokenResp {
 // rendered by the parent, outside the room.
 function ListenAudio({
   docId,
-  translateTarget,
+  translatorLanguage,
   translatorIdentity,
-  isOriginal,
   audioOn,
   onToggleAudio,
 }: {
   docId: string;
-  translateTarget: string;
+  translatorLanguage: string | null;
   translatorIdentity: string | null;
-  isOriginal: boolean;
   audioOn: boolean;
   onToggleAudio: () => void;
 }) {
@@ -75,11 +74,15 @@ function ListenAudio({
   const speakerPresent = remoteParticipants.some((p) =>
     p.identity.startsWith(ORGANIZER_PREFIX)
   );
-  // The bot we depend on (for translated audio, or just the transcript when
-  // listening to the original). Identities are deterministic: translator-<code>.
-  const translatorPresent = remoteParticipants.some(
-    (p) => p.identity === `translator-${translateTarget}`
-  );
+  // What this pane depends on beyond the speaker. For a translation it's our own bot
+  // (identities are deterministic: translator-<code>). For original audio the speaker's
+  // mic is the audio, but the transcript still comes from a bot — the server's default
+  // bridge — so *some* translator has to be present for this pane to be fully working.
+  // Checking the prefix rather than naming that language keeps the server's choice of
+  // default out of the client.
+  const translatorPresent = translatorLanguage
+    ? remoteParticipants.some((p) => p.identity === `translator-${translatorLanguage}`)
+    : remoteParticipants.some((p) => p.identity.startsWith(TRANSLATOR_PREFIX));
 
   // Self-heal backstop: the server's presence supervisor recreates lost bridges from
   // our `listen` attribute, but if that path is ever wrong or slow, re-requesting
@@ -95,7 +98,10 @@ function ListenAudio({
     lastEnsureRef.current = Date.now();
   }, []);
   useEffect(() => {
-    if (!needsTranslator) return;
+    // Only a translation is ours to re-request. The default bridge that writes the
+    // transcript isn't requested by anyone — the supervisor runs it for any live
+    // broadcaster — so on original audio there is nothing for us to ensure.
+    if (!needsTranslator || !translatorLanguage) return;
     const ensure = () => {
       const now = Date.now();
       if (now - lastEnsureRef.current < ENSURE_TRANSLATOR_INTERVAL_MS) return;
@@ -103,7 +109,7 @@ function ListenAudio({
       void fetch("/api/livekit/translate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId: docId, targetLanguage: translateTarget }),
+        body: JSON.stringify({ sessionId: docId, targetLanguage: translatorLanguage }),
       }).catch(() => {
         // Transient; the next tick retries.
       });
@@ -111,7 +117,7 @@ function ListenAudio({
     ensure();
     const id = setInterval(ensure, ENSURE_TRANSLATOR_INTERVAL_MS);
     return () => clearInterval(id);
-  }, [needsTranslator, docId, translateTarget]);
+  }, [needsTranslator, docId, translatorLanguage]);
 
   // Subscribe to the audio we want only while audio is enabled: the translator
   // bot for a translation, or the speaker's raw mic for "Original / English".
@@ -123,33 +129,35 @@ function ListenAudio({
     for (const participant of remoteParticipants) {
       const wanted =
         audioOn &&
-        (isOriginal
-          ? participant.identity.startsWith(ORGANIZER_PREFIX)
-          : participant.identity === translatorIdentity);
+        (translatorIdentity
+          ? participant.identity === translatorIdentity
+          : participant.identity.startsWith(ORGANIZER_PREFIX));
       for (const [, pub] of participant.trackPublications) {
         if (pub.kind === Track.Kind.Audio) pub.setSubscribed(wanted);
       }
     }
-  }, [room, translatorIdentity, isOriginal, remoteParticipants, audioOn]);
+  }, [room, translatorIdentity, remoteParticipants, audioOn]);
 
   // No unload beacon: leaving the LiveKit room IS the unsubscribe signal now — the
   // server's supervisor reads demand from room presence and winds the bridge down
   // after a grace window.
 
-  // Three-light status: gray = no speaker, amber = speaker is live but our
-  // translator is missing (being re-requested above), green = fully wired. For
-  // original audio the translator only carries the transcript, so its absence
-  // doesn't demote the light — the audio the listener chose is unaffected.
-  const degraded = needsTranslator && !isOriginal;
+  // Three-light status: gray = no speaker, amber = speaker is live but the bot this
+  // pane needs is missing, green = fully wired. Amber covers original audio too: the
+  // audio is unaffected there, but a missing transcript writer means half the pane is
+  // silently frozen, and green over frozen text is the one reading that leaves a
+  // listener staring at a stale paragraph believing it's current.
   const dotClass = !speakerPresent
     ? "bg-gray-400"
-    : degraded
+    : needsTranslator
       ? "bg-amber-500 animate-pulse"
       : "bg-green-500 animate-pulse";
   const statusText = !speakerPresent
     ? s.waitingForSpeaker
-    : degraded
-      ? s.restartingTranslation
+    : needsTranslator
+      ? translatorLanguage
+        ? s.restartingTranslation
+        : s.waitingForTranscript
       : s.liveListening;
 
   return (
@@ -178,10 +186,13 @@ export function ListenViewer({ language }: { language: string }) {
   const s = useStrings();
   // `language` is a BCP-47 code from the picker; tolerate a legacy display name.
   const langCode = LANGUAGE_BCP47[language] ?? language;
-  const isOriginal = langCode === LISTEN_ORIGINAL_CODE;
-  // For original audio we don't run a bot of our own — we keep the default bridge
-  // alive (it produces the English transcript) and listen to the speaker directly.
-  const translateTarget = isOriginal ? DEFAULT_LISTEN_CODE : langCode;
+  // The bot this pane needs, or null for original audio — where we listen to the
+  // speaker directly and read a transcript the server already writes for every live
+  // broadcaster. Null is the whole "original" special case: no /translate request, no
+  // demand attribute, nothing to re-request. It used to claim the default language for
+  // all three, which spun up a bridge we didn't need and counted us on the broadcaster
+  // dashboard as a listener of a language we weren't hearing.
+  const translatorLanguage = langCode === LISTEN_ORIGINAL_CODE ? null : langCode;
   const docId = getDocId();
   const [conn, setConn] = useState<ConnectInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -203,20 +214,27 @@ export function ListenViewer({ language }: { language: string }) {
     let cancelled = false;
     const connect = async () => {
       try {
-        // Ask the server to spin up (or reuse) the translator bot. For original
-        // audio this just ensures the default bridge (and its transcript) runs.
-        const tr = (await fetch("/api/livekit/translate", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sessionId: docId, targetLanguage: translateTarget }),
-        }).then((r) => r.json())) as TranslateResp;
-        if (tr.error) throw new Error(tr.error);
+        // Ask the server to spin up (or reuse) our translator bot. Skipped entirely on
+        // original audio: we need no bot, and the transcript's bridge is the server's
+        // to run.
+        let translatorIdentity: string | null = null;
+        if (translatorLanguage) {
+          const tr = (await fetch("/api/livekit/translate", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ sessionId: docId, targetLanguage: translatorLanguage }),
+          }).then((r) => r.json())) as TranslateResp;
+          if (tr.error) throw new Error(tr.error);
+          if (!tr.translatorIdentity) throw new Error("Incomplete response from server");
+          translatorIdentity = tr.translatorIdentity;
+        }
 
         const identity = `attendee-${Math.random().toString(36).slice(2, 8)}`;
         // listenLanguage rides into the LiveKit token as a participant attribute:
         // it's how the server's translation supervisor reads demand from room
         // presence, so our bridge survives as long as we're in the room — no
-        // refcounts, no unload beacon.
+        // refcounts, no unload beacon. Sent only when we actually want a bot, so
+        // "demand" stays a true statement about what someone is listening to.
         const tk = (await fetch("/api/livekit/token", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -224,23 +242,16 @@ export function ListenViewer({ language }: { language: string }) {
             room: docId,
             identity,
             role: "attendee",
-            listenLanguage: translateTarget,
+            ...(translatorLanguage ? { listenLanguage: translatorLanguage } : {}),
           }),
         }).then((r) => r.json())) as TokenResp;
         if (tk.error) throw new Error(tk.error);
         if (!tk.token || !tk.serverUrl) {
           throw new Error("Incomplete response from server");
         }
-        if (!isOriginal && !tr.translatorIdentity) {
-          throw new Error("Incomplete response from server");
-        }
 
         if (cancelled) return;
-        setConn({
-          token: tk.token,
-          serverUrl: tk.serverUrl,
-          translatorIdentity: isOriginal ? null : tr.translatorIdentity ?? null,
-        });
+        setConn({ token: tk.token, serverUrl: tk.serverUrl, translatorIdentity });
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       }
@@ -249,7 +260,7 @@ export function ListenViewer({ language }: { language: string }) {
     return () => {
       cancelled = true;
     };
-  }, [docId, translateTarget, isOriginal, attempt, wantLive]);
+  }, [docId, translatorLanguage, attempt, wantLive]);
 
   // The control bar reflects state: before opt-in, a "Listen Live" button that
   // joins on demand; then error (with retry), the live audio controls once
@@ -304,9 +315,8 @@ export function ListenViewer({ language }: { language: string }) {
       >
         <ListenAudio
           docId={docId}
-          translateTarget={translateTarget}
+          translatorLanguage={translatorLanguage}
           translatorIdentity={conn.translatorIdentity}
-          isOriginal={isOriginal}
           audioOn={audioOn}
           onToggleAudio={() => setAudioOn((v) => !v)}
         />

--- a/src/ListenViewer.tsx
+++ b/src/ListenViewer.tsx
@@ -55,14 +55,14 @@ interface TokenResp {
 // rendered by the parent, outside the room.
 function ListenAudio({
   docId,
-  releaseTarget,
+  translateTarget,
   translatorIdentity,
   isOriginal,
   audioOn,
   onToggleAudio,
 }: {
   docId: string;
-  releaseTarget: string;
+  translateTarget: string;
   translatorIdentity: string | null;
   isOriginal: boolean;
   audioOn: boolean;
@@ -78,15 +78,15 @@ function ListenAudio({
   // The bot we depend on (for translated audio, or just the transcript when
   // listening to the original). Identities are deterministic: translator-<code>.
   const translatorPresent = remoteParticipants.some(
-    (p) => p.identity === `translator-${releaseTarget}`
+    (p) => p.identity === `translator-${translateTarget}`
   );
 
-  // Self-heal: the server can lose our translator (restart, presence reap, its room
-  // connection dropping) and nothing server-side recreates it — so while the speaker
-  // is broadcasting without our bot, periodically re-request it. Gated on speaker
-  // presence so a pre-broadcast wait doesn't churn against the server's presence
-  // reaper (docs/live-audio-state-architecture.md, "the waiting-room reap"): the
-  // re-request then fires exactly when the session becomes healthy, so it sticks.
+  // Self-heal backstop: the server's presence supervisor recreates lost bridges from
+  // our `listen` attribute, but if that path is ever wrong or slow, re-requesting
+  // here converges too — same reconcile principle, run from both ends. Gated on
+  // speaker presence so a pre-broadcast wait doesn't churn against the supervisor's
+  // wind-down (docs/live-audio-state-architecture.md, "the waiting-room reap"): the
+  // re-request then fires exactly when demand becomes satisfiable, so it sticks.
   const needsTranslator = speakerPresent && !translatorPresent;
   const lastEnsureRef = useRef(0);
   // Stamp mount time (not in render — Date.now is impure there) so the bot the parent
@@ -103,7 +103,7 @@ function ListenAudio({
       void fetch("/api/livekit/translate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId: docId, targetLanguage: releaseTarget }),
+        body: JSON.stringify({ sessionId: docId, targetLanguage: translateTarget }),
       }).catch(() => {
         // Transient; the next tick retries.
       });
@@ -111,7 +111,7 @@ function ListenAudio({
     ensure();
     const id = setInterval(ensure, ENSURE_TRANSLATOR_INTERVAL_MS);
     return () => clearInterval(id);
-  }, [needsTranslator, docId, releaseTarget]);
+  }, [needsTranslator, docId, translateTarget]);
 
   // Subscribe to the audio we want only while audio is enabled: the translator
   // bot for a translation, or the speaker's raw mic for "Original / English".
@@ -132,23 +132,9 @@ function ListenAudio({
     }
   }, [room, translatorIdentity, isOriginal, remoteParticipants, audioOn]);
 
-  // Decrement the listener count when this pane goes away (unmount or tab close)
-  // so idle translator bots tear down. (Best-effort; the server's presence reaper
-  // is the authoritative teardown.)
-  useEffect(() => {
-    const release = () => {
-      const body = JSON.stringify({ sessionId: docId, targetLanguage: releaseTarget });
-      navigator.sendBeacon(
-        "/api/livekit/translate/unsubscribe",
-        new Blob([body], { type: "application/json" })
-      );
-    };
-    window.addEventListener("beforeunload", release);
-    return () => {
-      window.removeEventListener("beforeunload", release);
-      release();
-    };
-  }, [docId, releaseTarget]);
+  // No unload beacon: leaving the LiveKit room IS the unsubscribe signal now — the
+  // server's supervisor reads demand from room presence and winds the bridge down
+  // after a grace window.
 
   // Three-light status: gray = no speaker, amber = speaker is live but our
   // translator is missing (being re-requested above), green = fully wired. For
@@ -227,10 +213,19 @@ export function ListenViewer({ language }: { language: string }) {
         if (tr.error) throw new Error(tr.error);
 
         const identity = `attendee-${Math.random().toString(36).slice(2, 8)}`;
+        // listenLanguage rides into the LiveKit token as a participant attribute:
+        // it's how the server's translation supervisor reads demand from room
+        // presence, so our bridge survives as long as we're in the room — no
+        // refcounts, no unload beacon.
         const tk = (await fetch("/api/livekit/token", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ room: docId, identity, role: "attendee" }),
+          body: JSON.stringify({
+            room: docId,
+            identity,
+            role: "attendee",
+            listenLanguage: translateTarget,
+          }),
         }).then((r) => r.json())) as TokenResp;
         if (tk.error) throw new Error(tk.error);
         if (!tk.token || !tk.serverUrl) {
@@ -309,7 +304,7 @@ export function ListenViewer({ language }: { language: string }) {
       >
         <ListenAudio
           docId={docId}
-          releaseTarget={translateTarget}
+          translateTarget={translateTarget}
           translatorIdentity={conn.translatorIdentity}
           isOriginal={isOriginal}
           audioOn={audioOn}

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -59,6 +59,7 @@ export interface AppStrings {
   englishTranscript: string;
   liveListening: string;
   waitingForSpeaker: string;
+  restartingTranslation: string;
   waitingForSpeech: string;
   liveAudioError: string;
   retry: string;
@@ -150,6 +151,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     englishTranscript: 'English transcript',
     liveListening: 'Listening live',
     waitingForSpeaker: 'Waiting for the speaker…',
+    restartingTranslation: 'Restarting translation…',
     waitingForSpeech: 'Waiting for translated speech…',
     liveAudioError: 'Live audio unavailable',
     retry: 'Retry',
@@ -237,6 +239,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     englishTranscript: 'Transcription anglaise',
     liveListening: 'Écoute en direct',
     waitingForSpeaker: 'En attente de l’orateur…',
+    restartingTranslation: 'Redémarrage de la traduction…',
     waitingForSpeech: 'En attente de la traduction vocale…',
     liveAudioError: 'Audio en direct indisponible',
     retry: 'Réessayer',
@@ -324,6 +327,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     englishTranscript: 'Transcripción en inglés',
     liveListening: 'Escuchando en vivo',
     waitingForSpeaker: 'Esperando al orador…',
+    restartingTranslation: 'Reiniciando la traducción…',
     waitingForSpeech: 'Esperando la traducción hablada…',
     liveAudioError: 'Audio en vivo no disponible',
     retry: 'Reintentar',
@@ -411,6 +415,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     englishTranscript: 'Transkripsyon anglè',
     liveListening: 'Ap koute an dirèk',
     waitingForSpeaker: 'N ap tann moun k ap pale a…',
+    restartingTranslation: 'N ap redemare tradiksyon an…',
     waitingForSpeech: 'N ap tann tradiksyon vokal la…',
     liveAudioError: 'Odyo an dirèk pa disponib',
     retry: 'Reeseye',

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -60,6 +60,7 @@ export interface AppStrings {
   liveListening: string;
   waitingForSpeaker: string;
   restartingTranslation: string;
+  waitingForTranscript: string;
   waitingForSpeech: string;
   liveAudioError: string;
   retry: string;
@@ -152,6 +153,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     liveListening: 'Listening live',
     waitingForSpeaker: 'Waiting for the speaker…',
     restartingTranslation: 'Restarting translation…',
+    waitingForTranscript: 'Waiting for the transcript…',
     waitingForSpeech: 'Waiting for translated speech…',
     liveAudioError: 'Live audio unavailable',
     retry: 'Retry',
@@ -240,6 +242,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     liveListening: 'Écoute en direct',
     waitingForSpeaker: 'En attente de l’orateur…',
     restartingTranslation: 'Redémarrage de la traduction…',
+    waitingForTranscript: 'En attente de la transcription…',
     waitingForSpeech: 'En attente de la traduction vocale…',
     liveAudioError: 'Audio en direct indisponible',
     retry: 'Réessayer',
@@ -328,6 +331,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     liveListening: 'Escuchando en vivo',
     waitingForSpeaker: 'Esperando al orador…',
     restartingTranslation: 'Reiniciando la traducción…',
+    waitingForTranscript: 'Esperando la transcripción…',
     waitingForSpeech: 'Esperando la traducción hablada…',
     liveAudioError: 'Audio en vivo no disponible',
     retry: 'Reintentar',
@@ -416,6 +420,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     liveListening: 'Ap koute an dirèk',
     waitingForSpeaker: 'N ap tann moun k ap pale a…',
     restartingTranslation: 'N ap redemare tradiksyon an…',
+    waitingForTranscript: 'N ap tann transkripsyon an…',
     waitingForSpeech: 'N ap tann tradiksyon vokal la…',
     liveAudioError: 'Odyo an dirèk pa disponib',
     retry: 'Reeseye',

--- a/template-.env
+++ b/template-.env
@@ -15,11 +15,12 @@ ELEVENLABS_API_KEY=...
 # LIVEKIT_API_KEY=...
 # LIVEKIT_API_SECRET=...
 
-# Live-audio cost path (optional, default off). When truthy (1/true/yes/on), bridges suspend
-# their Gemini session after ~30s of silence and reopen on speech, and the default translator
-# runs for any present broadcaster (always-on English transcript). The goaway/reconnect
-# reliability fixes are independent and always on. Leave off until the cost path is validated.
-# LIVE_AUDIO_SILENCE_GATING=false
+# Live-audio cost path (optional, default off). Set a dBFS level to make bridges suspend their
+# Gemini session after ~30s below it and reopen on speech; -30 is the tuned value. Unset means
+# no suspending at all. Note the sign — dBFS is negative below full scale, so a higher number
+# gates harder and 0 would treat all speech as silence. The goaway/reconnect reliability fixes
+# and the always-on default translator are independent of this and always on.
+# LIVE_AUDIO_SILENCE_THRESHOLD_DBFS=-30
 
 # PostHog Analytics (optional)
 # VITE_PUBLIC_POSTHOG_KEY=...

--- a/template-.env
+++ b/template-.env
@@ -16,10 +16,10 @@ ELEVENLABS_API_KEY=...
 # LIVEKIT_API_SECRET=...
 
 # Live-audio cost path (optional, default off). Set a dBFS level to make bridges suspend their
-# Gemini session after ~30s below it and reopen on speech; -30 is the tuned value. Unset means
-# no suspending at all. Note the sign — dBFS is negative below full scale, so a higher number
-# gates harder and 0 would treat all speech as silence. The goaway/reconnect reliability fixes
-# and the always-on default translator are independent of this and always on.
+# Gemini session after ~30s below it and reopen on speech; -30 is a guess, not a measured value.
+# Unset means no suspending at all. Note the sign — dBFS is negative below full scale, so a
+# higher number gates harder and 0 would treat all speech as silence. The goaway/reconnect
+# fixes and the always-on default translator are independent of this and always on.
 # LIVE_AUDIO_SILENCE_THRESHOLD_DBFS=-30
 
 # PostHog Analytics (optional)


### PR DESCRIPTION
The architecture from [docs/live-audio-state-architecture.md](https://github.com/kcarnold/live-notes/pull/85), implemented. **Stacked on #86** (the hot fixes) — base retargets to `main` when that merges. Review #86 first.

## What changes

**LiveKit presence is now the single source of truth for demand.** Listeners carry their requested language into the room as a `listen=<lang>` participant attribute (set server-side on the token from a new `listenLanguage` field in the token request); the organizer carries `role=organizer`. There is no listener refcount and no unload beacon anymore — leaving the room *is* the unsubscribe.

**A supervisor loop reconciles running bridges against that presence** (10s tick, plus pokes from the token route and `/translate`). Two exported pure functions carry the whole decision:

- `computeDesiredLanguages(participants)` — nothing without a broadcaster (a waiting listener costs nothing, and bridges start the tick the organizer joins — the waiting-room outage is inexpressible in this shape); otherwise each listener's attribute language plus the default/source-transcript bridge (unconditionally under `LIVE_AUDIO_SILENCE_GATING`, else while anyone listens).
- `planRoomActions(desired, running, …)` — start what's missing or dead (`error`/`closed` while desired ⇒ recreate), stop what's undesired past a 60s grace, with a 30s per-language start damper.

Consequences that fall out for free: **server restart self-heals** (the supervisor rebuilds bridges from room presence within one tick — no client action), failed bridges are recreated while demand persists, refresh churn is absorbed by the grace, and a failed `listRooms` skips the whole tick so a LiveKit blind spot never reads as "empty rooms" and mass-teardown.

**Bridge hardening:**
- A **teardown epoch**: every socket's handlers capture the epoch at wiring; a `setupComplete` whose epoch is stale (the bridge suspended, stopped, or failed meanwhile) is dropped and its socket closed, instead of swapping a paid-for zombie session into a bridge that believes it has none. Closes the illegal-state class (#8 in the doc's catalog).
- A composite **`health()` snapshot** (per-leg Gemini state derived from the connection fields, input/output frame timestamps, reconnect count, gap-buffer depth) now rides `GET /translate/status` — "active" as a single word stops being the only signal.

**Deleted:** `isSessionHealthy` + the reaper (subsumed by the supervisor's wind-down branch), `subscriberCount` bookkeeping (now stamped from presence, dashboard-info only), the client unsubscribe beacon (endpoint kept as a legacy no-op nudge), and dead methods (`createSession`/`getSession`/`getAllSessions`/`removeTranslation`/`removeAllTranslations`).

**Kept:** `getOrCreate` as the `/translate` fast path (response still carries the translator identity synchronously) — it also stamps demand, covering clients whose cached bundle predates the attribute. The client ensure-loop from #86 stays as a convergence backstop from the other end.

**Explicitly deferred** (noted in the doc's migration sketch): the full enum rewrite of the bridge's Gemini leg internals — the epoch guard delivers the safety property with a fraction of the risk to a battle-tested file — and LiveKit webhooks in place of polling.

## Testing

- New manager suite: pure demand/diff decisions (7 cases) + supervisor convergence with a fake room directory and fake bridges — restart recovery, waiting room → broadcaster arrival, recreate-on-error, grace wind-down, whole-session teardown, blind-tick safety, listener-count stamping, and demand stamping via `getOrCreate`.
- New e2e test: the stale-`setupComplete` race (goAway replacement loses to `stop()`), **verified to fail against the pre-epoch bridge**.
- Full suite 282 tests / 23 files green; `npm run typecheck` and `npm run lint` clean.

## Smoke test sections touched

**§4 Live audio translation** — updated in this PR: the waiting-room item (translator appears ~10s after broadcast starts) and a new **server-restart recovery** item (transcript resumes ~15s after a Node restart, no client reload). **§6 Teardown sanity** — updated: wind-down now happens via the supervisor within ~2 minutes (60s grace + tick). A real pre-service run of §4 is the required validation before this deploys to a Sunday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XQh3xXo9Yk2B5iHtzWR2B

---
_Generated by [Claude Code](https://claude.ai/code/session_014XQh3xXo9Yk2B5iHtzWR2B)_