### PR TITLE
Auto-scale slide text to fit without vertical scrolling

### DIFF
--- a/src/CurrentSlideViewer.test.tsx
+++ b/src/CurrentSlideViewer.test.tsx
@@ -40,28 +40,11 @@ describe('CurrentSlideViewer (pure)', () => {
     expect(screen.getByText('No slides available')).toBeInTheDocument();
   });
 
-  it('shows only the current slide when context is 0', () => {
-    render(<CurrentSlideViewer title="T" slides={['a', 'b', 'c']} currentIndex={1} context={0} />);
+  it('shows only the current slide', () => {
+    render(<CurrentSlideViewer title="T" slides={['a', 'b', 'c']} currentIndex={1} />);
     expect(screen.getByText('b')).toBeInTheDocument();
     expect(screen.queryByText('a')).not.toBeInTheDocument();
     expect(screen.queryByText('c')).not.toBeInTheDocument();
-  });
-
-  it('shows previous/next context slides with labels', () => {
-    render(<CurrentSlideViewer title="T" slides={['a', 'b', 'c']} currentIndex={1} context={1} />);
-    expect(screen.getByText('a')).toBeInTheDocument();
-    expect(screen.getByText('b')).toBeInTheDocument();
-    expect(screen.getByText('c')).toBeInTheDocument();
-    expect(screen.getByText('Previous')).toBeInTheDocument();
-    expect(screen.getByText('Next')).toBeInTheDocument();
-  });
-
-  it('clamps the window at the start (no Previous label at index 0)', () => {
-    render(<CurrentSlideViewer title="T" slides={['a', 'b', 'c']} currentIndex={0} context={1} />);
-    expect(screen.getByText('a')).toBeInTheDocument();
-    expect(screen.getByText('b')).toBeInTheDocument();
-    expect(screen.queryByText('Previous')).not.toBeInTheDocument();
-    expect(screen.getByText('Next')).toBeInTheDocument();
   });
 
   it('splits multi-line slide text and renders blank lines as a non-breaking space', () => {
@@ -77,14 +60,14 @@ describe('CurrentSlideViewer (pure)', () => {
   // so currentIndex can transiently point past the known slides. The viewer must
   // show a real slide, not a blank container.
   it('clamps an out-of-range currentIndex to the last slide', () => {
-    render(<CurrentSlideViewer title="T" slides={['a', 'b', 'c']} currentIndex={5} context={0} />);
+    render(<CurrentSlideViewer title="T" slides={['a', 'b', 'c']} currentIndex={5} />);
     expect(screen.getByText('c')).toBeInTheDocument();
     expect(screen.queryByText('a')).not.toBeInTheDocument();
     expect(screen.queryByText('b')).not.toBeInTheDocument();
   });
 
   it('clamps a negative currentIndex to the first slide', () => {
-    render(<CurrentSlideViewer title="T" slides={['a', 'b', 'c']} currentIndex={-1} context={0} />);
+    render(<CurrentSlideViewer title="T" slides={['a', 'b', 'c']} currentIndex={-1} />);
     expect(screen.getByText('a')).toBeInTheDocument();
     expect(screen.queryByText('c')).not.toBeInTheDocument();
   });

--- a/src/CurrentSlideViewer.tsx
+++ b/src/CurrentSlideViewer.tsx
@@ -1,26 +1,17 @@
 import { useMap } from '@y-sweet/react';
 import { useStrings } from './useLocale';
-
-interface Slide {
-  text: string;
-  isActive: boolean;
-}
+import { SlideText } from './SlideText';
 
 interface CurrentSlideViewerProps {
   title: string;
   slides: string[];
   currentIndex: number;
-  context?: number; // How many slides before/after to show (default: 0)
 }
 
 /**
- * Pure component that displays current slide with context (prev/next slides)
+ * Pure component that displays the current slide, auto-scaled to fit.
  */
-export function CurrentSlideViewer({
-  slides,
-  currentIndex,
-  context = 0
-}: CurrentSlideViewerProps) {
+export function CurrentSlideViewer({ slides, currentIndex }: CurrentSlideViewerProps) {
   const s = useStrings();
 
   if (slides.length === 0) {
@@ -35,57 +26,7 @@ export function CurrentSlideViewer({
   // separate writes, so currentIndex can transiently point past the slides.
   const clampedIndex = Math.min(Math.max(currentIndex, 0), slides.length - 1);
 
-  // Build array of slides to display with context
-  const startIdx = Math.max(0, clampedIndex - context);
-  const endIdx = Math.min(slides.length - 1, clampedIndex + context);
-
-  const visibleSlides: Slide[] = [];
-  for (let i = startIdx; i <= endIdx; i++) {
-    visibleSlides.push({
-      text: slides[i],
-      isActive: i === clampedIndex,
-    });
-  }
-
-  return (
-    <div className="flex flex-col bg-black dark:bg-gray-950 text-white overflow-hidden">
-      {/* Slides with context */}
-      <div className="flex-1 overflow-y-auto px-1 py-1 space-y-3">
-        {visibleSlides.map((slide, idx) => (
-          <div
-            key={startIdx + idx}
-            className={`transition-all duration-300 ${
-              slide.isActive
-                ? 'opacity-100 scale-100'
-                : 'opacity-40 scale-95'
-            }`}
-          >
-            <div
-              className={`p-1`}
-            >
-              <div className="text-center space-y-2">
-                {slide.text.split('\n').map((line, lineIdx) => (
-                  <div
-                    key={lineIdx}
-                    className={`leading-normal ${
-                      slide.isActive ? 'text-2xl' : 'text-xl font-light'
-                    }`}
-                  >
-                    {line || '\u00A0'}
-                  </div>
-                ))}
-              </div>
-            </div>
-            {!slide.isActive && (
-              <div className="text-xs text-gray-500 dark:text-gray-600 mt-1 text-center">
-                {startIdx + idx < clampedIndex ? s.previous : s.next}
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+  return <SlideText lines={slides[clampedIndex].split('\n')} />;
 }
 
 /**
@@ -120,12 +61,5 @@ export function CurrentSlideViewerContainer() {
     (slide): slide is string => typeof slide === 'string',
   );
 
-  return (
-    <CurrentSlideViewer
-      title={title}
-      slides={slides}
-      currentIndex={slideIndex}
-      context={0}
-    />
-  );
+  return <CurrentSlideViewer title={title} slides={slides} currentIndex={slideIndex} />;
 }

--- a/src/SlideText.tsx
+++ b/src/SlideText.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from 'react';
+import { useFitText } from './useFitText';
+
+// Non-breaking space so blank lines keep their height (and testing-library can
+// match them without whitespace-collapsing).
+const BLANK_LINE = ' ';
+
+export interface SlideTextProps {
+  /** Lines of the slide, already split on newlines. Omit to show `placeholder`. */
+  lines?: string[];
+  /** Optional content above the text (e.g. translation badges). Not scaled. */
+  header?: ReactNode;
+  /** Rendered in place of `lines` when there is nothing to show (e.g. "not translated"). */
+  placeholder?: ReactNode;
+}
+
+/**
+ * Shared presentation for a single slide: a full-height black panel whose text
+ * is auto-scaled to fit without vertical scrolling.
+ *
+ * Both the original-language slide viewer and the translation viewer render
+ * through here so the shell and the fit behavior live in one place.
+ */
+export function SlideText({ lines, header, placeholder }: SlideTextProps) {
+  // Re-fit whenever the content changes.
+  const contentKey = placeholder != null ? ' placeholder' : (lines ?? []).join('\n');
+  const { containerRef, textRef, fontSize } = useFitText<HTMLDivElement, HTMLDivElement>([
+    contentKey,
+  ]);
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0 h-full bg-black dark:bg-gray-950 text-white overflow-hidden">
+      <div
+        ref={containerRef}
+        style={{ fontSize }}
+        className="flex-1 min-h-0 overflow-hidden flex flex-col justify-center px-2 py-2"
+      >
+        <div ref={textRef} className="w-full">
+          {header && <div className="mb-1">{header}</div>}
+          {placeholder != null ? (
+            <div className="text-center">{placeholder}</div>
+          ) : (
+            <div className="text-center leading-tight space-y-1">
+              {(lines ?? []).map((line, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: lines have no stable id
+                <div key={i}>{line || BLANK_LINE}</div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/SlideTranslationViewer.tsx
+++ b/src/SlideTranslationViewer.tsx
@@ -1,5 +1,6 @@
 import { useMap } from '@y-sweet/react';
 import { useStrings } from './useLocale';
+import { SlideText } from './SlideText';
 import {
   resolveSlideTranslation,
   slideTranslationKey,
@@ -8,18 +9,17 @@ import {
 } from './slideTranslation';
 
 export interface SlideTranslationViewerProps {
-  /** Original-language source slides (for indexing/context). */
+  /** Original-language source slides (for indexing). */
   slides: string[];
   currentIndex: number;
   /** The requested target language. */
   language: string;
   /** Resolved translation per slide (undefined = not translated yet). */
   resolvedBySlide: (ResolvedSlideTranslation | undefined)[];
-  context?: number;
 }
 
 /**
- * Pure component showing the translation of the current slide.
+ * Pure component showing the translation of the current slide, auto-scaled to fit.
  *
  * - An `auto` (machine, unreviewed) translation gets a subtle "unreviewed" badge.
  * - When the displayed language differs from the requested one (e.g. reviewed French
@@ -29,7 +29,6 @@ export function SlideTranslationViewer({
   slides,
   currentIndex,
   resolvedBySlide,
-  context = 0,
 }: SlideTranslationViewerProps) {
   const s = useStrings();
 
@@ -41,65 +40,38 @@ export function SlideTranslationViewer({
     );
   }
 
-  const startIdx = Math.max(0, currentIndex - context);
-  const endIdx = Math.min(slides.length - 1, currentIndex + context);
+  // Clamp: Proclaim publishes status and presentation separately, so the index
+  // can transiently point past the slides.
+  const clampedIndex = Math.min(Math.max(currentIndex, 0), slides.length - 1);
+  const resolved = resolvedBySlide[clampedIndex];
+  const isUnreviewed = resolved?.entry.status === 'auto';
 
-  const visible: { index: number; isActive: boolean; resolved: ResolvedSlideTranslation | undefined }[] = [];
-  for (let i = startIdx; i <= endIdx; i++) {
-    visible.push({ index: i, isActive: i === currentIndex, resolved: resolvedBySlide[i] });
+  const header =
+    isUnreviewed || resolved?.isFallbackLanguage ? (
+      <div className="flex justify-center gap-2">
+        {resolved?.isFallbackLanguage && (
+          <span className="text-xs px-1.5 py-0.5 rounded bg-gray-700 text-gray-200">
+            {resolved.displayLanguage}
+          </span>
+        )}
+        {isUnreviewed && (
+          <span className="text-xs px-1.5 py-0.5 rounded bg-amber-700/80 text-amber-50 opacity-20">
+            {s.unreviewedBadge}
+          </span>
+        )}
+      </div>
+    ) : undefined;
+
+  if (!resolved) {
+    return (
+      <SlideText
+        header={header}
+        placeholder={<span className="text-gray-500 italic">{s.notTranslated}</span>}
+      />
+    );
   }
 
-  return (
-    <div className="flex flex-col bg-black dark:bg-gray-950 text-white overflow-hidden">
-      <div className="flex-1 overflow-y-auto px-1 py-1 space-y-3">
-        {visible.map(({ index, isActive, resolved }) => {
-          const isUnreviewed = resolved?.entry.status === 'auto';
-          return (
-            <div
-              key={index}
-              className={`transition-all duration-300 ${isActive ? 'opacity-100 scale-100' : 'opacity-40 scale-95'}`}
-            >
-              <div className="p-1">
-                {(isUnreviewed || resolved?.isFallbackLanguage) && (
-                  <div className="flex justify-center gap-2 mb-1">
-                    {resolved?.isFallbackLanguage && (
-                      <span className="text-xs px-1.5 py-0.5 rounded bg-gray-700 text-gray-200">
-                        {resolved.displayLanguage}
-                      </span>
-                    )}
-                    {isUnreviewed && (
-                      <span className="text-xs px-1.5 py-0.5 rounded bg-amber-700/80 text-amber-50 opacity-20">
-                        {s.unreviewedBadge}
-                      </span>
-                    )}
-                  </div>
-                )}
-                <div className="text-center space-y-2">
-                  {resolved ? (
-                    resolved.entry.text.split('\n').map((line, lineIdx) => (
-                      <div
-                        key={lineIdx}
-                        className={`leading-normal ${isActive ? 'text-2xl' : 'text-xl font-light'}`}
-                      >
-                        {line || ' '}
-                      </div>
-                    ))
-                  ) : (
-                    <div className="text-xl font-light text-gray-500 italic">{s.notTranslated}</div>
-                  )}
-                </div>
-              </div>
-              {!isActive && (
-                <div className="text-xs text-gray-500 dark:text-gray-600 mt-1 text-center">
-                  {index < currentIndex ? s.previous : s.next}
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
+  return <SlideText lines={resolved.entry.text.split('\n')} header={header} />;
 }
 
 /** Yjs connector: reads the source slides + per-day slideTranslations and resolves. */
@@ -149,7 +121,6 @@ export function SlideTranslationViewerContainer({ language }: { language: string
       currentIndex={view.slideIndex}
       language={language}
       resolvedBySlide={view.resolvedBySlide}
-      context={0}
     />
   );
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -22,3 +22,15 @@ global.Audio = vi.fn().mockImplementation(() => ({
 if (!Element.prototype.scrollTo) {
   Element.prototype.scrollTo = vi.fn();
 }
+
+// jsdom doesn't implement ResizeObserver. The text auto-fit hook (useFitText)
+// observes its container; without this stub construction throws. jsdom also has
+// no layout, so clientHeight/clientWidth are 0 and the hook skips the fit — the
+// stub just needs to exist.
+if (!('ResizeObserver' in globalThis)) {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}

--- a/src/useFitText.test.ts
+++ b/src/useFitText.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { fitFontSize } from './useFitText';
+
+describe('fitFontSize', () => {
+  // Model: text height grows linearly with font size (one line), width fixed.
+  // heightAt(px) = px * lineCount * lineHeight
+  const model = (lineCount: number, lineHeight = 1.2) =>
+    (px: number) => ({ width: 100, height: px * lineCount * lineHeight });
+
+  it('returns the largest font size that fits the available height', () => {
+    // avail height 120, single line, lineHeight 1.2 => fits up to 100px.
+    const best = fitFontSize(1000, 120, model(1), { min: 10, max: 200, steps: 20 });
+    expect(best).toBeGreaterThan(99);
+    expect(best).toBeLessThanOrEqual(100);
+  });
+
+  it('shrinks more when there are more lines', () => {
+    const one = fitFontSize(1000, 120, model(1), { min: 10, max: 200, steps: 20 });
+    const four = fitFontSize(1000, 120, model(4), { min: 10, max: 200, steps: 20 });
+    expect(four).toBeLessThan(one);
+    // four lines at 120px / (4 * 1.2) => ~25px
+    expect(four).toBeGreaterThan(24);
+    expect(four).toBeLessThanOrEqual(25);
+  });
+
+  it('is constrained by width when text is too wide', () => {
+    // Width grows with font; only <= 50px keeps width under 500.
+    const measure = (px: number) => ({ width: px * 10, height: px });
+    const best = fitFontSize(500, 100000, measure, { min: 10, max: 200, steps: 20 });
+    expect(best).toBeLessThanOrEqual(50);
+    expect(best).toBeGreaterThan(49);
+  });
+
+  it('never exceeds max even when everything fits', () => {
+    const best = fitFontSize(100000, 100000, model(1), { min: 10, max: 64, steps: 20 });
+    expect(best).toBe(64);
+  });
+
+  it('falls back to min when nothing fits', () => {
+    // Even the smallest size overflows.
+    const measure = () => ({ width: 0, height: 10_000 });
+    const best = fitFontSize(1000, 100, measure, { min: 12, max: 160, steps: 20 });
+    expect(best).toBe(12);
+  });
+});

--- a/src/useFitText.ts
+++ b/src/useFitText.ts
@@ -1,0 +1,109 @@
+import { useLayoutEffect, useRef, useState, type DependencyList } from 'react';
+
+export interface UseFitTextOptions {
+  /** Smallest font size (px) to shrink to. Content may clip below this. */
+  min?: number;
+  /** Largest font size (px) to grow to. */
+  max?: number;
+  /** Binary-search steps. 10 gives sub-pixel precision over the default range. */
+  steps?: number;
+}
+
+/**
+ * Binary-search the largest font size in `[min, max]` at which the measured
+ * content still fits `availW × availH`. Pure: `measure(px)` reports the
+ * content's natural `{ width, height }` at that font size, so this is unit
+ * testable without a real layout engine.
+ */
+export function fitFontSize(
+  availW: number,
+  availH: number,
+  measure: (px: number) => { width: number; height: number },
+  { min = 14, max = 160, steps = 10 }: UseFitTextOptions = {},
+): number {
+  const fits = (px: number) => {
+    const { width, height } = measure(px);
+    return height <= availH && width <= availW;
+  };
+
+  // Short-circuit the common case (short slide): if the biggest size already
+  // fits, use it — and the binary search never tests `max` exactly.
+  if (fits(max)) return max;
+
+  let lo = min;
+  let hi = max;
+  let best = min;
+  for (let i = 0; i < steps; i++) {
+    const mid = (lo + hi) / 2;
+    if (fits(mid)) {
+      best = mid;
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  return best;
+}
+
+/**
+ * Auto-fit a block of text to the height (and width) of its container by
+ * binary-searching the font size.
+ *
+ * Two refs on purpose:
+ * - `containerRef` is the box the text must fit into. Its `clientHeight` is the
+ *   available space, and it carries the resolved `fontSize` so `em`/inherited
+ *   child sizes scale with it. It must have a bounded height (e.g. `flex-1
+ *   min-h-0`) and `overflow-hidden`.
+ * - `textRef` wraps the actual content. We measure *its* `scrollHeight`, which
+ *   is the content's natural height independent of how the container centers
+ *   it — so `justify-center` on the container doesn't confuse the measurement
+ *   the way reading the container's own `scrollHeight` would.
+ *
+ * Re-fits when `deps` change (new slide text) and when the container resizes.
+ *
+ * @param deps content identity — re-run the fit when this changes.
+ */
+export function useFitText<
+  C extends HTMLElement = HTMLDivElement,
+  T extends HTMLElement = HTMLDivElement,
+>(deps: DependencyList, { min = 14, max = 160, steps = 10 }: UseFitTextOptions = {}) {
+  const containerRef = useRef<C | null>(null);
+  const textRef = useRef<T | null>(null);
+  const [fontSize, setFontSize] = useState(max);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const text = textRef.current;
+    if (!container || !text) return;
+
+    const fit = () => {
+      const availH = container.clientHeight;
+      const availW = container.clientWidth;
+      // Not laid out yet (or a non-layout test environment like jsdom, where
+      // these are 0). Leave the font size alone rather than collapsing to min.
+      if (availH === 0 || availW === 0) return;
+
+      const best = fitFontSize(
+        availW,
+        availH,
+        (px) => {
+          // Apply to the container so `em`/inherited child sizes scale, then
+          // read the content's natural size.
+          container.style.fontSize = `${px}px`;
+          return { width: text.scrollWidth, height: text.scrollHeight };
+        },
+        { min, max, steps },
+      );
+      container.style.fontSize = `${best}px`;
+      setFontSize(best);
+    };
+
+    fit();
+    const ro = new ResizeObserver(fit);
+    ro.observe(container);
+    return () => ro.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return { containerRef, textRef, fontSize };
+}


### PR DESCRIPTION
## What & why

The original-language slide viewer (`CurrentSlideViewer`) and the translation viewer (`SlideTranslationViewer`) both displayed slides at a hardcoded font size (`text-2xl` active / `text-xl` context) inside an `overflow-y-auto` box, so any slide taller than the panel scrolled vertically. The two components were also near-identical copies of one another, which is why they didn't share code.

This change makes slide text auto-scale to fit the panel height, and removes the duplication by routing both viewers through one shared component.

## Approach

- **`SlideText`** (new) — shared presentational component: a full-height black panel that renders one slide's lines centered and auto-scaled. Optional `header` slot (used for the translation viewer's unreviewed / fallback-language badges) and `placeholder` slot (the "not translated" state).
- **`useFitText`** (new) — hook that binary-searches the font size so the content fits, re-fitting on content change and on container resize (`ResizeObserver`). Two refs: the container supplies the available height and carries the resolved font size; the inner text element is measured for natural height, which sidesteps the flexbox `justify-center` / `scrollHeight` gotcha.
- **`fitFontSize`** (new, pure) — the binary-search math, extracted so it's unit-testable without a real layout engine. Short-circuits to `max` when the largest size already fits.
- Both viewers now render through `SlideText` and keep their Proclaim out-of-range **index clamp**.

## Scope note

The previous multi-slide **context/stack** (dimmed previous/next slides with "Previous"/"Next" labels) is **dropped for now** — per discussion it needs its own layout work before going past one slide, and only the current slide was shown in practice (`context` defaulted to `0` everywhere). Each viewer now shows only the current slide. Avoiding awkward line breaks is explicitly deferred.

`SlideText`'s root uses `flex-1 min-h-0` so it fills the height *remaining after* the translation card's header, giving `useFitText` a correctly bounded box to measure against (previously the height chain was unbounded, which is part of why nothing could "fit").

## Testing

- `npm test` — 270 passed. New `fitFontSize` unit tests cover largest-fit, more-lines-shrink-more, width-constrained, `max` cap, and `min` fallback.
- `npm run typecheck` and `npm run lint` — clean.
- `ResizeObserver` is stubbed in the test setup: jsdom has no layout, so `clientHeight`/`scrollHeight` are `0`, the hook no-ops there, and text still renders. (Kept jsdom rather than switching to happy-dom — happy-dom also lacks real layout, so it wouldn't enable measuring the fit; the pure `fitFontSize` test covers the math regardless.)

**Smoke test:** SMOKE_TEST.md — Proclaim slide display (current slide + slide translation panels). Not manually run against live Proclaim in this environment; recommend verifying that long song verses / Bible passages now scale down instead of scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmJog8mxBUEzXZ7dosZeRT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmJog8mxBUEzXZ7dosZeRT)_