### PR TITLE
live-audio: add OpenAI Realtime as a second provider, for Haitian Creole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ dist-ssr
 log*.txt
 audio-cache
 
+# Output of creole-voice-spike.ts (generated audio for a listening comparison)
+creole-voice-spike/
+
 *.pyc
 presentation.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This is a **live translation application** for presentations/talks. It provides 
 - **Proclaim integration**: Python service syncing Proclaim presentation slides to Yjs
 - **Frontend**: React + TypeScript + Vite + Tailwind CSS
 - **Backend**: Express server
-- **Live speech translation**: LiveKit rooms + Gemini Live ([live-audio/](live-audio/)) — a broadcaster publishes mic audio; per-language translator bots stream it through Gemini Live and publish translated audio + live transcripts
+- **Live speech translation**: LiveKit rooms + a realtime translation provider ([live-audio/](live-audio/)) — a broadcaster publishes mic audio; per-language translator bots stream it through **Gemini Live** (most languages) or **OpenAI Realtime** (Haitian Creole, which Gemini Live Translate cannot speak) and publish translated audio + live transcripts
 
 **Start with [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** for the component map (what runs where, who writes what into the shared Yjs doc). [docs/README.md](docs/README.md) is the docs index; [docs/SMOKE_TEST.md](docs/SMOKE_TEST.md) is the manual pre-service smoke checklist — PR descriptions should declare which of its sections they touch.
 
@@ -32,10 +32,23 @@ Required environment variables (`.env`):
 - `GEMINI_API_KEY` - Google Gemini API key
 - `ELEVENLABS_API_KEY` - ElevenLabs API key for text-to-speech
 
+Optional but required for **Haitian Creole live audio**:
+- `OPENAI_API_KEY` - OpenAI API key. Gemini Live Translate has no Creole voice, so `ht`
+  is served by the OpenAI Realtime provider; without this key the listen picker still
+  offers Creole but its bridge refuses to start. See [live-audio/openai-provider.ts](live-audio/openai-provider.ts)
+  for what that path does and does not guarantee.
+
 Optional environment variables:
 - `TTS_MAX_CONCURRENT` - Max concurrent TTS requests (default: 2)
 - `GEMINI_STRONG_MODEL` - Stronger Gemini model for whole-item slide drafting via `/api/translateItem` (default: `gemini-3.5-flash`)
-- `LIVE_AUDIO_SILENCE_THRESHOLD_DBFS` - dBFS voice bar for the live-audio cost path; a bridge suspends its Gemini session after ~30s below it (`-30` is a guess, never validated against a real room). Unset = off, no suspending. Beware the sign: dBFS is negative, so `0` gates hardest, not least. goaway/reconnect fixes and the always-on default translator are independent of this. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
+- `LIVE_AUDIO_SILENCE_THRESHOLD_DBFS` - dBFS voice bar for the live-audio cost path; a bridge suspends its provider session after ~30s below it (`-30` is a guess, never validated against a real room). Unset = off, no suspending. Beware the sign: dBFS is negative, so `0` gates hardest, not least. goaway/reconnect fixes and the always-on default translator are independent of this. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
+- `LIVE_AUDIO_OPENAI_MODEL` / `LIVE_AUDIO_OPENAI_VOICE` - override the OpenAI Realtime model
+  (default `gpt-realtime-2.1`, the general speech-to-speech model — deliberately *not*
+  `gpt-realtime-translate`, whose 13 output languages exclude Haitian Creole) and voice
+  (default `marin`)
+- `LIVE_AUDIO_OPENAI_LANGUAGES` - comma-separated BCP-47 codes to route to OpenAI instead of
+  Gemini. Only for comparing the two backends on a language both support; `ht` is routed by
+  capability and needs no entry.
 - `VITE_PUBLIC_POSTHOG_KEY` - PostHog analytics key (for usage tracking)
 - `VITE_PUBLIC_POSTHOG_HOST` - PostHog host URL (default: https://us.i.posthog.com)
 - `POSTHOG_CLI_TOKEN` - PostHog CLI token (for sourcemap uploads during Docker build)
@@ -395,6 +408,21 @@ The app has two modes determined by URL hash (`#editor`):
 ### Backend
 - [server.ts](server.ts) - Express backend with Y-Sweet auth, translation API, and TTS endpoint
 - [nlp.ts](nlp.ts) - Gemini API integration for translation
+- Live speech translation (`live-audio/`), split at a provider seam so the resilience work
+  is written once and every backend inherits it:
+  - [translation-bridge.ts](live-audio/translation-bridge.ts) - one bridge per (session, language):
+    LiveKit membership, subscription reconcile, stall watchdog, reconnect/gap buffering, silence gating
+  - [translation-session-manager.ts](live-audio/translation-session-manager.ts) - the supervisor loop
+    that reconciles running bridges against LiveKit room presence
+  - [realtime-provider.ts](live-audio/realtime-provider.ts) - the seam: `RealtimeProvider` (connect,
+    configure, interpret, wrap a frame, sample rates) and the `ProviderEvent` vocabulary
+  - [gemini-provider.ts](live-audio/gemini-provider.ts) - Gemini Live Translate (the default; a
+    purpose-built translate model, so "interpret, don't converse" is a model property)
+  - [openai-provider.ts](live-audio/openai-provider.ts) - OpenAI Realtime for Haitian Creole, via the
+    general speech-to-speech model + an interpreter prompt. **Read its header before touching it**:
+    it explains why not `gpt-realtime-translate`, and what a prompt guarantees that a model doesn't
+  - [provider-selection.ts](live-audio/provider-selection.ts) - which backend serves a language
+  - [transcript-writer.ts](live-audio/transcript-writer.ts) - persists transcript deltas into Yjs
 - Proclaim → Yjs sync (Python), decoupled into a slide feed + consumers:
   - [proclaim_service.py](proclaim_service.py) - thin entrypoint: env/config, telemetry, and wiring
   - [slide_feed.py](slide_feed.py) - the seam: `FeedSnapshot` (serializable), `SlideFeed` Protocol, `SnapshotBus`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,22 @@ asyncio backend via the `anyio_backend` fixture in [tests/conftest.py](tests/con
 which also sets `YSWEET_URL` and puts the repo root on `sys.path`. The new library modules are
 import-clean (no `YSWEET_URL` needed to import them).
 
+### Spikes
+
+```bash
+# Which TTS engine can actually speak Haitian Creole? (see the script header)
+node creole-voice-spike.ts --help
+node creole-voice-spike.ts --file notes-ht.txt
+```
+
+[creole-voice-spike.ts](creole-voice-spike.ts) synthesizes one passage through the OpenAI
+speech endpoint, OpenAI Realtime (text in → audio out), and ElevenLabs as a control, then
+writes an `index.html` that plays them side by side. It exists because **no vendor
+documents a Haitian Creole voice** — `VOICE_CONFIG` in [server.ts](server.ts) has only
+French and Spanish, so `/api/tts` returns 400 for Creole even though Creole *is* a notes
+translation language in [configAtoms.ts](src/configAtoms.ts). Whether any engine sounds
+acceptable is a listening question, not a testable one. Output is gitignored.
+
 ### Deployment
 ```bash
 # Build and run with Docker Compose

--- a/creole-voice-spike.ts
+++ b/creole-voice-spike.ts
@@ -1,0 +1,593 @@
+#!/usr/bin/env node
+/**
+ * Haitian Creole voice spike — which TTS engine can actually speak Creole?
+ *
+ * ## The question
+ *
+ * Creole is already a first-class *notes* translation language (`configAtoms.ts`), but
+ * `VOICE_CONFIG` in server.ts has entries only for French and Spanish, so `/api/tts`
+ * returns 400 for it: Creole notes are translated today and cannot be spoken. Fixing
+ * that means picking an engine — and **no vendor documents a Haitian Creole voice**:
+ *
+ *   - ElevenLabs v3 publishes 74 languages; Creole is not among them.
+ *   - OpenAI's speech API advertises "50+ languages" and doesn't name Creole either.
+ *   - Google Chirp 3 HD (see the `switch-tts-chirp-3-hd` branch) almost certainly not.
+ *
+ * What makes it worth trying anyway is that these endpoints take **no language
+ * parameter**. You hand them text and they speak it. So "unsupported" may mean "we
+ * don't promise anything" rather than "it will refuse" — and OpenAI's realtime model
+ * demonstrably produces Creole, since that is what ChatGPT's voice mode does.
+ *
+ * That is an empirical question about how something *sounds*, which no test can answer.
+ * Hence a spike: synthesize the same passage through every candidate, then have a
+ * Creole speaker listen and rank them.
+ *
+ * ## Why this is worth doing on the notes path rather than live audio
+ *
+ * Notes TTS is text-driven and cacheable, so the audio exists *before* the service and
+ * can be reviewed. Live speech-to-speech (the `ht` bridge on this branch) cannot be
+ * reviewed even in principle — you find out what it said when the congregation does.
+ * See issues #81 and #88.
+ *
+ * ## Usage
+ *
+ *   node creole-voice-spike.ts                        # all available engines, sample text
+ *   node creole-voice-spike.ts --file notes-ht.txt    # real Creole notes (preferred)
+ *   node creole-voice-spike.ts --text "Bonjou tout moun."
+ *   node creole-voice-spike.ts --engines openai-tts,openai-realtime
+ *   node creole-voice-spike.ts --mode translate --file notes-en.txt
+ *   node creole-voice-spike.ts --help
+ *
+ * Modes:
+ *   read      (default) Creole text in, spoken Creole out — the notes-TTS question.
+ *   translate English text in, spoken Creole out — asks whether one realtime hop can
+ *             replace "Gemini translates, then something speaks it". Only meaningful
+ *             for the realtime engine; the plain TTS endpoints just read what you give
+ *             them, so they are skipped in this mode.
+ *
+ * Reads keys from `.env` (same as the server): OPENAI_API_KEY, ELEVENLABS_API_KEY.
+ * An engine whose key is missing is skipped and reported as skipped — never silently.
+ *
+ * Output: `creole-voice-spike/` containing one audio file per engine, an `index.html`
+ * that plays them side by side (open it in a browser and hand it to a Creole speaker),
+ * and `results.json` with what each engine did, including how long it took.
+ *
+ * **A vendor refusing is a result, not a crash.** Every engine's failure is captured
+ * and reported so the run always produces a comparison, however partial.
+ */
+
+import 'dotenv/config';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import WebSocket from 'ws';
+
+const OUT_DIR = 'creole-voice-spike';
+
+/**
+ * Default passage. Deliberately liturgical and widely published (the opening of the
+ * Lord's Prayer and John 3:16 in standard Haitian Creole) rather than composed here, so
+ * a listener can judge pronunciation against text they already know — and so this file
+ * isn't inventing Creole.
+ *
+ * It also contains the two things I expect engines to get wrong, which is the point of
+ * including them: a spoken scripture reference with numbers ("chapit twa, vèsè sèz")
+ * and proper names ("Jan", "Bondye").
+ *
+ * **Replace this for the real evaluation.** Use actual Creole notes from a past service
+ * (`sessionExport.ts` can pull them) — the register of real notes is what matters, and a
+ * native speaker should confirm whatever text you test with.
+ */
+const SAMPLE_CREOLE = [
+  'Papa nou ki nan syèl la, se pou yo toujou respekte non ou.',
+  'Bonjou tout moun. Jodi a, n ap li nan liv Jan, chapit twa, vèsè sèz.',
+  'Paske Bondye te renmen lemonn lan tèlman, li bay sèl Pitit li a.',
+  'Mèsi anpil. Ann priye ansanm.',
+].join('\n');
+
+/** English source for `--mode translate`, roughly parallel to the Creole sample. */
+const SAMPLE_ENGLISH = [
+  'Good morning, everyone. Today we are reading from the book of John, chapter three, verse sixteen.',
+  'For God so loved the world that he gave his only Son.',
+  'Thank you. Let us pray together.',
+].join('\n');
+
+interface Options {
+  text: string;
+  /** Path to read the passage from, if given; overrides `text`. */
+  file: string | null;
+  mode: 'read' | 'translate';
+  engines: string[] | null;
+  outDir: string;
+  voice: string | null;
+  realtimeModel: string;
+  ttsModel: string;
+}
+
+interface EngineResult {
+  id: string;
+  label: string;
+  status: 'ok' | 'skipped' | 'failed';
+  file?: string;
+  bytes?: number;
+  elapsedMs?: number;
+  /** What the model reported it said, when it tells us (realtime transcript). */
+  reportedText?: string;
+  detail?: string;
+}
+
+/** One candidate engine. `run` returns the audio and the extension to save it under. */
+interface Engine {
+  id: string;
+  label: string;
+  /** Why this engine can't run, or null if it can. */
+  unavailable(opts: Options): string | null;
+  /** Whether this engine is meaningful in the given mode. */
+  supportsMode(mode: Options['mode']): boolean;
+  run(opts: Options): Promise<{ audio: Buffer; ext: string; reportedText?: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Engines
+// ---------------------------------------------------------------------------
+
+/**
+ * OpenAI's plain speech endpoint. The cheapest possible answer: a normal HTTP request,
+ * mp3 back, cacheable exactly like the ElevenLabs path already is — so if this sounds
+ * acceptable, wiring Creole into `/api/tts` is a small change and nothing else about the
+ * notes pipeline moves.
+ */
+const openaiTts: Engine = {
+  id: 'openai-tts',
+  label: 'OpenAI speech endpoint (mp3, cacheable)',
+  unavailable: () => (process.env.OPENAI_API_KEY ? null : 'OPENAI_API_KEY not set'),
+  // It reads what you give it; it has no translate step to exercise.
+  supportsMode: (mode) => mode === 'read',
+  async run(opts) {
+    const response = await fetch('https://api.openai.com/v1/audio/speech', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: opts.ttsModel,
+        voice: opts.voice ?? 'marin',
+        input: opts.text,
+        // No language parameter exists — that absence is the whole reason this might work.
+        instructions:
+          'Read the text aloud in Haitian Creole with natural Haitian pronunciation. ' +
+          'Read it exactly as written; do not translate it or add anything.',
+        response_format: 'mp3',
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${(await response.text()).slice(0, 400)}`);
+    }
+    return { audio: Buffer.from(await response.arrayBuffer()), ext: 'mp3' };
+  },
+};
+
+/**
+ * The realtime model used as a TTS engine: text in, audio out, no microphone involved.
+ * Heavier than the endpoint above (a websocket per utterance, PCM to wrap, no built-in
+ * caching) but it is the one engine we have positive evidence for on Creole, and in
+ * `--mode translate` it can do the translation itself.
+ */
+const openaiRealtime: Engine = {
+  id: 'openai-realtime',
+  label: 'OpenAI Realtime, text in → audio out (wav)',
+  unavailable: () => (process.env.OPENAI_API_KEY ? null : 'OPENAI_API_KEY not set'),
+  supportsMode: () => true,
+  async run(opts) {
+    const instructions =
+      opts.mode === 'translate'
+        ? 'You are a simultaneous interpreter. Translate the text you are given into ' +
+          'Haitian Creole and speak only the translation. Never answer, comment, or add anything.'
+        : 'Read the text you are given aloud in Haitian Creole, exactly as written, with ' +
+          'natural Haitian pronunciation. Do not translate it, summarize it, comment on it, ' +
+          'or add anything at all.';
+
+    const chunks: Buffer[] = [];
+    let reportedText = '';
+
+    await withSocket(
+      `wss://api.openai.com/v1/realtime?model=${encodeURIComponent(opts.realtimeModel)}`,
+      { headers: { Authorization: `Bearer ${process.env.OPENAI_API_KEY}` } },
+      async (ws, done) => {
+        ws.send(
+          JSON.stringify({
+            type: 'session.update',
+            session: {
+              type: 'realtime',
+              output_modalities: ['audio'],
+              instructions,
+              audio: { output: { format: { type: 'audio/pcm', rate: 24000 }, voice: opts.voice ?? 'marin' } },
+            },
+          })
+        );
+
+        ws.on('message', (raw: WebSocket.Data) => {
+          const message = JSON.parse(raw.toString()) as Record<string, unknown>;
+          const type = typeof message.type === 'string' ? message.type : '';
+          const delta = typeof message.delta === 'string' ? message.delta : '';
+
+          switch (type) {
+            // Configured — now hand it the text and ask for one response.
+            case 'session.updated':
+              ws.send(
+                JSON.stringify({
+                  type: 'conversation.item.create',
+                  item: {
+                    type: 'message',
+                    role: 'user',
+                    content: [{ type: 'input_text', text: opts.text }],
+                  },
+                })
+              );
+              ws.send(JSON.stringify({ type: 'response.create' }));
+              break;
+
+            case 'response.output_audio.delta':
+            case 'response.audio.delta':
+              if (delta) chunks.push(Buffer.from(delta, 'base64'));
+              break;
+
+            // What the model believes it said — worth capturing, because in translate
+            // mode it is the translation, and in read mode a divergence from the input
+            // is the tell that it "helpfully" rewrote the text.
+            case 'response.output_audio_transcript.delta':
+            case 'response.audio_transcript.delta':
+              reportedText += delta;
+              break;
+
+            case 'response.done':
+              done(null);
+              break;
+
+            case 'error': {
+              const error = (message.error ?? {}) as { message?: string; code?: string };
+              done(new Error(`${error.code ?? 'error'}: ${error.message ?? 'unknown'}`));
+              break;
+            }
+          }
+        });
+      }
+    );
+
+    if (chunks.length === 0) throw new Error('session produced no audio');
+    return {
+      audio: pcm16ToWav(Buffer.concat(chunks), 24000),
+      ext: 'wav',
+      reportedText: reportedText.trim() || undefined,
+    };
+  },
+};
+
+/**
+ * The incumbent, included as a control rather than a candidate. ElevenLabs doesn't list
+ * Creole, so the useful question isn't "does it work" but "what does it *do*" — read it
+ * as French (partially intelligible, given the shared vocabulary), mangle it, or refuse?
+ * The answer decides whether Creole needs a different engine or merely a voice setting,
+ * and it sets the quality bar the alternatives are judged against, since this is what
+ * French and Spanish listeners already hear.
+ */
+const elevenlabs: Engine = {
+  id: 'elevenlabs',
+  label: 'ElevenLabs multilingual v2 (control — Creole not on its language list)',
+  unavailable: () => (process.env.ELEVENLABS_API_KEY ? null : 'ELEVENLABS_API_KEY not set'),
+  supportsMode: (mode) => mode === 'read',
+  async run(opts) {
+    const { ElevenLabsClient } = await import('@elevenlabs/elevenlabs-js');
+    const client = new ElevenLabsClient({ apiKey: process.env.ELEVENLABS_API_KEY });
+    // Same voice and model server.ts uses for French, so this is a fair read of what
+    // the existing pipeline would produce if Creole were simply added to VOICE_CONFIG.
+    const stream = await client.textToSpeech.convert(opts.voice ?? 'JBFqnCBsd6RMkjVDRZzb', {
+      text: opts.text,
+      modelId: 'eleven_multilingual_v2',
+      voiceSettings: { speed: 0.9 },
+    });
+
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream as AsyncIterable<Uint8Array>) chunks.push(Buffer.from(chunk));
+    return { audio: Buffer.concat(chunks), ext: 'mp3' };
+  },
+};
+
+const ENGINES: Engine[] = [openaiTts, openaiRealtime, elevenlabs];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a websocket exchange to completion, with a hard timeout so a stalled vendor can't
+ * hang the spike. `register` wires the message handlers and calls `done` to finish.
+ */
+async function withSocket(
+  url: string,
+  options: WebSocket.ClientOptions,
+  register: (ws: WebSocket, done: (err: Error | null) => void) => Promise<void>,
+  timeoutMs = 90_000
+): Promise<void> {
+  const ws = new WebSocket(url, options);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs);
+      const done = (err: Error | null) => {
+        clearTimeout(timer);
+        if (err) reject(err);
+        else resolve();
+      };
+      ws.on('error', (err) => done(err instanceof Error ? err : new Error(String(err))));
+      ws.on('close', (code, reason) =>
+        done(new Error(`socket closed before finishing: ${code} ${reason.toString()}`))
+      );
+      ws.on('open', () => {
+        void register(ws, done).catch(done);
+      });
+    });
+  } finally {
+    ws.close();
+  }
+}
+
+/** Wrap raw PCM16 mono in a RIFF/WAVE header so the file is double-clickable. */
+function pcm16ToWav(pcm: Buffer, sampleRate: number, channels = 1): Buffer {
+  const header = Buffer.alloc(44);
+  const byteRate = sampleRate * channels * 2;
+  header.write('RIFF', 0);
+  header.writeUInt32LE(36 + pcm.length, 4);
+  header.write('WAVE', 8);
+  header.write('fmt ', 12);
+  header.writeUInt32LE(16, 16); // fmt chunk size
+  header.writeUInt16LE(1, 20); // PCM
+  header.writeUInt16LE(channels, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(channels * 2, 32); // block align
+  header.writeUInt16LE(16, 34); // bits per sample
+  header.write('data', 36);
+  header.writeUInt32LE(pcm.length, 40);
+  return Buffer.concat([header, pcm]);
+}
+
+function parseArgs(argv: string[]): Options | 'help' {
+  const opts: Options = {
+    text: '',
+    file: null,
+    mode: 'read',
+    engines: null,
+    outDir: OUT_DIR,
+    voice: null,
+    realtimeModel: process.env.LIVE_AUDIO_OPENAI_MODEL || 'gpt-realtime-2.1',
+    ttsModel: 'gpt-4o-mini-tts',
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const value = () => {
+      const v = argv[++i];
+      if (v === undefined) throw new Error(`${arg} needs a value`);
+      return v;
+    };
+    switch (arg) {
+      case '--help':
+      case '-h':
+        return 'help';
+      case '--text':
+        opts.text = value();
+        break;
+      case '--file':
+        opts.file = value();
+        break;
+      case '--mode': {
+        const mode = value();
+        if (mode !== 'read' && mode !== 'translate') throw new Error(`unknown mode: ${mode}`);
+        opts.mode = mode;
+        break;
+      }
+      case '--engines':
+        opts.engines = value()
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        break;
+      case '--out':
+        opts.outDir = value();
+        break;
+      case '--voice':
+        opts.voice = value();
+        break;
+      case '--realtime-model':
+        opts.realtimeModel = value();
+        break;
+      case '--tts-model':
+        opts.ttsModel = value();
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg} (try --help)`);
+    }
+  }
+
+  return opts;
+}
+
+const HELP = `
+Haitian Creole voice spike — synthesize one passage through every candidate engine
+so a Creole speaker can listen and rank them.
+
+  node creole-voice-spike.ts [options]
+
+  --file PATH            read the passage from a file (preferred: real Creole notes)
+  --text "..."           read the passage from the command line
+  --mode read|translate  read (default): Creole in, Creole speech out
+                         translate: English in, Creole speech out (realtime only)
+  --engines a,b          limit to these engines (${ENGINES.map((e) => e.id).join(', ')})
+  --voice ID             voice name (OpenAI) or voice id (ElevenLabs)
+  --realtime-model ID    default gpt-realtime-2.1
+  --tts-model ID         default gpt-4o-mini-tts
+  --out DIR              output directory (default ${OUT_DIR})
+
+Keys come from .env: OPENAI_API_KEY, ELEVENLABS_API_KEY. Missing keys skip an engine.
+Writes audio + index.html + results.json; open index.html to compare them.
+`.trim();
+
+/** A tiny local player, so the person judging this doesn't have to be a developer. */
+function buildIndexHtml(opts: Options, results: EngineResult[]): string {
+  const rows = results
+    .map((r) => {
+      if (r.status !== 'ok') {
+        return `<section class="engine bad">
+      <h2>${escapeHtml(r.label)}</h2>
+      <p class="status">${r.status.toUpperCase()}: ${escapeHtml(r.detail ?? '')}</p>
+    </section>`;
+      }
+      const reported = r.reportedText
+        ? `<p class="reported"><strong>Model reported saying:</strong> ${escapeHtml(r.reportedText)}</p>`
+        : '';
+      return `<section class="engine">
+      <h2>${escapeHtml(r.label)}</h2>
+      <audio controls preload="none" src="${escapeHtml(r.file ?? '')}"></audio>
+      <p class="meta">${r.bytes ?? 0} bytes · ${r.elapsedMs ?? 0} ms · <code>${escapeHtml(r.id)}</code></p>
+      ${reported}
+    </section>`;
+    })
+    .join('\n    ');
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Haitian Creole voice spike</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 46rem; margin: 2rem auto; padding: 0 1rem;
+           line-height: 1.5; color: #111; }
+    @media (prefers-color-scheme: dark) { body { background: #111; color: #eee; }
+      .engine { border-color: #444; } pre { background: #1c1c1c; } }
+    h1 { font-size: 1.4rem; }
+    pre { white-space: pre-wrap; background: #f4f4f4; padding: .75rem; border-radius: .4rem; }
+    .engine { border: 1px solid #ddd; border-radius: .5rem; padding: .75rem 1rem; margin: 1rem 0; }
+    .engine.bad { opacity: .65; }
+    audio { width: 100%; margin: .5rem 0; }
+    .meta, .status { font-size: .85rem; opacity: .75; margin: .25rem 0 0; }
+    .reported { font-size: .9rem; }
+    .ask { border-left: 3px solid #888; padding-left: .8rem; }
+  </style>
+</head>
+<body>
+  <h1>Haitian Creole voice spike</h1>
+  <p>Mode: <code>${escapeHtml(opts.mode)}</code>. Passage given to each engine:</p>
+  <pre>${escapeHtml(opts.text)}</pre>
+
+  <div class="ask">
+    <p><strong>What to listen for</strong> (please note answers per engine):</p>
+    <ol>
+      <li>Is it Haitian Creole, or French/English with Creole words?</li>
+      <li>Is the pronunciation natural enough for a congregation to follow easily?</li>
+      <li>Are the proper names and the scripture reference (chapter and verse numbers) right?</li>
+      <li>Would you rather hear this than nothing? (That is the real bar today.)</li>
+    </ol>
+  </div>
+
+  ${rows}
+</body>
+</html>
+`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] ?? c
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  let parsed: Options | 'help';
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(`${(error as Error).message}\n\n${HELP}`);
+    process.exit(2);
+  }
+  if (parsed === 'help') {
+    console.log(HELP);
+    return;
+  }
+
+  const opts = parsed;
+  // --file wins over --text, and both win over the built-in sample.
+  if (opts.file) opts.text = (await fs.readFile(opts.file, 'utf8')).trim();
+  if (!opts.text) opts.text = opts.mode === 'translate' ? SAMPLE_ENGLISH : SAMPLE_CREOLE;
+
+  const selected = ENGINES.filter((e) => !opts.engines || opts.engines.includes(e.id));
+  if (opts.engines) {
+    for (const id of opts.engines) {
+      if (!ENGINES.some((e) => e.id === id)) console.warn(`! unknown engine "${id}" ignored`);
+    }
+  }
+
+  await fs.mkdir(opts.outDir, { recursive: true });
+  console.log(`Mode: ${opts.mode}\nPassage (${opts.text.length} chars):\n${opts.text}\n`);
+
+  const results: EngineResult[] = [];
+  for (const engine of selected) {
+    const base: EngineResult = { id: engine.id, label: engine.label, status: 'skipped' };
+
+    if (!engine.supportsMode(opts.mode)) {
+      results.push({ ...base, detail: `not meaningful in --mode ${opts.mode}` });
+      console.log(`- ${engine.id}: skipped (not meaningful in --mode ${opts.mode})`);
+      continue;
+    }
+    const blocked = engine.unavailable(opts);
+    if (blocked) {
+      results.push({ ...base, detail: blocked });
+      console.log(`- ${engine.id}: skipped (${blocked})`);
+      continue;
+    }
+
+    const startedAt = Date.now();
+    try {
+      const { audio, ext, reportedText } = await engine.run(opts);
+      const filename = `${engine.id}-${opts.mode}.${ext}`;
+      await fs.writeFile(path.join(opts.outDir, filename), audio);
+      results.push({
+        ...base,
+        status: 'ok',
+        file: filename,
+        bytes: audio.length,
+        elapsedMs: Date.now() - startedAt,
+        reportedText,
+      });
+      console.log(`✓ ${engine.id}: ${filename} (${audio.length} bytes, ${Date.now() - startedAt} ms)`);
+      if (reportedText) console.log(`    reported: ${reportedText}`);
+    } catch (error) {
+      // A vendor refusing Creole is the finding, not a crash. Record and carry on.
+      const detail = (error as Error).message;
+      results.push({ ...base, status: 'failed', elapsedMs: Date.now() - startedAt, detail });
+      console.log(`✗ ${engine.id}: FAILED — ${detail}`);
+    }
+  }
+
+  const indexPath = path.join(opts.outDir, 'index.html');
+  await fs.writeFile(indexPath, buildIndexHtml(opts, results));
+  await fs.writeFile(
+    path.join(opts.outDir, 'results.json'),
+    JSON.stringify({ mode: opts.mode, text: opts.text, ranAt: new Date().toISOString(), results }, null, 2)
+  );
+
+  const ok = results.filter((r) => r.status === 'ok').length;
+  console.log(`\n${ok}/${results.length} engine(s) produced audio.`);
+  console.log(`Open ${indexPath} and listen — ideally with a Creole speaker.`);
+  if (ok === 0) console.log('No audio at all: check keys and the failure messages above.');
+}
+
+// Keep the exit code honest so this can be dropped into a script later.
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,9 +14,9 @@ derived data) drives the testing/replay strategy.
 │  future macOS      │                  │   │ translated │ source  │
 │  ingest service)   │                  │   │ audio      ▼ audio   │
 └────────────────────┘                  │ translation-bridge ──────┼──▶ Gemini Live
-┌────────────────────┐                  │  (per language, spawned  │    (translate speech)
-│ Proclaim Mac       │                  │   on listener demand by  │
-│ proclaim_service.py│─┐                │   translation-session-   │
+┌────────────────────┐                  │  (per language, spawned  │    (most languages)
+│ Proclaim Mac       │                  │   on listener demand by  │──▶ OpenAI Realtime
+│ proclaim_service.py│─┐                │   translation-session-   │    (Haitian Creole)
 └────────────────────┘ │                │   manager)               │
                        │ Y-Sweet WS     ├──────────────────────────┤
 ┌────────────────────┐ │                │ Express server           │──▶ Gemini (block +
@@ -38,13 +38,23 @@ derived data) drives the testing/replay strategy.
   reconciles running `translation-bridge`s against LiveKit room presence — listeners carry a
   `listen=<lang>` participant attribute in their token, and the loop starts, recreates, or
   winds down one bridge per (session, language) to match (no refcounts or beacons). Each
-  bridge subscribes to the organizer's LiveKit track (16 kHz in), streams to Gemini Live,
+  bridge subscribes to the organizer's LiveKit track, streams it to its **provider**,
   publishes translated audio (24 kHz out), and writes the transcript into Yjs via
-  `transcript-writer`. When a Gemini session is swapped (goaway/reconnect), input frames are
+  `transcript-writer`. Which provider is a per-language decision (`provider-selection.ts`):
+  **Gemini Live Translate** (16 kHz in) for everything it supports, **OpenAI Realtime**
+  (24 kHz in) for Haitian Creole, which Gemini Live Translate has no voice for. The seam is
+  `RealtimeProvider` — connect, configure, interpret a message, wrap an input frame, and the
+  two sample rates — and it is deliberately narrow: everything below (reconnects, the gap
+  buffer, subscription reconcile, the stall watchdog, silence gating) is one implementation
+  shared by both, so a new provider inherits the incident history in `live-audio-resilience.md`
+  instead of re-earning it. Two consequences worth knowing: for OpenAI the "only translate,
+  never converse" rule is a *prompt*, not a model property, and that path is turn-based
+  rather than continuous — see `openai-provider.ts`'s header. When a provider session is
+  swapped (goaway/reconnect), input frames are
   buffered across the gap and flushed into the fresh session, so a swap costs a little
   latency rather than dropped words (always on). A **cost path** — off unless
   `LIVE_AUDIO_SILENCE_THRESHOLD_DBFS` names a level (−30 is a guess) — additionally
-  suspends a bridge's Gemini socket after ~30 s below that level, reopening on the first
+  suspends a bridge's provider socket after ~30 s below that level, reopening on the first
   non-silent frame; the LiveKit participant/track stay live so listeners never resubscribe.
   That threshold is the feature's only switch: unset, it is −Infinity, every frame reads as
   voice, and nothing can suspend. It affects only what a bridge does while nobody speaks —
@@ -69,7 +79,7 @@ doc is *derived* data that the system under test will regenerate.
 |---|---|---|
 | Human editor (browser) | `sourceTextBlocks` edits | Keystrokes — these *are* Yjs deltas; Yjs-level recording is correct **only** for this writer |
 | `proclaim_service.py` (slide feed → Yjs publisher + translator) | `proclaimServiceOrder`, `proclaimPresentations`, `proclaimStatus`, `slideTranslations`, `status.proclaimService` | Proclaim local HTTP API responses + `PresentationManager.db` |
-| translation-bridge / transcript-writer | live transcript | Organizer audio track + Gemini Live responses |
+| translation-bridge / transcript-writer | live transcript | Organizer audio track + provider (Gemini Live / OpenAI Realtime) responses |
 | Block translation manager | per-language translations, `notesTranslationCache` | Source blocks + `/api/translate` (Gemini) |
 | Slide translation agent | slide translations, conversations, library | Slide texts + Gemini |
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -13,12 +13,15 @@ most of these signals.
    sink, captured with `distinctId = sessionId` and every property also tagged with `sessionId`,
    `targetLanguage`, and `identity` (`translator-<code>`), so a talk's whole history groups by
    session. Best for *history and rates* ("how often do sessions drop", "how long are the gaps").
-   Off when telemetry is unconfigured (dev/tests); logs still print each event.
+   Off when telemetry is unconfigured (dev/tests); logs still print each event. Every event
+   also carries `provider` (`gemini`/`openai`) and `model`, so a query can span both backends
+   even though the provider-leg event *names* are per-provider (see below).
 2. **In-process manager/bridge state** — live, authoritative for "what is running right now",
    but in-memory only (single server instance; rebuilt from presence after a restart by the
    supervisor). Exposed by `GET /api/livekit/translate/status?sessionId=…` →
    `getActiveTranslations()` (`{ language, translatorIdentity, status, subscriberCount,
-   health }[]`, where `health` is the bridge's composite snapshot: per-leg Gemini state,
+   health }[]`, where `health` is the bridge's composite snapshot: `providerName`, the
+   provider leg's state (`provider` — the field was called `gemini` before there were two),
    last input/output frame ages, reconnect count, gap-buffer depth).
 3. **LiveKit RoomService** — source of truth for *room/participant presence* (who's actually
    connected: `organizer-*`, `translator-*`, listeners; their track publications, and each
@@ -35,6 +38,19 @@ supervisor start/stop decision.
 
 ## PostHog events (from `translation-bridge.ts`)
 
+**Provider-leg events are prefixed with the provider name.** The table below lists the Gemini
+names; an OpenAI bridge (Haitian Creole) emits the identical set as `openai_session_closed`,
+`openai_reconnect_attempt`, and so on. That's deliberate rather than tidy: every existing
+dashboard and saved insight is written against the `gemini_*` names, and observability is worth
+least at the moment it changes meaning — so the incumbent's history is left alone and the second
+provider gets a parallel series. Break down or filter by the `provider` property to see both at
+once. Room/input-side events (`livekit_*`, `organizer_*`, `supervisor_*`) are provider-independent
+and are **not** prefixed.
+
+Two Gemini-shaped rows do not apply to OpenAI: it sends no `goAway` (a session hits its limit and
+the socket simply closes, which lands in `*_session_closed` and the backoff path) and offers no
+resumption handle. `openai_session_error` is the one row Gemini doesn't have.
+
 | Event | Meaning | Key properties |
 |---|---|---|
 | `gemini_session_setup_complete` | A Gemini socket finished setup and is serving. | `isReconnect`, `trigger`, `setupLatencyMs`, `totalReconnects` |
@@ -48,6 +64,7 @@ supervisor start/stop decision.
 | `gemini_suspended_silence` | Cost path: socket torn down after sustained silence. | `silentMs`, `framesSent/Received` |
 | `gemini_resumed_voice` | Cost path: socket reopened on returning speech. | `silentMs` |
 | `gemini_session_resumption_update` | Whether the translate model offered a resume handle (not yet used). | `resumable`, `hasHandle` |
+| `<provider>_session_error` | The server reported an error on the session. `fatal` means the session is over and a replacement socket is opening; non-fatal is per-response (e.g. OpenAI rejecting a response while one is still speaking) and the socket keeps working. | `code`, `message`, `fatal` |
 
 Server-level exceptions go through `phClient.captureException(...)` in
 [server.ts](../server.ts) (token issue, translate start, unsubscribe, etc.).
@@ -70,19 +87,26 @@ Server-level exceptions go through `phClient.captureException(...)` in
 - **Is the supervisor converging?** `supervisor_bridge_started` / `supervisor_bridge_stopped` /
   `supervisor_bridge_start_failed` events (distinctId = sessionId). A start/stop cycle repeating
   for one language means demand is flapping or a bridge can't hold; `start_failed` repeating
-  means LiveKit/Gemini won't accept the bridge at all.
+  means LiveKit or the provider won't accept the bridge at all. One specific cause worth
+  recognizing: `start_failed` for `ht` with "No realtime provider configured that can translate
+  into..." means `OPENAI_API_KEY` is unset — Haitian Creole has no Gemini fallback, so it fails
+  rather than quietly translating into something else. The server logs which providers it has at
+  boot (`[server] Live-audio providers: …`).
+- **Which backend is a language on?** `health.providerName` from the status endpoint, or the
+  `provider` property on any bridge event. Expect `gemini` everywhere except `ht`, unless
+  `LIVE_AUDIO_OPENAI_LANGUAGES` has been set.
 
 ## Gaps worth filling (not yet exposed)
 
-The status endpoint now returns each bridge's `health` snapshot (`status`, per-leg `gemini`
-state, `lastInputFrameAt`/`lastOutputFrameAt`, `reconnects`, `bufferedFrames`). Still cheap and
-worth surfacing:
+The status endpoint now returns each bridge's `health` snapshot (`status`, `providerName`,
+per-leg `provider` state, `lastInputFrameAt`/`lastOutputFrameAt`, `reconnects`,
+`bufferedFrames`). Still cheap and worth surfacing:
 
-- Per bridge: `framesSentToGemini` / `framesReceivedFromGemini`, `lastVoiceAt` /
+- Per bridge: `framesSentToProvider` / `framesReceivedFromProvider`, `lastVoiceAt` /
   `sessionConnectedAt` ages, `framesDroppedWhileDown`.
 - Server: whether the cost path is enabled and whether LiveKit is configured, so a dashboard can
   explain why behavior differs between environments.
-- A cheap **liveness heartbeat**: "frames received from Gemini in the last N s" per active bridge
+- A cheap **liveness heartbeat**: "frames received from the provider in the last N s" per active bridge
   distinguishes "active" from "active but silent/stuck" without waiting for the 2 s `gemini_audio_gap`
   threshold. Consider a periodic gauge rather than only edge events.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,8 @@ Short, surfaced-not-comprehensive documentation. Coding agents can grep; humans 
 - [OBSERVABILITY.md](OBSERVABILITY.md) — what to observe about the live-audio backend
   (status/liveness) and where to pull it from: PostHog events, in-process state, LiveKit, Yjs.
 - [live-audio-resilience.md](live-audio-resilience.md) — how the translation bridge survives
-  LiveKit and Gemini dropping connections under it. Incident history (two "active but deaf"
-  outages), the invariant, and the three defense layers. **Read before changing the bridge's
+  LiveKit and its translation provider dropping connections under it. Incident history (two
+  "active but deaf" outages), the invariant, and the three defense layers. **Read before changing the bridge's
   subscription or reconnect paths** — the failure mode is silent, and the sample code this
   subsystem came from does not defend against it. Written to be upstreamable.
 

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -71,14 +71,37 @@ an incident happens that this list would not have caught, add a line.
 - [ ] With **no listener yet**, the English transcript still flows — the default translator
       runs whenever the broadcaster is present, whatever the cost path is set to.
 
+Haitian Creole (the OpenAI provider). Creole is the one language not served by Gemini Live
+Translate, so it runs on a different backend — the general OpenAI speech-to-speech model told
+by prompt to interpret. **That path is unvalidated by ear and cannot be validated by CI**, so
+this block is a listening test, not a plumbing test, and it wants someone who speaks Creole:
+
+- [ ] Join Listen as `ht` while the speaker is talking. A `translator-ht` participant appears
+      and the transcript flows. Server log: `Starting bridge … via openai/gpt-realtime-2.1`.
+      (If the bridge won't start, check the boot line `[server] Live-audio providers: …` —
+      Creole has no Gemini fallback, so a missing `OPENAI_API_KEY` fails outright.)
+- [ ] **It is actually Creole**, not French and not English. This is the whole feature.
+- [ ] **It interprets, it doesn't converse.** Ask a rhetorical question from the podium
+      ("So what does Paul mean here?") and confirm the bot *translates the question* instead of
+      answering it. Also listen for added greetings, preambles, or commentary. Any of these
+      means the prompt lost — note it in the PR/issue rather than silently retuning.
+- [ ] **Lag under continuous speech.** This model waits for an end-of-turn before it speaks,
+      and is configured not to let new speech cut off a translation in progress, so lag can
+      grow behind a speaker who never pauses. Talk steadily for ~60 s and judge whether the
+      delay is usable for the room. Compare a French listener (Gemini, continuous) side by side.
+- [ ] Check the server log for `openai_session_error` lines — particularly a rejected response
+      while another is still speaking, the expected cost of the no-interruption setting.
+
 Cost path (only when `LIVE_AUDIO_SILENCE_THRESHOLD_DBFS` names a level — off by default; the
 startup log line reports which):
 
-- [ ] **Silence suspend/resume**: stay silent >30 s (server logs "Suspending Gemini after…");
-      then speak — the first words resume translation ("resuming Gemini after…") without the
+- [ ] **Silence suspend/resume**: stay silent >30 s (server logs "Suspending gemini after…");
+      then speak — the first words resume translation ("resuming gemini after…") without the
       listener resubscribing.
 - [ ] With the threshold **unset**, the opposite: stay silent >30 s and confirm no
-      "Suspending Gemini" line appears, with the mic both open-but-quiet and fully muted.
+      "Suspending" line appears, with the mic both open-but-quiet and fully muted.
+- [ ] If a Creole listener is connected, the same two checks on its bridge (logs name the
+      provider, so look for `openai`) — silence gating is shared code, not per-provider.
 
 ## 5. TTS (text-to-speech on translated notes)
 
@@ -89,6 +112,7 @@ startup log line reports which):
 
 - [ ] Close all listener tabs; confirm the supervisor winds the translator bots down within
       ~2 minutes (60 s demand grace + a reconcile tick; watch for `[SessionManager] Supervisor
-      stopping …` in server logs) — no orphaned Gemini sessions burning quota. (With the cost
+      stopping …` in server logs) — no orphaned provider sessions burning quota (check both
+      Gemini and, if Creole ran, OpenAI). (With the cost
       path enabled, closing listeners is not enough: the default translator stays up for the
       transcript until the broadcaster also leaves.)

--- a/docs/live-audio-resilience.md
+++ b/docs/live-audio-resilience.md
@@ -10,6 +10,17 @@ outages in services that run for ninety. **The notes here are written so they ca
 each fix is stated as a failure mode, an invariant, and a minimal remedy, not as a diff against
 our code.
 
+> **Naming note (since the OpenAI provider landed).** Everything below still holds, but the
+> bridge's model-side leg is no longer Gemini-specific: it talks to a `RealtimeProvider`
+> (Gemini Live Translate for most languages, OpenAI Realtime for Haitian Creole). Where this
+> document says "Gemini" about the *incidents*, it means Gemini — that's what was running.
+> Where it says "Gemini" about the *mechanism*, read "the provider": the fields, methods, and
+> tests were renamed accordingly (`geminiWs` → `providerWs`, `connectGemini` →
+> `connectProvider`, `sendAudioToGemini` → `sendAudioToProvider`, `health().gemini` →
+> `health().provider`). The defenses are shared by both providers, which is the point of the
+> seam. Telemetry event names stay per-provider (`gemini_*`, `openai_*`) so this history keeps
+> its dashboards — see [OBSERVABILITY.md](OBSERVABILITY.md).
+
 ## The invariant
 
 > A bridge whose `status` is `"active"` is receiving organizer audio.

--- a/docs/live-audio-state-architecture.md
+++ b/docs/live-audio-state-architecture.md
@@ -9,6 +9,15 @@ Companion to [live-audio-resilience.md](live-audio-resilience.md), which covers 
 "active but deaf" outages on the bridge's *input* side. This document zooms out: the same
 disease exists at every other layer, and the fixes so far have treated one organ.
 
+> **Naming note (since the OpenAI provider landed).** The "Gemini socket leg" audited below
+> is now the *provider* leg: a `RealtimeProvider` behind the same five fields (Gemini Live
+> Translate for most languages, OpenAI Realtime for Haitian Creole). The analysis and the
+> edge-case catalog are unchanged — extracting the provider seam deliberately did not touch
+> the lifecycle it describes — but the identifiers were renamed (`connectGemini` →
+> `connectProvider`, and so on; see [live-audio-resilience.md](live-audio-resilience.md)).
+> One line item does change: the leg now has one more way to be told it is finished, a fatal
+> `error` event from the provider, which routes into the existing reconnect path.
+
 ## The thesis
 
 The bridge's input side was fixed with a principle: **don't store a decision made from an

--- a/live-audio/gemini-provider.ts
+++ b/live-audio/gemini-provider.ts
@@ -1,0 +1,156 @@
+/**
+ * Gemini Live Translate, as a `RealtimeProvider`.
+ *
+ * This is a straight lift of what `translation-bridge.ts` used to do inline, so its
+ * behavior on the wire is unchanged: same model, same setup message, same
+ * `realtimeInput` frame shape, same 16 kHz in / 24 kHz out. Nothing here is new — the
+ * only new thing is that it is now nameable, so a second provider can sit beside it.
+ *
+ * Gemini's purpose-built translate model does the interpreting for us (`translationConfig`
+ * with `echoTargetLanguage`), which is why this provider carries no prompt: the model is
+ * already a simultaneous interpreter and cannot be talked into being a chatbot. That is
+ * the main thing the OpenAI provider has to reproduce by other means.
+ *
+ * Note it does **not** cover every language: Gemini Live Translate has no Haitian Creole,
+ * which is the whole reason a second provider exists (see provider-selection.ts).
+ */
+
+import type { ProviderConfig, ProviderEvent, RealtimeProvider } from "./realtime-provider.ts";
+
+const GEMINI_MODEL = "gemini-3.5-live-translate-preview";
+/** Gemini Live expects 16 kHz PCM16 input and returns 24 kHz PCM16 output. */
+const INPUT_SAMPLE_RATE = 16_000;
+const OUTPUT_SAMPLE_RATE = 24_000;
+
+/**
+ * Parse the `timeLeft` from a Gemini `goAway` message into milliseconds. The wire
+ * shape is unconfirmed for the translate model (the raw value is logged), so this
+ * tolerates a protobuf Duration string ("10s", "10.5s"), a bare number of seconds,
+ * or an expanded `{ seconds, nanos }` object. Returns null if it can't be parsed.
+ */
+export function parseGoAwayTimeLeftMs(raw: unknown): number | null {
+  if (raw == null) return null;
+  if (typeof raw === "number") return isFinite(raw) ? Math.round(raw * 1000) : null;
+  if (typeof raw === "string") {
+    const m = raw.trim().match(/^([\d.]+)\s*s?$/);
+    return m ? Math.round(parseFloat(m[1]) * 1000) : null;
+  }
+  if (typeof raw === "object") {
+    const o = raw as { seconds?: number | string; nanos?: number | string };
+    const secs = o.seconds != null ? Number(o.seconds) : NaN;
+    if (isNaN(secs)) return null;
+    return Math.round(secs * 1000 + Number(o.nanos ?? 0) / 1e6);
+  }
+  return null;
+}
+
+/** The subset of Gemini's serverContent the bridge reads. */
+interface GeminiServerContent {
+  modelTurn?: { parts?: Array<{ inlineData?: { data?: string } }> };
+  outputTranscription?: { text?: string };
+  inputTranscription?: { text?: string };
+}
+
+export class GeminiProvider implements RealtimeProvider {
+  readonly name = "gemini" as const;
+  readonly model = GEMINI_MODEL;
+  readonly inputSampleRate = INPUT_SAMPLE_RATE;
+  readonly outputSampleRate = OUTPUT_SAMPLE_RATE;
+
+  private readonly apiKey: string;
+  private readonly targetLanguage: string;
+  private readonly transcribeInput: boolean;
+
+  constructor(config: ProviderConfig) {
+    this.apiKey = config.apiKey;
+    this.targetLanguage = config.targetLanguage;
+    this.transcribeInput = config.transcribeInput;
+  }
+
+  socket(): { url: string } {
+    return {
+      url: `wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=${this.apiKey}`,
+    };
+  }
+
+  setupMessages(): unknown[] {
+    return [
+      {
+        setup: {
+          model: `models/${this.model}`,
+          outputAudioTranscription: {},
+          // Only the primary bridge transcribes the source audio (English), so the
+          // English transcript is produced once regardless of how many languages run.
+          ...(this.transcribeInput ? { inputAudioTranscription: {} } : {}),
+          generationConfig: {
+            responseModalities: ["AUDIO"],
+            translationConfig: {
+              targetLanguageCode: this.targetLanguage,
+              echoTargetLanguage: true,
+            },
+          },
+          realtimeInputConfig: {
+            automaticActivityDetection: {
+              disabled: false,
+            },
+          },
+        },
+      },
+    ];
+  }
+
+  inputFrameMessage(base64Audio: string): unknown {
+    return {
+      realtimeInput: {
+        audio: {
+          mimeType: `audio/pcm;rate=${this.inputSampleRate}`,
+          data: base64Audio,
+        },
+      },
+    };
+  }
+
+  interpret(message: Record<string, unknown>): ProviderEvent[] {
+    if (message.setupComplete) return [{ kind: "ready" }];
+
+    const events: ProviderEvent[] = [];
+
+    // goAway: the server warns before terminating, so the bridge can reconnect
+    // make-before-break rather than after the fact.
+    const goAway = (message.goAway ?? message.go_away) as
+      | { timeLeft?: unknown; time_left?: unknown }
+      | undefined;
+    if (goAway) {
+      const raw = goAway.timeLeft ?? goAway.time_left;
+      return [{ kind: "goAway", timeLeftMs: parseGoAwayTimeLeftMs(raw), raw }];
+    }
+
+    // sessionResumptionUpdate: we don't resume yet, but record whether the translate
+    // model even offers a handle — informs whether session resumption is worth adding.
+    const sru = message.sessionResumptionUpdate ?? message.session_resumption_update;
+    if (sru) {
+      const o = sru as { resumable?: boolean; newHandle?: string; new_handle?: string };
+      events.push({
+        kind: "resumable",
+        resumable: !!o.resumable,
+        hasHandle: !!(o.newHandle ?? o.new_handle),
+      });
+    }
+
+    const serverContent = (message as { serverContent?: GeminiServerContent }).serverContent;
+    for (const part of serverContent?.modelTurn?.parts ?? []) {
+      if (part.inlineData?.data) events.push({ kind: "audio", base64: part.inlineData.data });
+    }
+
+    // Gemini Live Translate streams a continuous flow of transcript deltas with no
+    // turnComplete, so every delta is persisted as it arrives.
+    if (serverContent?.outputTranscription?.text) {
+      events.push({ kind: "targetTranscript", text: serverContent.outputTranscription.text });
+    }
+    if (this.transcribeInput && serverContent?.inputTranscription?.text) {
+      events.push({ kind: "sourceTranscript", text: serverContent.inputTranscription.text });
+    }
+
+    return events;
+  }
+}

--- a/live-audio/openai-provider.ts
+++ b/live-audio/openai-provider.ts
@@ -1,0 +1,245 @@
+/**
+ * OpenAI Realtime, as a `RealtimeProvider` — the second live-translation backend, added
+ * for **Haitian Creole**, which Gemini Live Translate cannot produce.
+ *
+ * ## Why the conversational model and not the translation model
+ *
+ * OpenAI ships a purpose-built live-translation model (`gpt-realtime-translate`, on a
+ * separate `/v1/realtime/translations` endpoint, where you name the output language in
+ * `session.audio.output.language`). It would be the obvious choice — except that it
+ * translates *from* 70+ languages into only **13** output languages, and Haitian Creole
+ * is on the input list, not the output list. It cannot speak Creole. So it solves the
+ * problem we don't have (Gemini already covers those 13) and not the one we do.
+ *
+ * What can speak Creole is the general speech-to-speech model — the one behind ChatGPT's
+ * voice mode — instructed to behave as an interpreter. That is what this provider uses.
+ *
+ * ## What that costs us, honestly
+ *
+ * With Gemini's translate model, "only translate, never converse" is a property of the
+ * model. Here it is a **prompt**, and prompts are not guarantees:
+ *
+ *   - It can break character — answer a rhetorical question, add a preamble, editorialize.
+ *     `INTERPRETER_INSTRUCTIONS` is written to make that as unlikely as possible, but a
+ *     live service is the only real test.
+ *   - It is **turn-based**. A conversational model waits for end-of-turn, then speaks,
+ *     so output lags a phrase behind rather than flowing continuously, and a speaker who
+ *     never pauses makes that lag grow. See `interruptResponse` below for the knob that
+ *     trades truncation against lag.
+ *   - Creole output quality (accent, register, vocabulary) is **unverified**. OpenAI
+ *     publishes no per-language quality bar for non-English *output* on this model, and
+ *     nobody on this project has listened to it yet. docs/SMOKE_TEST.md §4 has the check.
+ *
+ * None of that is a reason not to ship it — a rough Creole translation is worth a great
+ * deal more than the nothing we can offer today — but it is a reason to keep the knobs
+ * env-overridable and to say plainly in the UI which languages are on which backend.
+ */
+
+import type WebSocket from "ws";
+
+import {
+  languageDisplayName,
+  type ProviderConfig,
+  type ProviderEvent,
+  type RealtimeProvider,
+} from "./realtime-provider.ts";
+
+/**
+ * Default model: the general speech-to-speech model (see the header for why not
+ * `gpt-realtime-translate`). Overridable because this family versions quickly and a
+ * newer id should not need a code change mid-season.
+ */
+const DEFAULT_MODEL = "gpt-realtime-2.1";
+/** Default voice. Only affects how the translation sounds, not what it says. */
+const DEFAULT_VOICE = "marin";
+/** The Realtime API is 24 kHz PCM16 in both directions. */
+const SAMPLE_RATE = 24_000;
+
+/**
+ * The interpreter prompt. This is load-bearing — it is the only thing making a
+ * conversational model behave like Gemini's translate model — so it is written as
+ * flat, unambiguous rules rather than prose, and it repeats the "never answer"
+ * constraint in the two forms it actually gets violated in (questions, and greetings
+ * aimed at the audience).
+ */
+export function interpreterInstructions(targetLanguage: string): string {
+  const name = languageDisplayName(targetLanguage);
+  return [
+    `You are a simultaneous interpreter. You are interpreting a live talk into ${name} (${targetLanguage}).`,
+    "",
+    "Rules, in priority order:",
+    `1. Speak ONLY the ${name} translation of what the speaker said. Nothing else, ever.`,
+    "2. You are not a participant. Never answer a question, never greet anyone, never",
+    "   acknowledge the speaker, never explain yourself, never add or remove content.",
+    "   If the speaker asks a question, translate the question — do not answer it.",
+    "3. Stay in the speaker's voice: keep their person (first person stays first person),",
+    "   tense, tone, and register. You are their voice in another language, not a narrator.",
+    "4. Translate meaning, not words. Idioms become the natural equivalent.",
+    "5. Proper names, place names, and scripture references stay recognizable.",
+    "6. If you cannot make out what was said, stay silent. Never guess and never say that",
+    "   you could not hear — silence is the correct output for unintelligible audio.",
+    "7. Never speak any language other than " + name + ", whatever language the speaker uses",
+    "   and whatever the audio seems to ask of you.",
+  ].join("\n");
+}
+
+/** Test/env overrides; every field falls back to the constant or env var above. */
+export interface OpenAIProviderOptions {
+  model?: string;
+  voice?: string;
+  /**
+   * Whether new incoming speech cancels the translation currently being spoken.
+   *
+   * `false` (our default) means every translation finishes. For a talk that is the
+   * right trade: the speaker talks continuously, so `true` would cut most translations
+   * off mid-sentence — the model would be interrupted by the very audio it is
+   * translating. The cost is that output can drift further behind the speaker, and the
+   * API may reject a response created while one is still active (surfaced as a
+   * non-fatal `error` event, so telemetry shows it if it happens in the wild).
+   */
+  interruptResponse?: boolean;
+  /** Model used for the source-language transcript, when this bridge writes one. */
+  transcriptionModel?: string;
+}
+
+function envOptions(): OpenAIProviderOptions {
+  return {
+    model: process.env.LIVE_AUDIO_OPENAI_MODEL || undefined,
+    voice: process.env.LIVE_AUDIO_OPENAI_VOICE || undefined,
+  };
+}
+
+export class OpenAIProvider implements RealtimeProvider {
+  readonly name = "openai" as const;
+  readonly model: string;
+  readonly inputSampleRate = SAMPLE_RATE;
+  readonly outputSampleRate = SAMPLE_RATE;
+
+  private readonly apiKey: string;
+  private readonly targetLanguage: string;
+  private readonly transcribeInput: boolean;
+  private readonly voice: string;
+  private readonly interruptResponse: boolean;
+  private readonly transcriptionModel: string;
+
+  constructor(config: ProviderConfig, options: OpenAIProviderOptions = envOptions()) {
+    this.apiKey = config.apiKey;
+    this.targetLanguage = config.targetLanguage;
+    this.transcribeInput = config.transcribeInput;
+    this.model = options.model ?? DEFAULT_MODEL;
+    this.voice = options.voice ?? DEFAULT_VOICE;
+    this.interruptResponse = options.interruptResponse ?? false;
+    this.transcriptionModel = options.transcriptionModel ?? "gpt-realtime-whisper";
+  }
+
+  socket(): { url: string; options: WebSocket.ClientOptions } {
+    return {
+      url: `wss://api.openai.com/v1/realtime?model=${encodeURIComponent(this.model)}`,
+      // Unlike Gemini, the key goes in a header, not the query string — so it stays out
+      // of anything that logs URLs.
+      options: { headers: { Authorization: `Bearer ${this.apiKey}` } },
+    };
+  }
+
+  setupMessages(): unknown[] {
+    return [
+      {
+        type: "session.update",
+        session: {
+          type: "realtime",
+          output_modalities: ["audio"],
+          instructions: interpreterInstructions(this.targetLanguage),
+          audio: {
+            input: {
+              format: { type: "audio/pcm", rate: this.inputSampleRate },
+              // Server-side turn detection drives response creation: the bridge just
+              // streams frames and never sends `response.create` itself, so there is no
+              // second place that decides when a translation starts.
+              turn_detection: {
+                type: "semantic_vad",
+                create_response: true,
+                interrupt_response: this.interruptResponse,
+              },
+              // Only the source-transcript bridge pays for input transcription.
+              ...(this.transcribeInput ? { transcription: { model: this.transcriptionModel } } : {}),
+            },
+            output: {
+              format: { type: "audio/pcm", rate: this.outputSampleRate },
+              voice: this.voice,
+            },
+          },
+        },
+      },
+    ];
+  }
+
+  inputFrameMessage(base64Audio: string): unknown {
+    return { type: "input_audio_buffer.append", audio: base64Audio };
+  }
+
+  /**
+   * Read one inbound event.
+   *
+   * Both the GA event names (`response.output_audio.delta`) and the earlier beta ones
+   * (`response.audio.delta`) are accepted. That is not indecision: this codebase cannot
+   * pin the API version it is talking to, the rename happened once already, and treating
+   * both as the same thing costs one array entry — whereas guessing wrong means a bridge
+   * that connects, reports healthy, and plays silence, which is the exact failure mode
+   * this subsystem is built to never have again.
+   */
+  interpret(message: Record<string, unknown>): ProviderEvent[] {
+    const type = typeof message.type === "string" ? message.type : "";
+
+    switch (type) {
+      // `session.created` arrives before our `session.update` is even sent, so it is not
+      // "ready" — the session is not yet configured as an interpreter. Waiting for
+      // `session.updated` means the first audio we send is audio it will translate.
+      case "session.updated":
+        return [{ kind: "ready" }];
+
+      case "response.output_audio.delta":
+      case "response.audio.delta": {
+        const base64 = typeof message.delta === "string" ? message.delta : "";
+        return base64 ? [{ kind: "audio", base64 }] : [];
+      }
+
+      case "response.output_audio_transcript.delta":
+      case "response.audio_transcript.delta": {
+        const text = typeof message.delta === "string" ? message.delta : "";
+        return text ? [{ kind: "targetTranscript", text }] : [];
+      }
+
+      case "conversation.item.input_audio_transcription.delta": {
+        if (!this.transcribeInput) return [];
+        const text = typeof message.delta === "string" ? message.delta : "";
+        return text ? [{ kind: "sourceTranscript", text }] : [];
+      }
+
+      case "error":
+        return [this.readError(message)];
+
+      default:
+        return [];
+    }
+  }
+
+  /**
+   * Turn an `error` event into either a fatal error (this session is over, so the bridge
+   * replaces the socket) or a noted one (the socket still works).
+   *
+   * There is no `goAway` in this protocol: a session hits its maximum duration and the
+   * socket just closes, which the bridge's close→backoff path already covers. Only an
+   * *expiry* error is fatal — it's the one that says the socket is dead but hasn't
+   * closed yet, so reacting early buys the replacement a head start. Everything else,
+   * including a rejected `response.create` while another response is still speaking, is
+   * per-response: worth recording, not worth throwing away a working session for. An
+   * auth failure never reaches here at all — a bad key fails the websocket handshake.
+   */
+  private readError(message: Record<string, unknown>): ProviderEvent {
+    const error = (message.error ?? {}) as { message?: string; code?: string; type?: string };
+    const code = error.code ?? error.type ?? null;
+    const text = error.message ?? "unknown error";
+    const fatal = code != null && /session_expired|session_timeout/.test(code);
+    return { kind: "error", message: text, code, fatal };
+  }
+}

--- a/live-audio/provider-selection.test.ts
+++ b/live-audio/provider-selection.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  chooseProviderName,
+  createProvider,
+  parseLanguageList,
+  providerForLanguage,
+} from "./provider-selection.ts";
+
+/**
+ * Routing tests. The interesting property is not "ht goes to OpenAI" on its own — it is
+ * that adding a second provider changed *nothing* about the languages the first one
+ * already served. A Sunday that ran on Gemini must still run on Gemini, so most of these
+ * assert the absence of a change.
+ */
+
+const bothKeys = { gemini: "g", openai: "o" };
+const geminiOnly = { gemini: "g", openai: undefined };
+const openaiOnly = { gemini: undefined, openai: "o" };
+
+const choose = (language: string, keys = bothKeys, openaiLanguages?: Set<string>) =>
+  chooseProviderName({ language, keys, openaiLanguages });
+
+describe("chooseProviderName", () => {
+  it("routes Haitian Creole to OpenAI — the reason the second provider exists", () => {
+    expect(choose("ht")).toBe("openai");
+  });
+
+  it("leaves every language Gemini supports on Gemini", () => {
+    // Including the two this project actually runs, and the source language.
+    for (const code of ["fr", "es", "en", "sw", "zh"]) {
+      expect(choose(code)).toBe("gemini");
+    }
+  });
+
+  it("serves nothing it cannot speak, rather than guessing", () => {
+    // A typo'd `listen=` attribute must fail visibly at bridge start. Falling back to
+    // OpenAI here would spend money translating into a language that doesn't exist and
+    // hand the listener confident nonsense.
+    expect(choose("xx")).toBeNull();
+    expect(choose("")).toBeNull();
+  });
+
+  it("cannot serve Creole without an OpenAI key, and says so", () => {
+    // The honest failure for a deployment that hasn't added the key: null, not a Gemini
+    // bridge that would quietly translate into some other language.
+    expect(choose("ht", geminiOnly)).toBeNull();
+    expect(choose("fr", geminiOnly)).toBe("gemini");
+  });
+
+  it("falls back to nothing (not OpenAI) for Gemini languages when Gemini is unkeyed", () => {
+    // OpenAI *could* be prompted to speak French, but silently moving a language between
+    // backends on a missing env var is how a service ends up sounding different for
+    // reasons nobody can trace.
+    expect(choose("fr", openaiOnly)).toBeNull();
+    expect(choose("ht", openaiOnly)).toBe("openai");
+  });
+
+  it("lets an operator move a language onto OpenAI without a deploy", () => {
+    // For comparing the two backends on a language both can serve.
+    expect(choose("fr", bothKeys, new Set(["fr"]))).toBe("openai");
+    expect(choose("es", bothKeys, new Set(["fr"]))).toBe("gemini");
+  });
+
+  it("ignores an override it has no key for", () => {
+    expect(choose("fr", geminiOnly, new Set(["fr"]))).toBe("gemini");
+  });
+});
+
+describe("parseLanguageList", () => {
+  it("reads a comma-separated list, tolerating spacing", () => {
+    expect(parseLanguageList(" fr , ht ,es ")).toEqual(new Set(["fr", "ht", "es"]));
+  });
+
+  it("is empty when unset or blank", () => {
+    expect(parseLanguageList(undefined)).toEqual(new Set());
+    expect(parseLanguageList("")).toEqual(new Set());
+    expect(parseLanguageList(" , ")).toEqual(new Set());
+  });
+});
+
+describe("createProvider / providerForLanguage", () => {
+  it("builds a provider carrying the bridge's language and transcript role", () => {
+    const provider = providerForLanguage({
+      language: "ht",
+      keys: bothKeys,
+      transcribeInput: false,
+    });
+    expect(provider?.name).toBe("openai");
+    // The prompt is where the target language lands for this provider, so this is the
+    // check that the language actually reached it.
+    expect(JSON.stringify(provider?.setupMessages())).toContain("Haitian Creole");
+  });
+
+  it("returns null (not a broken provider) for a language nothing can serve", () => {
+    expect(providerForLanguage({ language: "xx", keys: bothKeys, transcribeInput: false })).toBeNull();
+  });
+
+  it("refuses to build a provider whose key is missing", () => {
+    expect(() =>
+      createProvider("openai", geminiOnly, { targetLanguage: "ht", transcribeInput: false })
+    ).toThrow(/OPENAI_API_KEY/);
+    expect(() =>
+      createProvider("gemini", openaiOnly, { targetLanguage: "fr", transcribeInput: false })
+    ).toThrow(/GEMINI_API_KEY/);
+  });
+});

--- a/live-audio/provider-selection.ts
+++ b/live-audio/provider-selection.ts
@@ -1,0 +1,101 @@
+/**
+ * Which realtime backend serves a requested listen language.
+ *
+ * The rule is "whoever can actually speak it", and it has exactly one interesting case:
+ * Haitian Creole, which Gemini Live Translate cannot produce and OpenAI's Realtime API
+ * can be prompted into. Everything else Gemini already covers, and Gemini stays the
+ * default for it — this is an *addition*, not a migration, so a Sunday that used to run
+ * on Gemini still runs on Gemini, byte for byte.
+ *
+ * The decision is a pure function over (language, which keys are configured, operator
+ * override) so it can be unit-tested without constructing a provider, and so the answer
+ * "nobody can serve this" is a value the supervisor can act on rather than an exception
+ * thrown from inside a bridge.
+ */
+
+import {
+  GEMINI_LISTEN_LANGUAGE_CODES,
+  OPENAI_LISTEN_LANGUAGE_CODES,
+} from "../src/listenLanguages.ts";
+import { GeminiProvider } from "./gemini-provider.ts";
+import { OpenAIProvider } from "./openai-provider.ts";
+import type { ProviderConfig, ProviderName, RealtimeProvider } from "./realtime-provider.ts";
+
+/** Which providers this deployment has credentials for. */
+export interface ProviderKeys {
+  gemini: string | undefined;
+  openai: string | undefined;
+}
+
+/**
+ * Parse a comma-separated list of BCP-47 codes from an env var into a set. Used by
+ * `LIVE_AUDIO_OPENAI_LANGUAGES` so an operator can move a language onto OpenAI (to
+ * compare the two on a language both support, say) without a deploy.
+ */
+export function parseLanguageList(raw: string | undefined): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((code) => code.trim())
+      .filter((code) => code.length > 0)
+  );
+}
+
+/**
+ * Pick the provider for a language, or null if this deployment cannot serve it.
+ *
+ * Order matters:
+ *   1. An explicit operator override wins, so an experiment doesn't need a code change.
+ *   2. Otherwise Gemini gets everything it supports — the incumbent keeps its languages.
+ *   3. Otherwise OpenAI gets the languages we've decided it can carry (Haitian Creole).
+ *   4. Otherwise null: an unknown or unserveable code. Deliberately *not* "send it to
+ *      OpenAI and hope" — a typo'd `listen=` attribute would then start a paid session
+ *      translating into nothing, and the listener would hear confident gibberish rather
+ *      than an obvious failure.
+ */
+export function chooseProviderName(params: {
+  language: string;
+  keys: ProviderKeys;
+  openaiLanguages?: ReadonlySet<string>;
+}): ProviderName | null {
+  const { language, keys } = params;
+  const overrides = params.openaiLanguages ?? new Set<string>();
+
+  if (overrides.has(language) && keys.openai) return "openai";
+  if (GEMINI_LISTEN_LANGUAGE_CODES.includes(language) && keys.gemini) return "gemini";
+  if (OPENAI_LISTEN_LANGUAGE_CODES.includes(language) && keys.openai) return "openai";
+  return null;
+}
+
+/** Construct the named provider. Throws if its key is missing — check first. */
+export function createProvider(
+  name: ProviderName,
+  keys: ProviderKeys,
+  config: Omit<ProviderConfig, "apiKey">
+): RealtimeProvider {
+  if (name === "openai") {
+    if (!keys.openai) throw new Error("OPENAI_API_KEY is not set");
+    return new OpenAIProvider({ ...config, apiKey: keys.openai });
+  }
+  if (!keys.gemini) throw new Error("GEMINI_API_KEY is not set");
+  return new GeminiProvider({ ...config, apiKey: keys.gemini });
+}
+
+/**
+ * The one call site's whole decision: name the provider for this language and build it,
+ * or return null because nothing here can speak it.
+ */
+export function providerForLanguage(params: {
+  language: string;
+  keys: ProviderKeys;
+  openaiLanguages?: ReadonlySet<string>;
+  transcribeInput: boolean;
+}): RealtimeProvider | null {
+  const name = chooseProviderName(params);
+  if (!name) return null;
+  return createProvider(name, params.keys, {
+    targetLanguage: params.language,
+    transcribeInput: params.transcribeInput,
+  });
+}

--- a/live-audio/realtime-provider.test.ts
+++ b/live-audio/realtime-provider.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest";
+
+import { GeminiProvider, parseGoAwayTimeLeftMs } from "./gemini-provider.ts";
+import { interpreterInstructions, OpenAIProvider } from "./openai-provider.ts";
+import type { ProviderEvent, RealtimeProvider } from "./realtime-provider.ts";
+
+/**
+ * Provider tests: "do we speak this vendor's protocol correctly."
+ *
+ * This is the whole reason the provider seam is shaped the way it is. A provider takes a
+ * parsed message and returns events; it never touches a socket. So the questions that
+ * used to require a live session and a pair of headphones — does a `setupComplete`
+ * actually read as ready, does an audio delta actually reach the bridge, does the model
+ * get told to translate rather than converse — are now plain assertions.
+ *
+ * What these tests deliberately do *not* prove is that the vendor agrees with us. If
+ * OpenAI renames an event, this file stays green and the bridge goes silent — which is
+ * exactly the failure this subsystem exists to prevent, so it is handled two other ways:
+ * the interpreters accept both spellings of the events that have already been renamed
+ * once, and docs/SMOKE_TEST.md §4 requires a human to hear real Creole audio before a
+ * service. Tests pin our side of the contract; only listening pins theirs.
+ */
+
+const geminiProvider = (over: Partial<{ targetLanguage: string; transcribeInput: boolean }> = {}) =>
+  new GeminiProvider({
+    apiKey: "test-key",
+    targetLanguage: over.targetLanguage ?? "fr",
+    transcribeInput: over.transcribeInput ?? false,
+  });
+
+const openaiProvider = (over: Partial<{ targetLanguage: string; transcribeInput: boolean }> = {}) =>
+  new OpenAIProvider(
+    {
+      apiKey: "test-key",
+      targetLanguage: over.targetLanguage ?? "ht",
+      transcribeInput: over.transcribeInput ?? false,
+    },
+    {} // don't read env in tests
+  );
+
+/**
+ * The one setup message a provider sends — every provider we have sends exactly one.
+ * Typed loosely on purpose: these are foreign vendor payloads whose shape is the thing
+ * under test, so re-declaring it here would only assert that our copy matches our copy.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type VendorPayload = Record<string, any>;
+
+function setup(provider: RealtimeProvider): VendorPayload {
+  const messages = provider.setupMessages();
+  expect(messages).toHaveLength(1);
+  return messages[0] as VendorPayload;
+}
+
+const kinds = (events: ProviderEvent[]) => events.map((e) => e.kind);
+
+describe("GeminiProvider", () => {
+  it("connects to the Gemini Live endpoint with the key in the URL", () => {
+    const { url } = geminiProvider().socket();
+    expect(url).toContain("generativelanguage.googleapis.com");
+    expect(url).toContain("key=test-key");
+  });
+
+  it("configures the translate model for audio out in the target language", () => {
+    const { setup: s } = setup(geminiProvider({ targetLanguage: "es" }));
+    expect(s.model).toBe("models/gemini-3.5-live-translate-preview");
+    expect(s.generationConfig.responseModalities).toEqual(["AUDIO"]);
+    expect(s.generationConfig.translationConfig).toEqual({
+      targetLanguageCode: "es",
+      echoTargetLanguage: true,
+    });
+  });
+
+  it("asks for input transcription only when this bridge writes the source transcript", () => {
+    // The English transcript must be written once per session, not once per language,
+    // so every non-primary bridge has to leave this off.
+    expect(setup(geminiProvider({ transcribeInput: false })).setup).not.toHaveProperty(
+      "inputAudioTranscription"
+    );
+    expect(setup(geminiProvider({ transcribeInput: true })).setup).toHaveProperty(
+      "inputAudioTranscription"
+    );
+  });
+
+  it("wraps an input frame as realtimeInput at 16 kHz", () => {
+    const provider = geminiProvider();
+    expect(provider.inputSampleRate).toBe(16_000);
+    expect(provider.inputFrameMessage("QUJD")).toEqual({
+      realtimeInput: { audio: { mimeType: "audio/pcm;rate=16000", data: "QUJD" } },
+    });
+  });
+
+  it("reads setupComplete as ready", () => {
+    expect(kinds(geminiProvider().interpret({ setupComplete: {} }))).toEqual(["ready"]);
+  });
+
+  it("reads audio and transcript out of serverContent", () => {
+    const events = geminiProvider().interpret({
+      serverContent: {
+        modelTurn: { parts: [{ inlineData: { data: "QUJD" } }, { inlineData: { data: "REVG" } }] },
+        outputTranscription: { text: "bonjour" },
+      },
+    });
+    expect(events).toEqual([
+      { kind: "audio", base64: "QUJD" },
+      { kind: "audio", base64: "REVG" },
+      { kind: "targetTranscript", text: "bonjour" },
+    ]);
+  });
+
+  it("drops input transcription unless this bridge asked for it", () => {
+    const content = { serverContent: { inputTranscription: { text: "hello" } } };
+    expect(geminiProvider({ transcribeInput: false }).interpret(content)).toEqual([]);
+    expect(geminiProvider({ transcribeInput: true }).interpret(content)).toEqual([
+      { kind: "sourceTranscript", text: "hello" },
+    ]);
+  });
+
+  it("reads goAway (either casing) so the bridge can swap make-before-break", () => {
+    expect(geminiProvider().interpret({ goAway: { timeLeft: "10s" } })).toEqual([
+      { kind: "goAway", timeLeftMs: 10_000, raw: "10s" },
+    ]);
+    expect(geminiProvider().interpret({ go_away: { time_left: "2s" } })).toEqual([
+      { kind: "goAway", timeLeftMs: 2_000, raw: "2s" },
+    ]);
+  });
+
+  it("reports session-resumption offers without acting on them", () => {
+    expect(
+      geminiProvider().interpret({ sessionResumptionUpdate: { resumable: true, newHandle: "h" } })
+    ).toEqual([{ kind: "resumable", resumable: true, hasHandle: true }]);
+  });
+
+  it("ignores messages it has no meaning for", () => {
+    expect(geminiProvider().interpret({ usageMetadata: { totalTokenCount: 12 } })).toEqual([]);
+  });
+});
+
+// The wire shape here is the part of this change that cannot be verified from a test
+// suite alone (see the file header), so these tests pin every field the bridge depends
+// on — a silent typo in one of them is a bridge that connects and plays nothing.
+describe("OpenAIProvider", () => {
+  it("connects to the Realtime endpoint with the key in a header, not the URL", () => {
+    // Gemini puts its key in the query string; this one must not, so the URL stays safe
+    // to log.
+    const { url, options } = openaiProvider().socket();
+    expect(url).toBe("wss://api.openai.com/v1/realtime?model=gpt-realtime-2.1");
+    expect(url).not.toContain("test-key");
+    expect(options.headers).toEqual({ Authorization: "Bearer test-key" });
+  });
+
+  it("honors a model override, so a new model id needs no code change", () => {
+    const provider = new OpenAIProvider(
+      { apiKey: "k", targetLanguage: "ht", transcribeInput: false },
+      { model: "gpt-realtime-9" }
+    );
+    expect(provider.model).toBe("gpt-realtime-9");
+    expect(provider.socket().url).toContain("model=gpt-realtime-9");
+  });
+
+  it("configures audio-only output with server-driven turns at 24 kHz both ways", () => {
+    const provider = openaiProvider();
+    expect(provider.inputSampleRate).toBe(24_000);
+    expect(provider.outputSampleRate).toBe(24_000);
+
+    const message = setup(provider);
+    expect(message.type).toBe("session.update");
+    expect(message.session.type).toBe("realtime");
+    expect(message.session.output_modalities).toEqual(["audio"]);
+    expect(message.session.audio.input.format).toEqual({ type: "audio/pcm", rate: 24_000 });
+    expect(message.session.audio.output.format).toEqual({ type: "audio/pcm", rate: 24_000 });
+    // The server decides when a translation starts; the bridge never sends
+    // response.create, so there is exactly one thing deciding turn boundaries.
+    expect(message.session.audio.input.turn_detection.create_response).toBe(true);
+  });
+
+  it("does not let new speech cut off a translation in progress", () => {
+    // A speaker at a podium talks continuously, so interruption-on-speech would truncate
+    // most translations — the model would be interrupted by the very audio it is
+    // translating. Latency is the accepted cost; see OpenAIProviderOptions.
+    expect(setup(openaiProvider()).session.audio.input.turn_detection.interrupt_response).toBe(
+      false
+    );
+  });
+
+  it("instructs the model to interpret rather than converse", () => {
+    const instructions = setup(openaiProvider({ targetLanguage: "ht" })).session.instructions;
+    // Unlike Gemini's translate model, "only translate" here is a prompt — so the prompt
+    // is part of the contract, and naming the language is the load-bearing half of it.
+    expect(instructions).toContain("Haitian Creole");
+    expect(instructions).toContain("ht");
+    expect(instructions.toLowerCase()).toContain("interpreter");
+    expect(instructions).toMatch(/do not answer it/i);
+  });
+
+  it("names the target language in the prompt for any code, not just Creole", () => {
+    expect(interpreterInstructions("es")).toContain("Spanish");
+    // An unknown code still produces a usable prompt rather than throwing.
+    expect(interpreterInstructions("zz")).toContain("zz");
+  });
+
+  it("asks for input transcription only when this bridge writes the source transcript", () => {
+    expect(setup(openaiProvider({ transcribeInput: false })).session.audio.input).not.toHaveProperty(
+      "transcription"
+    );
+    expect(setup(openaiProvider({ transcribeInput: true })).session.audio.input).toHaveProperty(
+      "transcription"
+    );
+  });
+
+  it("appends input frames to the audio buffer", () => {
+    expect(openaiProvider().inputFrameMessage("QUJD")).toEqual({
+      type: "input_audio_buffer.append",
+      audio: "QUJD",
+    });
+  });
+
+  it("waits for session.updated — not session.created — before sending audio", () => {
+    // session.created lands before our session.update is even sent, so the session is
+    // not yet an interpreter. Treating it as ready would stream the first words of the
+    // talk into a plain chatbot.
+    const provider = openaiProvider();
+    expect(provider.interpret({ type: "session.created", session: {} })).toEqual([]);
+    expect(kinds(provider.interpret({ type: "session.updated", session: {} }))).toEqual(["ready"]);
+  });
+
+  it("reads output audio and transcript deltas, under GA or beta event names", () => {
+    const provider = openaiProvider();
+    expect(provider.interpret({ type: "response.output_audio.delta", delta: "QUJD" })).toEqual([
+      { kind: "audio", base64: "QUJD" },
+    ]);
+    expect(provider.interpret({ type: "response.audio.delta", delta: "QUJD" })).toEqual([
+      { kind: "audio", base64: "QUJD" },
+    ]);
+    expect(
+      provider.interpret({ type: "response.output_audio_transcript.delta", delta: "bonjou" })
+    ).toEqual([{ kind: "targetTranscript", text: "bonjou" }]);
+    expect(provider.interpret({ type: "response.audio_transcript.delta", delta: "bonjou" })).toEqual(
+      [{ kind: "targetTranscript", text: "bonjou" }]
+    );
+  });
+
+  it("reads input transcription deltas only when asked for them", () => {
+    const message = {
+      type: "conversation.item.input_audio_transcription.delta",
+      delta: "hello",
+    };
+    expect(openaiProvider({ transcribeInput: false }).interpret(message)).toEqual([]);
+    expect(openaiProvider({ transcribeInput: true }).interpret(message)).toEqual([
+      { kind: "sourceTranscript", text: "hello" },
+    ]);
+  });
+
+  it("ignores empty deltas rather than writing blank transcript", () => {
+    const provider = openaiProvider();
+    expect(provider.interpret({ type: "response.output_audio.delta", delta: "" })).toEqual([]);
+    expect(provider.interpret({ type: "response.output_audio_transcript.delta" })).toEqual([]);
+  });
+
+  it("treats a session expiry as fatal and everything else as noise", () => {
+    const provider = openaiProvider();
+    expect(
+      provider.interpret({ type: "error", error: { code: "session_expired", message: "bye" } })
+    ).toEqual([{ kind: "error", message: "bye", code: "session_expired", fatal: true }]);
+
+    // A response rejected because one is still speaking is per-response, not
+    // per-session: throwing away a working socket over it would be the worse outcome.
+    expect(
+      provider.interpret({
+        type: "error",
+        error: { code: "conversation_already_has_active_response", message: "busy" },
+      })
+    ).toEqual([
+      {
+        kind: "error",
+        message: "busy",
+        code: "conversation_already_has_active_response",
+        fatal: false,
+      },
+    ]);
+  });
+
+  it("ignores the rest of a chatty protocol", () => {
+    const provider = openaiProvider();
+    for (const type of [
+      "response.created",
+      "response.done",
+      "input_audio_buffer.speech_started",
+      "rate_limits.updated",
+      "conversation.item.created",
+    ]) {
+      expect(provider.interpret({ type })).toEqual([]);
+    }
+    expect(provider.interpret({})).toEqual([]);
+  });
+});
+
+// Kept from the bridge's own suite when goAway parsing moved into the Gemini provider:
+// the wire shape is unconfirmed for the translate model, so it tolerates every plausible
+// encoding rather than guessing one.
+describe("parseGoAwayTimeLeftMs", () => {
+  it("parses protobuf Duration strings (seconds)", () => {
+    expect(parseGoAwayTimeLeftMs("10s")).toBe(10_000);
+    expect(parseGoAwayTimeLeftMs("10.5s")).toBe(10_500);
+    expect(parseGoAwayTimeLeftMs(" 2s ")).toBe(2_000);
+  });
+
+  it("parses a bare numeric string as seconds", () => {
+    expect(parseGoAwayTimeLeftMs("10")).toBe(10_000);
+  });
+
+  it("parses a number as seconds", () => {
+    expect(parseGoAwayTimeLeftMs(7)).toBe(7_000);
+  });
+
+  it("parses an expanded { seconds, nanos } Duration object", () => {
+    expect(parseGoAwayTimeLeftMs({ seconds: 8 })).toBe(8_000);
+    expect(parseGoAwayTimeLeftMs({ seconds: "8", nanos: 500_000_000 })).toBe(8_500);
+  });
+
+  it("returns null for missing or unparseable values", () => {
+    expect(parseGoAwayTimeLeftMs(null)).toBeNull();
+    expect(parseGoAwayTimeLeftMs(undefined)).toBeNull();
+    expect(parseGoAwayTimeLeftMs("soon")).toBeNull();
+    expect(parseGoAwayTimeLeftMs({})).toBeNull();
+  });
+});

--- a/live-audio/realtime-provider.ts
+++ b/live-audio/realtime-provider.ts
@@ -1,0 +1,108 @@
+/**
+ * The seam between the translation bridge and whichever realtime speech-translation
+ * API is behind it.
+ *
+ * `TranslationBridge` is almost entirely *not* about any particular vendor: it is about
+ * keeping organizer audio flowing through a websocket that periodically dies, into a
+ * LiveKit room that periodically rebuilds itself, without ever going "active but deaf"
+ * (see docs/live-audio-resilience.md). Only six things are actually vendor-specific:
+ *
+ *   1. where to connect and how to authenticate,
+ *   2. what to send to configure the session,
+ *   3. how to read an inbound message,
+ *   4. how to wrap one PCM16 input frame,
+ *   5. the input/output sample rates,
+ *   6. whether it can produce the target language at all.
+ *
+ * Those are this interface. Everything else — reconnects, the gap buffer, the epoch
+ * guard, silence gating, subscription reconcile, the stall watchdog — is written once
+ * and shared, so a second provider inherits the whole incident history rather than
+ * re-earning it.
+ *
+ * A provider is constructed per bridge (it knows its target language), is stateless
+ * with respect to the socket, and never touches the socket itself: it returns messages
+ * for the bridge to send and interprets messages the bridge received. That keeps it
+ * trivially unit-testable — see realtime-provider.test.ts, which is the whole test
+ * story for "do we speak this vendor's protocol correctly".
+ */
+
+import type WebSocket from "ws";
+
+/** Which realtime backend a bridge is running against. */
+export type ProviderName = "gemini" | "openai";
+
+/**
+ * What the bridge does with an inbound message, once the provider has read it. This
+ * is deliberately the *bridge's* vocabulary, not any vendor's — it is the list of
+ * things the bridge knows how to react to, and a provider that has no equivalent for
+ * one simply never emits it.
+ */
+export type ProviderEvent =
+  /** Session configured and ready for audio. Promotes the socket to active. */
+  | { kind: "ready" }
+  /** A chunk of translated output audio, base64 PCM16 at `outputSampleRate`. */
+  | { kind: "audio"; base64: string }
+  /** Translated (target-language) transcript text. */
+  | { kind: "targetTranscript"; text: string }
+  /** Source-language (input) transcript text; only if `transcribeInput` was asked for. */
+  | { kind: "sourceTranscript"; text: string }
+  /**
+   * The server warned it is about to terminate this session. The bridge reconnects
+   * make-before-break. `timeLeftMs` is informational (null when unknown).
+   */
+  | { kind: "goAway"; timeLeftMs: number | null; raw: unknown }
+  /** Session-resumption metadata. Recorded only; the bridge does not resume yet. */
+  | { kind: "resumable"; resumable: boolean; hasHandle: boolean }
+  /**
+   * The server reported an error on this session. `fatal` means the session is done
+   * and the bridge should stop trusting the socket; a non-fatal error is recorded and
+   * otherwise ignored (the socket keeps working).
+   */
+  | { kind: "error"; message: string; code: string | null; fatal: boolean };
+
+/** Everything a provider needs to know at construction time. */
+export interface ProviderConfig {
+  apiKey: string;
+  /** BCP-47 code of the language this bridge translates *into*. */
+  targetLanguage: string;
+  /** Whether this bridge also needs the source-language transcript. */
+  transcribeInput: boolean;
+}
+
+export interface RealtimeProvider {
+  readonly name: ProviderName;
+  /** The model id in use, for logs and telemetry. */
+  readonly model: string;
+  /** Sample rate the provider wants input frames in (LiveKit resamples for us). */
+  readonly inputSampleRate: number;
+  /** Sample rate the provider's output audio arrives in. */
+  readonly outputSampleRate: number;
+  /** Where to connect, plus any per-request options (e.g. auth headers). */
+  socket(): { url: string; options?: WebSocket.ClientOptions };
+  /**
+   * Messages to send, in order, as soon as the socket opens. The bridge waits for a
+   * `ready` event before it will send any audio.
+   */
+  setupMessages(): unknown[];
+  /**
+   * Read one parsed inbound message. Returning an empty array means "nothing the
+   * bridge acts on" — normal for the majority of a chatty protocol's traffic.
+   */
+  interpret(message: Record<string, unknown>): ProviderEvent[];
+  /** Wire message carrying one base64-encoded PCM16 input frame. */
+  inputFrameMessage(base64Audio: string): unknown;
+}
+
+/**
+ * A human-readable name for a BCP-47 code, for prompts and logs. Uses `Intl` rather
+ * than a hand-kept table so we don't maintain a second language list (the same choice
+ * the listen picker makes), and falls back to the raw code if the runtime's ICU data
+ * doesn't know it.
+ */
+export function languageDisplayName(code: string): string {
+  try {
+    return new Intl.DisplayNames(["en"], { type: "language" }).of(code) ?? code;
+  } catch {
+    return code;
+  }
+}

--- a/live-audio/translation-bridge.e2e.test.ts
+++ b/live-audio/translation-bridge.e2e.test.ts
@@ -10,8 +10,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  * suite that only exercises pure functions would have passed, green, through both.
  *
  * So these tests drive the real TranslationBridge against fakes of the only two things it
- * talks to — a LiveKit room and a Gemini websocket — and assert on the one thing that
- * actually matters to a listener: **is audio still reaching Gemini?** Nothing here inspects
+ * talks to — a LiveKit room and a provider websocket — and assert on the one thing that
+ * actually matters to a listener: **is audio still reaching the provider?** Nothing here inspects
  * internal state; each test breaks the input the way production broke it and checks that
  * frames resume.
  *
@@ -86,9 +86,21 @@ class FakeAudioFrame {
   ) {}
 }
 
-/** `new AudioStream(track)` in the bridge resolves to a reader over that track. */
+/**
+ * `new AudioStream(track, opts)` in the bridge resolves to a reader over that track. The
+ * `opts` are recorded because the sample rate in them is how the bridge asks LiveKit to
+ * resample organizer audio to whatever its provider expects — 16 kHz for Gemini, 24 kHz
+ * for OpenAI. Get that wrong and the audio still flows, still reports healthy, and is
+ * pitched and paced wrong on arrival: a failure you can only hear.
+ */
 class FakeAudioStream {
-  constructor(private readonly track: FakeRemoteTrack) {}
+  static instances: FakeAudioStream[] = [];
+  constructor(
+    private readonly track: FakeRemoteTrack,
+    readonly opts?: { sampleRate?: number; numChannels?: number; frameSizeMs?: number }
+  ) {
+    FakeAudioStream.instances.push(this);
+  }
   getReader() {
     return { read: () => this.track.read() };
   }
@@ -209,12 +221,23 @@ class FakeRoom extends EventEmitter {
   }
 }
 
+/**
+ * The bridge's *output* leg: translated audio it publishes into the room. Recorded here
+ * (rather than dropped, as it used to be) so a test can assert the last hop — provider
+ * audio actually reaching a LiveKit track — instead of stopping at "we sent input".
+ */
 class FakeAudioSource {
+  static instances: FakeAudioSource[] = [];
+  readonly captured: unknown[] = [];
   constructor(
     readonly sampleRate: number,
     readonly channels: number
-  ) {}
-  async captureFrame(): Promise<void> {}
+  ) {
+    FakeAudioSource.instances.push(this);
+  }
+  async captureFrame(frame: unknown): Promise<void> {
+    this.captured.push(frame);
+  }
 }
 
 vi.mock("@livekit/rtc-node", () => ({
@@ -246,32 +269,73 @@ vi.mock("livekit-server-sdk", () => ({
 }));
 
 // ---------------------------------------------------------------------------
-// Fake Gemini socket
+// Fake provider socket
+//
+// Speaks both wire protocols, because both are now in production: Gemini Live for most
+// languages and OpenAI Realtime for Haitian Creole. One fake rather than two, so every
+// resilience test below is provider-agnostic by construction — if a reconnect path only
+// worked for Gemini, pointing these tests at the other provider would say so.
+//
+// The load-bearing asymmetry is the handshake. Gemini answers `setup` with
+// `setupComplete` and nothing before it. OpenAI sends `session.created` the moment you
+// connect — *before* our `session.update` is applied, when the session is still a plain
+// chatbot — and only `session.updated` means "configured as an interpreter". A bridge
+// that mistook the first for the second would stream the opening of the talk into an
+// unconfigured model, so the fake reproduces that order faithfully.
 // ---------------------------------------------------------------------------
 
 /** Records every audio frame the bridge sends us — the assertion surface of these tests. */
-class FakeGeminiSocket extends EventEmitter {
+class FakeProviderSocket extends EventEmitter {
   static OPEN = 1;
-  static instances: FakeGeminiSocket[] = [];
+  static instances: FakeProviderSocket[] = [];
 
-  readyState = FakeGeminiSocket.OPEN;
+  readyState = FakeProviderSocket.OPEN;
   readonly audioFramesReceived: string[] = [];
 
-  constructor(readonly url: string) {
+  /**
+   * "createdOnly" answers `session.update` with `session.created` and then goes quiet —
+   * a session that connected but was never configured. See the handshake note above.
+   */
+  static openaiHandshake: "full" | "createdOnly" = "full";
+
+  constructor(
+    readonly url: string,
+    readonly options?: unknown
+  ) {
     super();
-    FakeGeminiSocket.instances.push(this);
+    FakeProviderSocket.instances.push(this);
     setTimeout(() => this.emit("open"), 0);
+  }
+
+  private reply(message: unknown): void {
+    setTimeout(() => this.emit("message", Buffer.from(JSON.stringify(message))), 0);
   }
 
   send(raw: string): void {
     const msg = JSON.parse(raw);
+
+    // --- Gemini ---
     if (msg.setup) {
       // Gemini answers setup with setupComplete; until it does, the bridge won't send audio.
-      setTimeout(() => this.emit("message", Buffer.from(JSON.stringify({ setupComplete: {} }))), 0);
+      this.reply({ setupComplete: {} });
       return;
     }
     if (msg.realtimeInput?.audio?.data) {
       this.audioFramesReceived.push(msg.realtimeInput.audio.data);
+      return;
+    }
+
+    // --- OpenAI ---
+    if (msg.type === "session.update") {
+      this.reply({ type: "session.created", session: {} }); // NOT ready yet
+      if (FakeProviderSocket.openaiHandshake === "full") {
+        this.reply({ type: "session.updated", session: {} }); // now configured
+      }
+      return;
+    }
+    if (msg.type === "input_audio_buffer.append") {
+      this.audioFramesReceived.push(msg.audio);
+      return;
     }
   }
 
@@ -281,22 +345,24 @@ class FakeGeminiSocket extends EventEmitter {
   }
 }
 
-vi.mock("ws", () => ({ default: FakeGeminiSocket }));
+vi.mock("ws", () => ({ default: FakeProviderSocket }));
 
 // ---------------------------------------------------------------------------
 
 const { TranslationBridge, SILENCE_THRESHOLD_DBFS, SILENCE_GATING_OFF_DBFS } = await import(
   "./translation-bridge.ts"
 );
+const { OpenAIProvider } = await import("./openai-provider.ts");
+const { GeminiProvider } = await import("./gemini-provider.ts");
 
 const ORGANIZER = "organizer-host";
 
 /**
- * Frames Gemini has received, across every socket it opened — a Gemini `goAway` reconnect
+ * Frames the provider has received, across every socket it opened — a `goAway` reconnect
  * makes a new one, and we don't care which socket the audio landed on, only that it landed.
  */
-const framesToGemini = () =>
-  FakeGeminiSocket.instances.reduce((n, s) => n + s.audioFramesReceived.length, 0);
+const framesToProvider = () =>
+  FakeProviderSocket.instances.reduce((n, s) => n + s.audioFramesReceived.length, 0);
 
 /** Speak `count` 100ms frames into a mic track and let them propagate. */
 async function speak(track: FakeRemoteTrack, count = 3): Promise<void> {
@@ -339,19 +405,20 @@ async function holdSilence(track: FakeRemoteTrack, ms: number): Promise<void> {
 }
 
 /**
- * Start a bridge. `seat` runs once the bridge has a Room but before its Gemini handshake
+ * Start a bridge. `seat` runs once the bridge has a Room but before its provider handshake
  * completes, which is where the room's starting state gets decided (and where outage 1's
  * race lives). Whatever `seat` returns is handed back to the test.
  */
 async function boot<T>(
   seat: (room: FakeRoom) => T,
-  configOverrides: Partial<ConstructorParameters<typeof TranslationBridge>[3]> = {}
+  configOverrides: Partial<ConstructorParameters<typeof TranslationBridge>[3]> = {},
+  language = "fr"
 ): Promise<{
   bridge: InstanceType<typeof TranslationBridge>;
   room: FakeRoom;
   seated: T;
 }> {
-  const bridge = new TranslationBridge("doc-test", "fr", ORGANIZER, {
+  const bridge = new TranslationBridge("doc-test", language, ORGANIZER, {
     geminiApiKey: "fake-key",
     livekitUrl: "wss://fake.livekit",
     livekitApiKey: "fake",
@@ -362,16 +429,19 @@ async function boot<T>(
   await vi.advanceTimersByTimeAsync(10); // the bridge has constructed its Room
   const room = lastRoom as FakeRoom;
   const seated = seat(room);
-  await vi.advanceTimersByTimeAsync(300); // connectGemini polls for setupComplete every 100ms
+  await vi.advanceTimersByTimeAsync(300); // connectProvider polls for readiness every 100ms
   await started;
   await vi.advanceTimersByTimeAsync(10); // deliver the pending TrackSubscribed
   return { bridge, room, seated };
 }
 
-describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
+describe("TranslationBridge (end-to-end, faked LiveKit + provider)", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    FakeGeminiSocket.instances = [];
+    FakeProviderSocket.instances = [];
+    FakeProviderSocket.openaiHandshake = "full";
+    FakeAudioSource.instances = [];
+    FakeAudioStream.instances = [];
     lastRoom = null;
   });
 
@@ -385,7 +455,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
 
     await speak(mic, 3);
 
-    expect(framesToGemini()).toBe(3);
+    expect(framesToProvider()).toBe(3);
     expect(bridge.status).toBe("active");
     await bridge.stop();
   });
@@ -401,7 +471,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     await vi.advanceTimersByTimeAsync(10);
     await speak(mic, 2);
 
-    expect(framesToGemini()).toBe(2);
+    expect(framesToProvider()).toBe(2);
     await bridge.stop();
   });
 
@@ -411,7 +481,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     const { bridge, room, seated: mic } = await boot((r) => r.seatOrganizer(ORGANIZER));
 
     await speak(mic, 3);
-    expect(framesToGemini()).toBe(3);
+    expect(framesToProvider()).toBe(3);
 
     // LiveKit rebuilds the session. The bridge is handed nothing but ParticipantConnected
     // and a dead AudioStream: no TrackPublished, no Disconnected, no error.
@@ -421,7 +491,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     // The speaker keeps talking, now into the new track object.
     await speak(newMic, 4);
 
-    expect(framesToGemini()).toBe(7); // audio resumed — we are not deaf
+    expect(framesToProvider()).toBe(7); // audio resumed — we are not deaf
     expect(bridge.status).toBe("active");
     await bridge.stop();
   });
@@ -433,7 +503,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     const { bridge, room, seated: mic } = await boot((r) => r.seatOrganizer(ORGANIZER));
 
     await speak(mic, 2);
-    expect(framesToGemini()).toBe(2);
+    expect(framesToProvider()).toBe(2);
 
     // Swap the organizer's publication behind the bridge's back and kill the old stream.
     mic.end();
@@ -446,7 +516,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     await vi.advanceTimersByTimeAsync(25_000);
     await speak(newMic, 3);
 
-    expect(framesToGemini()).toBe(5);
+    expect(framesToProvider()).toBe(5);
     await bridge.stop();
   });
 
@@ -469,7 +539,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     await vi.advanceTimersByTimeAsync(50);
     await speak(newMic, 3);
 
-    expect(framesToGemini()).toBe(4);
+    expect(framesToProvider()).toBe(4);
     await bridge.stop();
   });
 
@@ -485,7 +555,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
       recordEvent: (event: string) => events.push(event),
     });
     await speak(mic, 2);
-    expect(framesToGemini()).toBe(2);
+    expect(framesToProvider()).toBe(2);
 
     room.emit(RoomEvent.Disconnected, 0);
     await vi.advanceTimersByTimeAsync(10);
@@ -493,8 +563,8 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     expect(bridge.status).toBe("error");
     expect(events).toContain("livekit_disconnected");
     // No paid-for zombie: every Gemini socket is closed.
-    for (const socket of FakeGeminiSocket.instances) {
-      expect(socket.readyState).not.toBe(FakeGeminiSocket.OPEN);
+    for (const socket of FakeProviderSocket.instances) {
+      expect(socket.readyState).not.toBe(FakeProviderSocket.OPEN);
     }
 
     // A deliberate stop stays "closed" — the disconnect its room.disconnect() emits
@@ -515,7 +585,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
       recordEvent: (event: string) => events.push(event),
     });
     await speak(mic, 2);
-    expect(framesToGemini()).toBe(2);
+    expect(framesToProvider()).toBe(2);
 
     // The stream dies; the publication stays, already-subscribed, so reconcile is a no-op.
     mic.end();
@@ -539,7 +609,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     await speak(mic, 1);
 
     // Gemini warns it will terminate → the bridge opens a pending replacement...
-    FakeGeminiSocket.instances[0].emit(
+    FakeProviderSocket.instances[0].emit(
       "message",
       Buffer.from(JSON.stringify({ goAway: { timeLeft: "5s" } }))
     );
@@ -577,7 +647,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
   // Silence gating × stall watchdog — the seam the merge created.
   //
   // These two subsystems arrived on different branches and now coexist in
-  // sendAudioToGemini: the watchdog treats "no organizer frames" as a dead input to
+  // sendAudioToProvider: the watchdog treats "no organizer frames" as a dead input to
   // rebuild, while silence gating treats "no *voice*" as a cue to suspend Gemini to save
   // cost. They read the same frames and must not fight. The load-bearing decision in the
   // merge is that liveness is stamped on *every* organizer frame, silence included —
@@ -597,7 +667,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     });
 
     await speakVoice(mic, 3);
-    expect(framesToGemini()).toBeGreaterThanOrEqual(3);
+    expect(framesToProvider()).toBeGreaterThanOrEqual(3);
 
     // 29s of open-mic room tone: past the 15s stall threshold, short of the 30s suspend.
     await holdSilence(mic, 29_000);
@@ -615,11 +685,11 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
 
     // Speech returns → Gemini resumes and audio reaches it again (buffered pre-roll +
     // fresh frames flushed into the new session).
-    const before = framesToGemini();
+    const before = framesToProvider();
     await speakVoice(mic, 4);
     await vi.advanceTimersByTimeAsync(300); // let the replacement socket set up and flush
     expect(events).toContain("gemini_resumed_voice");
-    expect(framesToGemini()).toBeGreaterThan(before);
+    expect(framesToProvider()).toBeGreaterThan(before);
     await bridge.stop();
   });
 
@@ -635,7 +705,7 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     });
 
     await speakVoice(mic, 2);
-    expect(framesToGemini()).toBeGreaterThanOrEqual(2);
+    expect(framesToProvider()).toBeGreaterThanOrEqual(2);
 
     // Swap the publication behind the bridge's back and kill the old stream — no frames
     // arrive on the new one until we resubscribe.
@@ -652,9 +722,9 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
     expect(events).not.toContain("gemini_suspended_silence");
 
     // Audio flows again through the resubscribed track.
-    const before = framesToGemini();
+    const before = framesToProvider();
     await speakVoice(newMic, 3);
-    expect(framesToGemini()).toBeGreaterThan(before);
+    expect(framesToProvider()).toBeGreaterThan(before);
     await bridge.stop();
   });
 
@@ -694,6 +764,126 @@ describe("TranslationBridge (end-to-end, faked LiveKit + Gemini)", () => {
 
     await vi.advanceTimersByTimeAsync(45_000); // past the 30s suspend window, no frames at all
     expect(events).not.toContain("gemini_suspended_silence");
+    await bridge.stop();
+  });
+
+  // -------------------------------------------------------------------------
+  // The second provider.
+  //
+  // Haitian Creole runs on OpenAI Realtime because Gemini Live Translate has no voice
+  // for it. The bridge around it is the *same* bridge — that's the point of the provider
+  // seam — so these tests deliberately don't re-test reconnects or the watchdog. They
+  // test the two things a new provider can get wrong on its own: the handshake (when is
+  // it safe to send audio) and the full audio round trip in both directions.
+  // -------------------------------------------------------------------------
+
+  /** A bridge translating into Haitian Creole over the OpenAI protocol. */
+  const bootOpenAI = (
+    seat: (room: FakeRoom) => FakeRemoteTrack,
+    overrides: Partial<ConstructorParameters<typeof TranslationBridge>[3]> = {}
+  ) =>
+    boot(
+      seat,
+      {
+        provider: new OpenAIProvider(
+          { apiKey: "fake-openai-key", targetLanguage: "ht", transcribeInput: false },
+          {}
+        ),
+        ...overrides,
+      },
+      "ht"
+    );
+
+  it("carries Haitian Creole end-to-end over the OpenAI protocol", async () => {
+    // Organizer mic → input_audio_buffer.append → (translation) → output audio delta →
+    // published LiveKit frame, plus the Creole transcript into Yjs. The whole product,
+    // on the provider that exists solely to make this language possible.
+    const transcript: Array<[string, string]> = [];
+    const writer = {
+      appendDelta: (code: string, text: string) => transcript.push([code, text]),
+    };
+    const { bridge, seated: mic } = await bootOpenAI((room) => room.seatOrganizer(ORGANIZER), {
+      writer: writer as unknown as ConstructorParameters<typeof TranslationBridge>[3]["writer"],
+    });
+
+    await speak(mic, 3);
+    expect(framesToProvider()).toBe(3);
+    expect(bridge.status).toBe("active");
+
+    // The model answers with Creole audio and its transcript.
+    const socket = FakeProviderSocket.instances[0];
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({ type: "response.output_audio.delta", delta: Buffer.alloc(480).toString("base64") })
+      )
+    );
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({ type: "response.output_audio_transcript.delta", delta: "Bonjou tout moun" })
+      )
+    );
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Translated audio reached a LiveKit track, and the transcript reached Yjs under the
+    // Creole code (not the source code — that would overwrite the English transcript).
+    expect(FakeAudioSource.instances[0].captured).toHaveLength(1);
+    expect(transcript).toEqual([["ht", "Bonjou tout moun"]]);
+
+    await bridge.stop();
+  });
+
+  it("asks LiveKit for each provider's own input sample rate", async () => {
+    // Gemini wants 16 kHz, OpenAI 24 kHz, and the bridge declares that rate to the
+    // provider — so a mismatch isn't an error anywhere, just audio that arrives at the
+    // wrong speed and pitch and translates badly. Nothing but this pins it.
+    const { bridge } = await bootOpenAI((room) => room.seatOrganizer(ORGANIZER));
+    expect(FakeAudioStream.instances[0].opts?.sampleRate).toBe(24_000);
+    await bridge.stop();
+
+    FakeAudioStream.instances = [];
+    const gemini = await boot((room) => room.seatOrganizer(ORGANIZER), {
+      provider: new GeminiProvider({
+        apiKey: "fake-gemini-key",
+        targetLanguage: "fr",
+        transcribeInput: false,
+      }),
+    });
+    expect(FakeAudioStream.instances[0].opts?.sampleRate).toBe(16_000);
+    await gemini.bridge.stop();
+  });
+
+  it("sends no audio to an OpenAI session that never got configured", async () => {
+    // `session.created` arrives before our `session.update` is applied — at that moment
+    // the model is a plain chatbot with no interpreter instructions. If the bridge read
+    // that as ready it would stream the opening of the talk into it and publish whatever
+    // came back. So a session stuck at `created` must fail to start, loudly, and leave
+    // the supervisor to retry rather than go live half-configured.
+    FakeProviderSocket.openaiHandshake = "createdOnly";
+
+    const bridge = new TranslationBridge("doc-test", "ht", ORGANIZER, {
+      geminiApiKey: "unused",
+      provider: new OpenAIProvider(
+        { apiKey: "fake-openai-key", targetLanguage: "ht", transcribeInput: false },
+        {}
+      ),
+      livekitUrl: "wss://fake.livekit",
+      livekitApiKey: "fake",
+      livekitApiSecret: "fake",
+    });
+    const started = bridge.start();
+    // Claim the rejection before advancing time — the timeout fires inside the tick
+    // below, and an unclaimed rejection there is an unhandled one.
+    const rejects = expect(started).rejects.toThrow(/setup timeout/);
+    await vi.advanceTimersByTimeAsync(10);
+    (lastRoom as FakeRoom).seatOrganizer(ORGANIZER);
+    // The setup timeout is 15s; nothing but session.created ever arrives.
+    await vi.advanceTimersByTimeAsync(16_000);
+
+    await rejects;
+    expect(bridge.status).toBe("error");
+    expect(framesToProvider()).toBe(0);
     await bridge.stop();
   });
 });

--- a/live-audio/translation-bridge.test.ts
+++ b/live-audio/translation-bridge.test.ts
@@ -4,7 +4,6 @@ import {
   frameRmsDbfs,
   isSilentFrame,
   nextBackoffMs,
-  parseGoAwayTimeLeftMs,
   parseSilenceThresholdDbfs,
   SILENCE_FLOOR_DBFS,
   SILENCE_GATING_OFF_DBFS,
@@ -119,37 +118,10 @@ describe("silence thresholds", () => {
   });
 });
 
-// The Gemini Live session is periodically terminated; the bridge reconnects with
-// backoff and reads the goAway `timeLeft` to reconnect proactively. These pure
-// helpers back that logic and are the testable seams (the socket plumbing is not).
-describe("parseGoAwayTimeLeftMs", () => {
-  it("parses protobuf Duration strings (seconds)", () => {
-    expect(parseGoAwayTimeLeftMs("10s")).toBe(10_000);
-    expect(parseGoAwayTimeLeftMs("10.5s")).toBe(10_500);
-    expect(parseGoAwayTimeLeftMs(" 2s ")).toBe(2_000);
-  });
-
-  it("parses a bare numeric string as seconds", () => {
-    expect(parseGoAwayTimeLeftMs("10")).toBe(10_000);
-  });
-
-  it("parses a number as seconds", () => {
-    expect(parseGoAwayTimeLeftMs(7)).toBe(7_000);
-  });
-
-  it("parses an expanded { seconds, nanos } Duration object", () => {
-    expect(parseGoAwayTimeLeftMs({ seconds: 8 })).toBe(8_000);
-    expect(parseGoAwayTimeLeftMs({ seconds: "8", nanos: 500_000_000 })).toBe(8_500);
-  });
-
-  it("returns null for missing or unparseable values", () => {
-    expect(parseGoAwayTimeLeftMs(null)).toBeNull();
-    expect(parseGoAwayTimeLeftMs(undefined)).toBeNull();
-    expect(parseGoAwayTimeLeftMs("soon")).toBeNull();
-    expect(parseGoAwayTimeLeftMs({})).toBeNull();
-  });
-});
-
+// Realtime sessions are periodically terminated by the provider, so the bridge
+// reconnects with backoff. This is the testable seam of that path; the socket plumbing
+// around it is covered end-to-end instead (translation-bridge.e2e.test.ts), and reading
+// a provider's own "I'm about to hang up" message belongs to the provider tests.
 describe("nextBackoffMs", () => {
   const opts = { initialMs: 1_000, maxMs: 30_000 };
 

--- a/live-audio/translation-bridge.ts
+++ b/live-audio/translation-bridge.ts
@@ -1,24 +1,31 @@
 /**
- * TranslationBridge: Connects a LiveKit room to a Gemini Live API WebSocket
+ * TranslationBridge: Connects a LiveKit room to a realtime speech-translation API
  * for real-time audio translation.
  *
  * Each bridge instance:
  * 1. Joins the LiveKit room as a bot participant (e.g., "translator-es")
  * 2. Subscribes to the organizer's audio track
- * 3. Pipes PCM audio frames to Gemini Live API via WebSocket
+ * 3. Pipes PCM audio frames to the provider via WebSocket
  * 4. Receives translated audio back and publishes it as a new track
+ *
+ * *Which* API is behind it is a `RealtimeProvider` (see realtime-provider.ts): Gemini
+ * Live Translate for the languages it supports, OpenAI Realtime for Haitian Creole,
+ * which it doesn't. Everything in this file is written against that seam, so the
+ * hard-won behavior below is earned once and inherited by every provider — which is
+ * the entire reason the seam exists rather than a second copy of this file.
  *
  * Both sides of the bridge drop connections, and each is defended differently:
  *
- * - **Gemini** periodically terminates the session (duration/context limits, routine
- *   resets). The bridge listens for the `goAway` warning and reconnects
+ * - **The provider** periodically terminates the session (duration/context limits,
+ *   routine resets). Where it warns first (Gemini's `goAway`) the bridge reconnects
  *   make-before-break — it opens a replacement socket while the old one is still
- *   serving audio, then swaps once the new one is ready. Unexpected closures fall back
- *   to a backoff reconnect. When the overlap fails (the old socket dies before the
- *   replacement finishes setup, e.g. a short `goAway` lead time), input frames are
- *   buffered during the gap and flushed into the fresh session on setup, so a swap
- *   costs a little latency on that segment rather than dropped words. The same buffer
- *   covers the setup latency when the socket is reopened after a silence suspend.
+ *   serving audio, then swaps once the new one is ready. Unexpected closures — the
+ *   only kind some providers give you — fall back to a backoff reconnect. When the
+ *   overlap fails (the old socket dies before the replacement finishes setup, e.g. a
+ *   short `goAway` lead time), input frames are buffered during the gap and flushed
+ *   into the fresh session on setup, so a swap costs a little latency on that segment
+ *   rather than dropped words. The same buffer covers the setup latency when the
+ *   socket is reopened after a silence suspend.
  * - **LiveKit** does full reconnects that silently rebuild remote track state, which
  *   twice left the bridge `active` but receiving no audio at all. The organizer
  *   subscription is therefore rebuildable (`Reconnected` re-drives it) and watched (a
@@ -51,12 +58,14 @@ import {
 // tsc accepts it either way, but ESM fails at runtime with "does not provide an export named".
 import type { RemoteTrack } from "@livekit/rtc-node";
 import WebSocket from "ws";
+import { GeminiProvider } from "./gemini-provider.ts";
+import type { ProviderEvent, ProviderName, RealtimeProvider } from "./realtime-provider.ts";
 import type { TranscriptWriter } from "./transcript-writer.ts";
 
 export type BridgeStatus = "starting" | "active" | "error" | "closed";
 
-/** The Gemini leg's state, derived for reporting (see health()). */
-export type GeminiLegState = "ready" | "connecting" | "backoff" | "suspended" | "down";
+/** The provider leg's state, derived for reporting (see health()). */
+export type ProviderLegState = "ready" | "connecting" | "backoff" | "suspended" | "down";
 
 /**
  * Composite health snapshot. `status` alone is a single word that has twice read
@@ -65,7 +74,10 @@ export type GeminiLegState = "ready" | "connecting" | "backoff" | "suspended" | 
  */
 export interface BridgeHealth {
   status: BridgeStatus;
-  gemini: GeminiLegState;
+  /** Which realtime backend this bridge is running against. */
+  providerName: ProviderName;
+  /** That backend's connection state (was `gemini` before there were two). */
+  provider: ProviderLegState;
   /** Last time an organizer audio frame entered the bridge (0 = never). */
   lastInputFrameAt: number;
   /** Last time translated audio was published to LiveKit (0 = never). */
@@ -83,7 +95,7 @@ export type RecordEvent = (
 
 /**
  * What prompted a reconnect, for telemetry.
- *   - goaway/close: the Gemini session died and we're re-establishing it.
+ *   - goaway/close: the provider session died and we're re-establishing it.
  *   - resume: the mic went from silence back to speech, so we're re-opening the
  *     socket we tore down to avoid paying to translate silence.
  */
@@ -101,7 +113,7 @@ const STALL_CHECK_INTERVAL_MS = 5_000;
 // escalates: that silence is expected, and recreating wouldn't (and shouldn't) end it.
 const STALL_ESCALATE_AFTER = 3;
 
-// Exponential-backoff bounds for failed Gemini reconnect attempts (mirrors the
+// Exponential-backoff bounds for failed provider reconnect attempts (mirrors the
 // Proclaim service's convention; see PROCLAIM_INTEGRATION.md).
 const RECONNECT_BACKOFF = { initialMs: 1_000, maxMs: 30_000 };
 
@@ -131,7 +143,7 @@ export const SILENCE_FLOOR_DBFS = -50;
 const SILENCE_SUSPEND_MS = 30_000;
 const SILENCE_CHECK_INTERVAL_MS = 5_000;
 
-// Input frames are 100 ms (AudioStream `frameSizeMs`). When the Gemini socket is
+// Input frames are 100 ms (AudioStream `frameSizeMs`). When the provider socket is
 // briefly unavailable — a reconnect gap where the old session closed before its
 // replacement finished setup, or the setup latency right after a silence resume — we
 // buffer input frames instead of dropping them, then flush them into the fresh
@@ -148,7 +160,7 @@ const MAX_BUFFERED_FRAMES = Math.round(4_000 / INPUT_FRAME_MS);
 const SILENCE_PREROLL_FRAMES = Math.round(500 / INPUT_FRAME_MS);
 
 // Flushing the backlog into a fresh session leaves that segment running a little
-// behind live, and Gemini processes input at ~1x, so the lag doesn't drain on its
+// behind live, and providers process input at ~1x, so the lag doesn't drain on its
 // own. But dead air carries no words: we collapse runs of below-floor silence in the
 // gap backlog beyond this many consecutive frames, keeping short pauses as
 // utterance-boundary cues. Since speech has natural gaps, a swap that lands in a
@@ -201,28 +213,6 @@ export function parseSilenceThresholdDbfs(raw: string | undefined): number {
 }
 
 /**
- * Parse the `timeLeft` from a Gemini `goAway` message into milliseconds. The wire
- * shape is unconfirmed for the translate model (the raw value is logged), so this
- * tolerates a protobuf Duration string ("10s", "10.5s"), a bare number of seconds,
- * or an expanded `{ seconds, nanos }` object. Returns null if it can't be parsed.
- */
-export function parseGoAwayTimeLeftMs(raw: unknown): number | null {
-  if (raw == null) return null;
-  if (typeof raw === "number") return isFinite(raw) ? Math.round(raw * 1000) : null;
-  if (typeof raw === "string") {
-    const m = raw.trim().match(/^([\d.]+)\s*s?$/);
-    return m ? Math.round(parseFloat(m[1]) * 1000) : null;
-  }
-  if (typeof raw === "object") {
-    const o = raw as { seconds?: number | string; nanos?: number | string };
-    const secs = o.seconds != null ? Number(o.seconds) : NaN;
-    if (isNaN(secs)) return null;
-    return Math.round(secs * 1000 + Number(o.nanos ?? 0) / 1e6);
-  }
-  return null;
-}
-
-/**
  * Equal-jitter exponential backoff: half the capped delay plus a random half, so
  * concurrent bridges don't reconnect in lockstep. Result is in [cap/2, cap] where
  * cap = min(maxMs, initialMs * 2^attempt).
@@ -272,7 +262,7 @@ export interface AudioParticipantLike {
  *     full reconnect emits `ParticipantConnected` for everyone already in the room — but
  *     **no `TrackPublished`** for their existing publications. So neither the startup
  *     enumeration nor the publish listener ever fired again, and the bridge streamed
- *     silence to Gemini for six minutes.
+ *     silence to the provider for six minutes.
  *
  * Reconciling is convergent rather than event-exhaustive: being wrong about any single
  * event costs nothing so long as some later trigger re-runs this. Enumerating events
@@ -324,12 +314,12 @@ export function shouldRecoverStalledInput(params: {
 
 export class TranslationBridge {
   private room: Room | null = null;
-  private geminiWs: WebSocket | null = null;
+  private providerWs: WebSocket | null = null;
   private audioSource: AudioSource | null = null;
   private localTrack: LocalAudioTrack | null = null;
   private publishedTrackSid: string = "";
-  private framesSentToGemini: number = 0;
-  private framesReceivedFromGemini: number = 0;
+  private framesSentToProvider: number = 0;
+  private framesReceivedFromProvider: number = 0;
 
   public readonly targetLanguage: string;
   public readonly sessionId: string;
@@ -337,11 +327,12 @@ export class TranslationBridge {
   public status: BridgeStatus = "starting";
   public subscriberCount: number = 0;
 
-  // Gemini Live API config
-  private readonly geminiApiKey: string;
-  private readonly geminiModel: string = "gemini-3.5-live-translate-preview";
-  private readonly sampleRate: number = 24000; // Gemini outputs 24kHz
-  private readonly inputSampleRate: number = 16000; // Gemini Live expects 16kHz input
+  // The realtime translation backend. Everything vendor-specific goes through this.
+  private readonly provider: RealtimeProvider;
+  // Sample rates are the provider's; LiveKit resamples the input for us on the way in,
+  // and the published track is created at the provider's output rate.
+  private readonly sampleRate: number;
+  private readonly inputSampleRate: number;
   private readonly channels: number = 1;
 
   // LiveKit config
@@ -349,13 +340,13 @@ export class TranslationBridge {
   private readonly livekitApiKey: string;
   private readonly livekitApiSecret: string;
 
-  // Whether the *current* (this.geminiWs) socket has finished setup and can take audio.
-  private geminiSetupComplete: boolean = false;
+  // Whether the *current* (this.providerWs) socket has finished setup and can take audio.
+  private providerSetupComplete: boolean = false;
   private organizerIdentity: string;
   private lastAudioFrameTime: number = 0;
   private captureChain: Promise<void> = Promise.resolve();
 
-  // Silence gating. `suspended` means we've torn down the Gemini socket because the
+  // Silence gating. `suspended` means we've torn down the provider socket because the
   // mic has been silent (the LiveKit participant/track stay live). `lastVoiceAt` is
   // the last time a non-silent input frame arrived; the monitor suspends once it's
   // older than SILENCE_SUSPEND_MS, and the first non-silent frame resumes.
@@ -370,7 +361,7 @@ export class TranslationBridge {
   // collapse dead air (see MAX_GAP_SILENCE_FRAMES).
   private bufferedSilenceRun: number = 0;
 
-  // Teardown epoch. Incremented whenever the Gemini side is torn down (stop, room
+  // Teardown epoch. Incremented whenever the provider side is torn down (stop, room
   // failure, silence suspend), and captured by every socket's handlers when the
   // socket is wired. A handler whose epoch is stale — its socket belongs to a life
   // the bridge has already left — is dropped instead of acting, which closes the
@@ -405,8 +396,8 @@ export class TranslationBridge {
 
   // Persists finalized transcript segments into the shared Yjs doc.
   private readonly writer: TranscriptWriter | null;
-  // Whether this bridge also writes the source-language (English) transcript,
-  // via Gemini input transcription. Only the primary bridge does, so the same
+  // Whether this bridge also writes the source-language (English) transcript, via the
+  // provider's input transcription. Only the primary bridge does, so the same
   // English text isn't appended once per running language.
   private readonly writesSourceTranscript: boolean;
   // Telemetry sink (PostHog, injected by the server). Null in tests / when unset.
@@ -429,6 +420,13 @@ export class TranslationBridge {
       livekitUrl: string;
       livekitApiKey: string;
       livekitApiSecret: string;
+      /**
+       * The realtime backend. Defaults to Gemini Live Translate built from
+       * `geminiApiKey`, so a caller that doesn't care which provider it gets — every
+       * caller before there were two — keeps working unchanged. The session manager
+       * passes one explicitly (see provider-selection.ts).
+       */
+      provider?: RealtimeProvider;
       writer?: TranscriptWriter | null;
       writesSourceTranscript?: boolean;
       recordEvent?: RecordEvent | null;
@@ -439,7 +437,15 @@ export class TranslationBridge {
     this.targetLanguage = targetLanguage;
     this.organizerIdentity = organizerIdentity;
     this.identity = `translator-${targetLanguage}`;
-    this.geminiApiKey = config.geminiApiKey;
+    this.provider =
+      config.provider ??
+      new GeminiProvider({
+        apiKey: config.geminiApiKey,
+        targetLanguage,
+        transcribeInput: config.writesSourceTranscript ?? false,
+      });
+    this.sampleRate = this.provider.outputSampleRate;
+    this.inputSampleRate = this.provider.inputSampleRate;
     this.livekitUrl = config.livekitUrl;
     this.livekitApiKey = config.livekitApiKey;
     this.livekitApiSecret = config.livekitApiSecret;
@@ -450,12 +456,12 @@ export class TranslationBridge {
   }
 
   /**
-   * The Gemini leg's current state, derived from the connection fields rather than
+   * The provider leg's current state, derived from the connection fields rather than
    * stored — so it can't drift from them. Reporting only; no behavior reads this.
    */
-  private geminiLegState(): GeminiLegState {
+  private providerLegState(): ProviderLegState {
     if (this.suspended) return "suspended";
-    if (this.geminiWs && this.geminiSetupComplete) return "ready";
+    if (this.providerWs && this.providerSetupComplete) return "ready";
     if (this.pendingWs) return "connecting";
     if (this.reconnectTimer) return "backoff";
     return "down";
@@ -465,7 +471,8 @@ export class TranslationBridge {
   health(): BridgeHealth {
     return {
       status: this.status,
-      gemini: this.geminiLegState(),
+      providerName: this.provider.name,
+      provider: this.providerLegState(),
       lastInputFrameAt: this.lastOrganizerFrameAt,
       lastOutputFrameAt: this.lastAudioFrameTime,
       reconnects: this.reconnectCount,
@@ -473,28 +480,47 @@ export class TranslationBridge {
     };
   }
 
-  /** Emit a telemetry event tagged with this bridge's language and identity. */
+  /**
+   * Emit a telemetry event tagged with this bridge's language, identity, and provider.
+   * Used for the room/input-side events, whose names are provider-independent.
+   */
   private record(event: string, properties: Record<string, unknown> = {}): void {
     if (!this.recordEvent) return;
     console.log(`[TranslationBridge:${this.targetLanguage}] telemetry: ${event}`, properties);
     this.recordEvent(event, {
       targetLanguage: this.targetLanguage,
       identity: this.identity,
+      provider: this.provider.name,
+      model: this.provider.model,
       ...properties,
     });
   }
 
+  /**
+   * Emit a *provider-leg* telemetry event, named `<provider>_<suffix>` — so a Gemini
+   * bridge still emits exactly `gemini_session_closed` and friends.
+   *
+   * That's on purpose: those names are what every existing dashboard, saved insight,
+   * and paragraph of docs/OBSERVABILITY.md is written against, and the whole point of
+   * observability is continuity across the moment you need it. A second provider gets
+   * its own parallel series (`openai_session_closed`) rather than renaming the first
+   * one's history, and the `provider` property on every event lets a query span both.
+   */
+  private recordProvider(suffix: string, properties: Record<string, unknown> = {}): void {
+    this.record(`${this.provider.name}_${suffix}`, properties);
+  }
+
   async start(): Promise<void> {
     console.log(
-      `[TranslationBridge:${this.targetLanguage}] Starting bridge for session ${this.sessionId} (telemetry: ${this.recordEvent ? 'enabled' : 'DISABLED'})`
+      `[TranslationBridge:${this.targetLanguage}] Starting bridge for session ${this.sessionId} via ${this.provider.name}/${this.provider.model} (telemetry: ${this.recordEvent ? 'enabled' : 'DISABLED'})`
     );
 
     try {
       // 1. Generate token and join LiveKit room
       await this.joinLiveKitRoom();
 
-      // 2. Connect to Gemini Live API
-      await this.connectGemini();
+      // 2. Connect to the realtime translation provider
+      await this.connectProvider();
 
       // 3. Subscribe to organizer's audio and wire up the pipeline
       await this.subscribeToOrganizer();
@@ -558,7 +584,7 @@ export class TranslationBridge {
     }
     this.pipedTracks.clear();
 
-    this.teardownGeminiSide();
+    this.teardownProviderSide();
 
     if (this.room) {
       await this.room.disconnect();
@@ -571,13 +597,13 @@ export class TranslationBridge {
   }
 
   /**
-   * Close the Gemini side completely: the active socket, any pending replacement, any
+   * Close the provider side completely: the active socket, any pending replacement, any
    * scheduled retry, and the gap buffer. Used by stop() and by failure paths (room
    * disconnect, watchdog escalation) where the bridge is done but must not leave a
    * paid-for socket behind. The sockets' close handlers see a non-active status (or
    * suspended) and won't reconnect.
    */
-  private teardownGeminiSide(): void {
+  private teardownProviderSide(): void {
     this.epoch++;
     this.reconnecting = false;
     if (this.reconnectTimer) {
@@ -588,11 +614,11 @@ export class TranslationBridge {
       this.pendingWs.close();
       this.pendingWs = null;
     }
-    if (this.geminiWs) {
-      this.geminiWs.close();
-      this.geminiWs = null;
+    if (this.providerWs) {
+      this.providerWs.close();
+      this.providerWs = null;
     }
-    this.geminiSetupComplete = false;
+    this.providerSetupComplete = false;
     this.pendingFrames = [];
     this.bufferedSilenceRun = 0;
   }
@@ -628,10 +654,10 @@ export class TranslationBridge {
       // Any other disconnect (duplicate identity, LiveKit server restart, connectivity
       // loss past the SDK's resume) is a failure. "error" marks the bridge recreatable —
       // ensureBridge treats it as stale, and listeners re-request the language when they
-      // see the translator gone. Drop the Gemini side too, so the bridge can't linger as
+      // see the translator gone. Drop the provider side too, so the bridge can't linger as
       // a zombie holding a paid-for session that no audio will ever reach.
       this.status = "error";
-      this.teardownGeminiSide();
+      this.teardownProviderSide();
     });
 
     this.room.on(RoomEvent.Reconnecting, () => {
@@ -692,7 +718,7 @@ export class TranslationBridge {
     );
 
     // Create an AudioSource to publish translated audio
-    // Gemini outputs 24kHz mono PCM
+    // Output rate is the provider's (24kHz mono PCM for both of ours)
     this.audioSource = new AudioSource(this.sampleRate, this.channels);
     this.localTrack = LocalAudioTrack.createAudioTrack(
       `translated-audio-${this.targetLanguage}`,
@@ -721,41 +747,43 @@ export class TranslationBridge {
     );
   }
 
-  private geminiWsUrl(): string {
-    return `wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=${this.geminiApiKey}`;
+  /** Open a socket to the provider. Auth lives in the URL or the headers, its choice. */
+  private openProviderSocket(): WebSocket {
+    const { url, options } = this.provider.socket();
+    return new WebSocket(url, options);
   }
 
-  /** Open the initial Gemini socket and resolve once its setup completes. */
-  private async connectGemini(): Promise<void> {
+  /** Open the initial provider socket and resolve once its setup completes. */
+  private async connectProvider(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      const ws = new WebSocket(this.geminiWsUrl());
-      this.geminiWs = ws;
-      this.wireGeminiSocket(ws, { role: "initial", onInitialError: reject });
+      const ws = this.openProviderSocket();
+      this.providerWs = ws;
+      this.wireProviderSocket(ws, { role: "initial", onInitialError: reject });
 
       const checkSetup = setInterval(() => {
-        if (this.geminiSetupComplete) {
+        if (this.providerSetupComplete) {
           clearInterval(checkSetup);
           resolve();
         }
       }, 100);
 
       setTimeout(() => {
-        if (!this.geminiSetupComplete) {
+        if (!this.providerSetupComplete) {
           clearInterval(checkSetup);
-          reject(new Error("Gemini setup timeout"));
+          reject(new Error(`${this.provider.name} setup timeout`));
         }
       }, 15000);
     });
   }
 
   /**
-   * Attach handlers to a Gemini socket. Used for both the initial connection and
+   * Attach handlers to a provider socket. Used for both the initial connection and
    * reconnect replacements, so their behavior never diverges. A "pending"
    * replacement is swapped in as the active socket once its setup completes
    * (make-before-break); content messages from any socket that isn't the current
-   * `this.geminiWs` are ignored.
+   * `this.providerWs` are ignored.
    */
-  private wireGeminiSocket(
+  private wireProviderSocket(
     ws: WebSocket,
     opts: {
       role: "initial" | "pending";
@@ -772,9 +800,9 @@ export class TranslationBridge {
     ws.on("open", () => {
       openedAt = Date.now();
       console.log(
-        `[TranslationBridge:${this.targetLanguage}] Gemini WebSocket open (${opts.role})`
+        `[TranslationBridge:${this.targetLanguage}] ${this.provider.name} socket open (${opts.role})`
       );
-      this.sendGeminiSetup(ws);
+      this.sendProviderSetup(ws);
     });
 
     ws.on("message", (data: WebSocket.Data) => {
@@ -783,7 +811,7 @@ export class TranslationBridge {
         message = JSON.parse(data.toString());
       } catch (error) {
         console.error(
-          `[TranslationBridge:${this.targetLanguage}] Error parsing Gemini message:`,
+          `[TranslationBridge:${this.targetLanguage}] Error parsing ${this.provider.name} message:`,
           error
         );
         return;
@@ -791,12 +819,14 @@ export class TranslationBridge {
 
       if (!ready) {
         console.log(
-          `[TranslationBridge:${this.targetLanguage}] Gemini message (pre-setup, ${opts.role}):`,
+          `[TranslationBridge:${this.targetLanguage}] ${this.provider.name} message (pre-setup, ${opts.role}):`,
           JSON.stringify(message).slice(0, 500)
         );
       }
 
-      if (message.setupComplete) {
+      const events = this.provider.interpret(message);
+
+      if (events.some((e) => e.kind === "ready")) {
         // The bridge may have moved on while this socket was setting up — suspended
         // for silence, stopped, or failed with its room. Swapping in then would strand
         // an open, paid-for socket in a bridge that believes it has none. (status
@@ -810,7 +840,7 @@ export class TranslationBridge {
           console.log(
             `[TranslationBridge:${this.targetLanguage}] Dropping stale setupComplete (${opts.role})`
           );
-          this.record("gemini_stale_socket_dropped", { role: opts.role, trigger: opts.trigger });
+          this.recordProvider("stale_socket_dropped", { role: opts.role, trigger: opts.trigger });
           try {
             ws.close();
           } catch {
@@ -824,13 +854,13 @@ export class TranslationBridge {
       }
 
       // Only the active socket's content drives audio/transcript output.
-      if (ws !== this.geminiWs) return;
-      this.processServerContent(message);
+      if (ws !== this.providerWs) return;
+      this.processProviderEvents(events);
     });
 
     ws.on("error", (error) => {
       console.error(
-        `[TranslationBridge:${this.targetLanguage}] Gemini WebSocket error (${opts.role}):`,
+        `[TranslationBridge:${this.targetLanguage}] ${this.provider.name} socket error (${opts.role}):`,
         error
       );
       if (opts.role === "initial" && !ready) {
@@ -840,40 +870,40 @@ export class TranslationBridge {
 
     ws.on("close", (code: number, reason: Buffer) => {
       const reasonStr = reason.toString();
-      const wasActive = ws === this.geminiWs;
+      const wasActive = ws === this.providerWs;
       const wasPending = ws === this.pendingWs;
       console.log(
-        `[TranslationBridge:${this.targetLanguage}] Gemini WebSocket closed (${opts.role})`,
+        `[TranslationBridge:${this.targetLanguage}] ${this.provider.name} socket closed (${opts.role})`,
         { code, reason: reasonStr, wasActive, wasPending }
       );
-      this.record("gemini_session_closed", {
+      this.recordProvider("session_closed", {
         code,
         reason: reasonStr,
         role: opts.role,
         wasActive,
         wasPending,
         socketLifetimeMs: openedAt ? Date.now() - openedAt : 0,
-        framesSent: this.framesSentToGemini,
-        framesReceived: this.framesReceivedFromGemini,
+        framesSent: this.framesSentToProvider,
+        framesReceived: this.framesReceivedFromProvider,
         totalReconnects: this.reconnectCount,
       });
 
       if (opts.role === "initial" && !ready) {
         opts.onInitialError?.(
-          new Error(`Gemini WebSocket closed before setup: code=${code} reason=${reasonStr}`)
+          new Error(`${this.provider.name} socket closed before setup: code=${code} reason=${reasonStr}`)
         );
         return;
       }
 
       // While suspended for silence we deliberately closed the socket and nulled
-      // `geminiWs`; the resume path reopens it. Don't treat that as a session drop.
+      // `providerWs`; the resume path reopens it. Don't treat that as a session drop.
       if (this.status !== "active" || this.suspended) return;
 
       if (wasActive) {
         // The live session died (with or without a goAway). Stop sending audio to
         // the dead socket and reconnect (no-op if a goAway replacement is already
         // in flight).
-        this.geminiSetupComplete = false;
+        this.providerSetupComplete = false;
         this.beginReconnect("close");
       } else if (wasPending) {
         // A replacement died before it could take over — retry with backoff,
@@ -882,7 +912,7 @@ export class TranslationBridge {
         const attempt = (opts.attempt ?? 0) + 1;
         const trigger = opts.trigger ?? "close";
         const backoffMs = nextBackoffMs(attempt);
-        this.record("gemini_reconnect_retry", { trigger, attempt, backoffMs });
+        this.recordProvider("reconnect_retry", { trigger, attempt, backoffMs });
         this.reconnectTimer = setTimeout(() => this.openReplacement(trigger, attempt), backoffMs);
       }
       // A stale socket we already swapped away from: nothing to do.
@@ -897,11 +927,11 @@ export class TranslationBridge {
     trigger?: ReconnectTrigger
   ): void {
     this.sessionConnectedAt = Date.now();
-    this.geminiSetupComplete = true;
+    this.providerSetupComplete = true;
 
     if (role === "pending") {
-      const old = this.geminiWs;
-      this.geminiWs = ws;
+      const old = this.providerWs;
+      this.providerWs = ws;
       this.pendingWs = null;
       this.reconnecting = false;
       this.reconnectCount++;
@@ -913,9 +943,9 @@ export class TranslationBridge {
         }
       }
       console.log(
-        `[TranslationBridge:${this.targetLanguage}] Gemini reconnect setup complete — swapped in (trigger=${trigger}, total=${this.reconnectCount})`
+        `[TranslationBridge:${this.targetLanguage}] ${this.provider.name} reconnect setup complete — swapped in (trigger=${trigger}, total=${this.reconnectCount})`
       );
-      this.record("gemini_session_setup_complete", {
+      this.recordProvider("session_setup_complete", {
         isReconnect: true,
         trigger,
         totalReconnects: this.reconnectCount,
@@ -923,9 +953,9 @@ export class TranslationBridge {
       });
     } else {
       console.log(
-        `[TranslationBridge:${this.targetLanguage}] Gemini setup complete`
+        `[TranslationBridge:${this.targetLanguage}] ${this.provider.name} setup complete`
       );
-      this.record("gemini_session_setup_complete", {
+      this.recordProvider("session_setup_complete", {
         isReconnect: false,
         totalReconnects: 0,
         setupLatencyMs,
@@ -950,16 +980,16 @@ export class TranslationBridge {
       return;
     }
     console.log(
-      `[TranslationBridge:${this.targetLanguage}] Opening replacement Gemini socket (trigger=${trigger}, attempt=${attempt})`
+      `[TranslationBridge:${this.targetLanguage}] Opening replacement ${this.provider.name} socket (trigger=${trigger}, attempt=${attempt})`
     );
-    this.record("gemini_reconnect_attempt", { trigger, attempt });
-    const ws = new WebSocket(this.geminiWsUrl());
+    this.recordProvider("reconnect_attempt", { trigger, attempt });
+    const ws = this.openProviderSocket();
     this.pendingWs = ws;
-    this.wireGeminiSocket(ws, { role: "pending", trigger, attempt });
+    this.wireProviderSocket(ws, { role: "pending", trigger, attempt });
   }
 
   /**
-   * Periodically suspend the Gemini socket after a long silence. Resumption is
+   * Periodically suspend the provider socket after a long silence. Resumption is
    * driven per-frame (the first non-silent frame reopens the socket), but this
    * timer also catches the case where the mic is muted and no frames arrive at
    * all — then `lastVoiceAt` simply stops advancing and the window elapses.
@@ -983,7 +1013,7 @@ export class TranslationBridge {
   }
 
   /**
-   * Tear down the Gemini socket after a sustained silence. The LiveKit room and the
+   * Tear down the provider socket after a sustained silence. The LiveKit room and the
    * published translated track are left untouched, so subscribers stay connected —
    * the translated audio just goes quiet until we resume. Any in-flight reconnect is
    * cancelled: there's nothing to reconnect to while we're intentionally down.
@@ -992,7 +1022,7 @@ export class TranslationBridge {
     if (this.suspended) return;
     const silentMs = this.lastVoiceAt ? Date.now() - this.lastVoiceAt : null;
     console.log(
-      `[TranslationBridge:${this.targetLanguage}] Suspending Gemini after ${silentMs}ms of silence`
+      `[TranslationBridge:${this.targetLanguage}] Suspending ${this.provider.name} after ${silentMs}ms of silence`
     );
     // Set suspended before closing so the socket's close handler treats this as an
     // intentional teardown rather than a session drop to reconnect from. The shared
@@ -1000,17 +1030,17 @@ export class TranslationBridge {
     // silence pre-roll) and bumps the epoch, so an in-flight setupComplete from
     // before the suspend can't swap a socket back in.
     this.suspended = true;
-    this.teardownGeminiSide();
+    this.teardownProviderSide();
 
-    this.record("gemini_suspended_silence", {
+    this.recordProvider("suspended_silence", {
       silentMs,
-      framesSent: this.framesSentToGemini,
-      framesReceived: this.framesReceivedFromGemini,
+      framesSent: this.framesSentToProvider,
+      framesReceived: this.framesReceivedFromProvider,
     });
   }
 
   /**
-   * Reopen the Gemini socket on the first sign of speech after a silence suspend.
+   * Reopen the provider socket on the first sign of speech after a silence suspend.
    * Reuses the make-before-break reconnect path (trigger "resume"); frames that
    * arrive before the replacement finishes setup are counted as dropped, so the
    * first word after silence may be clipped by the socket setup latency.
@@ -1019,115 +1049,118 @@ export class TranslationBridge {
     if (!this.suspended) return;
     const silentMs = this.lastVoiceAt ? Date.now() - this.lastVoiceAt : null;
     console.log(
-      `[TranslationBridge:${this.targetLanguage}] Voice detected — resuming Gemini after ${silentMs}ms of silence`
+      `[TranslationBridge:${this.targetLanguage}] Voice detected — resuming ${this.provider.name} after ${silentMs}ms of silence`
     );
     this.suspended = false;
-    this.record("gemini_resumed_voice", { silentMs });
+    this.recordProvider("resumed_voice", { silentMs });
     this.beginReconnect("resume");
   }
 
-  private sendGeminiSetup(ws: WebSocket): void {
-    const setupMessage = {
-      setup: {
-        model: `models/${this.geminiModel}`,
-        outputAudioTranscription: {},
-        // Only the primary bridge transcribes the source audio (English), so the
-        // English transcript is produced once regardless of how many languages run.
-        ...(this.writesSourceTranscript ? { inputAudioTranscription: {} } : {}),
-        generationConfig: {
-          responseModalities: ["AUDIO"],
-          translationConfig: {
-            targetLanguageCode: this.targetLanguage,
-            echoTargetLanguage: true,
-          },
-        },
-        realtimeInputConfig: {
-          automaticActivityDetection: {
-            disabled: false,
-          },
-        },
-      },
-    };
-
-    console.log(
-      `[TranslationBridge:${this.targetLanguage}] Sending Gemini setup:`,
-      JSON.stringify(setupMessage, null, 2)
-    );
-
-    ws.send(JSON.stringify(setupMessage));
+  /** Send the provider's session configuration on a freshly-opened socket. */
+  private sendProviderSetup(ws: WebSocket): void {
+    for (const setupMessage of this.provider.setupMessages()) {
+      console.log(
+        `[TranslationBridge:${this.targetLanguage}] Sending ${this.provider.name} setup:`,
+        JSON.stringify(setupMessage, null, 2)
+      );
+      ws.send(JSON.stringify(setupMessage));
+    }
   }
 
-  /** Handle a content message from the active Gemini socket. */
-  private processServerContent(message: Record<string, unknown>): void {
-    // goAway: the server warns before terminating. Reconnect now (make-before-break)
-    // so the replacement is ready before this socket actually closes.
-    const goAway = (message.goAway ?? message.go_away) as
-      | { timeLeft?: unknown; time_left?: unknown }
-      | undefined;
-    if (goAway) {
-      const raw = goAway.timeLeft ?? goAway.time_left;
-      const timeLeftMs = parseGoAwayTimeLeftMs(raw);
-      const sessionAgeMs = this.sessionConnectedAt ? Date.now() - this.sessionConnectedAt : null;
-      console.log(`[TranslationBridge:${this.targetLanguage}] Gemini goAway received`, {
-        raw,
-        timeLeftMs,
-        sessionAgeMs,
-      });
-      this.record("gemini_goaway", {
-        timeLeftRaw: typeof raw === "string" ? raw : JSON.stringify(raw ?? null),
-        timeLeftMs,
-        sessionAgeMs,
-      });
-      this.beginReconnect("goaway");
-      return;
-    }
-
-    // sessionResumptionUpdate: we don't resume yet, but record whether the translate
-    // model even offers a handle — informs whether session resumption is worth adding.
-    const sru = message.sessionResumptionUpdate ?? message.session_resumption_update;
-    if (sru) {
-      const o = sru as { resumable?: boolean; newHandle?: string; new_handle?: string };
-      this.record("gemini_session_resumption_update", {
-        resumable: !!o.resumable,
-        hasHandle: !!(o.newHandle ?? o.new_handle),
-      });
-    }
-
-    const serverContent = (message as { serverContent?: { modelTurn?: { parts?: Array<{ inlineData?: { data?: string } }> }; outputTranscription?: { text?: string }; inputTranscription?: { text?: string } } }).serverContent;
-    const parts = serverContent?.modelTurn?.parts;
-
-    if (parts?.length) {
-      for (const part of parts) {
-        if (part.inlineData?.data) {
-          this.framesReceivedFromGemini++;
-          if (this.framesReceivedFromGemini <= 3 || this.framesReceivedFromGemini % 100 === 0) {
+  /**
+   * Act on what the active provider socket said. The provider does the reading (which is
+   * where every vendor difference lives); this does the reacting, identically for all of
+   * them. Reading happens once, in the socket's message handler, because `ready` has to
+   * be answered before content dispatch — see wireProviderSocket.
+   */
+  private processProviderEvents(events: ProviderEvent[]): void {
+    for (const event of events) {
+      switch (event.kind) {
+        case "audio":
+          this.framesReceivedFromProvider++;
+          if (this.framesReceivedFromProvider <= 3 || this.framesReceivedFromProvider % 100 === 0) {
             console.log(
-              `[TranslationBridge:${this.targetLanguage}] Received audio frame #${this.framesReceivedFromGemini} from Gemini (${part.inlineData.data.length} bytes base64)`
+              `[TranslationBridge:${this.targetLanguage}] Received audio frame #${this.framesReceivedFromProvider} from ${this.provider.name} (${event.base64.length} bytes base64)`
             );
           }
           // Queue frame for sequential capture (avoid promise pile-up)
-          this.queueAudioFrame(part.inlineData.data);
+          this.queueAudioFrame(event.base64);
+          break;
+
+        // Transcript deltas are persisted straight into the shared Yjs transcript —
+        // the single source of truth for viewers. Providers stream these continuously
+        // with no end-of-turn marker, so there is nothing to wait for.
+        case "targetTranscript":
+          this.writer?.appendDelta(this.targetLanguage, event.text);
+          break;
+
+        // Source language (English), only on the primary bridge — enforced here as
+        // well as in the provider's setup, since this is the write that would double.
+        case "sourceTranscript":
+          if (this.writesSourceTranscript) {
+            this.writer?.appendDelta(TranslationBridge.SOURCE_CODE, event.text);
+          }
+          break;
+
+        // The server warned it will terminate this session. Reconnect now
+        // (make-before-break) so the replacement is ready before this socket closes.
+        case "goAway": {
+          const sessionAgeMs = this.sessionConnectedAt
+            ? Date.now() - this.sessionConnectedAt
+            : null;
+          console.log(
+            `[TranslationBridge:${this.targetLanguage}] ${this.provider.name} goAway received`,
+            { raw: event.raw, timeLeftMs: event.timeLeftMs, sessionAgeMs }
+          );
+          this.recordProvider("goaway", {
+            timeLeftRaw:
+              typeof event.raw === "string" ? event.raw : JSON.stringify(event.raw ?? null),
+            timeLeftMs: event.timeLeftMs,
+            sessionAgeMs,
+          });
+          this.beginReconnect("goaway");
+          return; // nothing after a goAway in the same message is worth acting on
         }
+
+        // We don't resume sessions yet; recording whether a handle was even offered is
+        // what tells us whether it's worth building.
+        case "resumable":
+          this.recordProvider("session_resumption_update", {
+            resumable: event.resumable,
+            hasHandle: event.hasHandle,
+          });
+          break;
+
+        // A server-reported error. Fatal means the session is finished but the socket
+        // hasn't closed yet, so we start the replacement rather than waiting for it.
+        case "error":
+          console.error(
+            `[TranslationBridge:${this.targetLanguage}] ${this.provider.name} error (fatal=${event.fatal}, code=${event.code}): ${event.message}`
+          );
+          this.recordProvider("session_error", {
+            code: event.code,
+            message: event.message,
+            fatal: event.fatal,
+          });
+          if (event.fatal) {
+            this.providerSetupComplete = false;
+            this.beginReconnect("close");
+            return;
+          }
+          break;
+
+        // `ready` is handled by the socket wiring before content dispatch, so a
+        // provider that re-announces it mid-session changes nothing.
+        case "ready":
+          break;
       }
-    }
-
-    // Transcription (target language): Gemini Live Translate streams a continuous
-    // flow of deltas with no turnComplete, so persist each delta straight into the
-    // shared Yjs transcript, which is the single source of truth for viewers.
-    if (serverContent?.outputTranscription?.text) {
-      this.writer?.appendDelta(this.targetLanguage, serverContent.outputTranscription.text);
-    }
-
-    // Input transcription (source language / English) — only on the primary bridge.
-    if (this.writesSourceTranscript && serverContent?.inputTranscription?.text) {
-      this.writer?.appendDelta(TranslationBridge.SOURCE_CODE, serverContent.inputTranscription.text);
     }
   }
 
   /**
    * Replay input frames buffered while the socket was down into the freshly-ready
    * session, then report any that overflowed the buffer (genuine loss). Called from
-   * onSocketReady, so `this.geminiWs` is the new active socket. Because only never-
+   * onSocketReady, so `this.providerWs` is the new active socket. Because only never-
    * sent frames are buffered, this never re-sends audio — the transcript can't double.
    */
   private flushPendingFrames(): void {
@@ -1141,14 +1174,14 @@ export class TranslationBridge {
         `[TranslationBridge:${this.targetLanguage}] Flushing ${frames.length} buffered input frames (${bufferedMs}ms) into the fresh session`
       );
       for (const f of frames) this.sendFrameData(f);
-      this.record("gemini_input_flushed", { frames: frames.length, bufferedMs });
+      this.recordProvider("input_flushed", { frames: frames.length, bufferedMs });
     }
 
     if (this.framesDroppedWhileDown > 0) {
       console.log(
         `[TranslationBridge:${this.targetLanguage}] Dropped ${this.framesDroppedWhileDown} input audio frames (buffer overflow) while reconnecting`
       );
-      this.record("gemini_input_dropped", { frames: this.framesDroppedWhileDown });
+      this.recordProvider("input_dropped", { frames: this.framesDroppedWhileDown });
       this.framesDroppedWhileDown = 0;
     }
   }
@@ -1181,10 +1214,10 @@ export class TranslationBridge {
       if (this.lastAudioFrameTime && now - this.lastAudioFrameTime > 2000) {
         const gapMs = now - this.lastAudioFrameTime;
         console.log(
-          `[TranslationBridge:${this.targetLanguage}] Audio resumed after ${gapMs}ms gap (frame #${this.framesReceivedFromGemini})`
+          `[TranslationBridge:${this.targetLanguage}] Audio resumed after ${gapMs}ms gap (frame #${this.framesReceivedFromProvider})`
         );
         // The user-visible "hang" duration — the headline metric for this work.
-        this.record("gemini_audio_gap", { gapMs });
+        this.recordProvider("audio_gap", { gapMs });
       }
       this.lastAudioFrameTime = now;
     } catch (error: unknown) {
@@ -1219,7 +1252,7 @@ export class TranslationBridge {
     room.on(RoomEvent.Reconnected, () => this.reconcile("reconnected"));
 
     // Piping is separate from subscribing: a track can be delivered to us more than once,
-    // and must reach Gemini exactly once. The dedupe is cleared when a stream ends, so a
+    // and must reach the provider exactly once. The dedupe is cleared when a stream ends, so a
     // track that comes back after a reconnect pipes again.
     room.on(
       RoomEvent.TrackSubscribed,
@@ -1228,7 +1261,7 @@ export class TranslationBridge {
         if (pub.kind !== TrackKind.KIND_AUDIO) return;
         if (this.pipedTracks.has(track)) return;
         this.pipedTracks.add(track);
-        this.pipeTrackToGemini(track);
+        this.pipeTrackToProvider(track);
       }
     );
 
@@ -1280,7 +1313,7 @@ export class TranslationBridge {
 
       // Level 2: reconcile has had its chances and frames never came back. Only when
       // the organizer's mic *looks* live — a muted/unpublished mic is expected silence,
-      // and recreating the bridge wouldn't end it (just churn a Gemini session).
+      // and recreating the bridge wouldn't end it (just churn a provider session).
       if (this.organizerHasUnmutedAudio()) {
         this.consecutiveStallRecoveries++;
         if (this.consecutiveStallRecoveries >= STALL_ESCALATE_AFTER) {
@@ -1328,9 +1361,9 @@ export class TranslationBridge {
     return false;
   }
 
-  private pipeTrackToGemini(track: RemoteAudioTrack): void {
+  private pipeTrackToProvider(track: RemoteAudioTrack): void {
     console.log(
-      `[TranslationBridge:${this.targetLanguage}] Subscribed to organizer audio track, piping to Gemini`
+      `[TranslationBridge:${this.targetLanguage}] Subscribed to organizer audio track, piping to ${this.provider.name}`
     );
     this.record("organizer_audio_piped");
 
@@ -1346,7 +1379,7 @@ export class TranslationBridge {
       while (true) {
         const { done, value } = await reader.read();
         if (done) return;
-        this.sendAudioToGemini(value);
+        this.sendAudioToProvider(value);
       }
     };
 
@@ -1377,9 +1410,9 @@ export class TranslationBridge {
       });
   }
 
-  private sendAudioToGemini(frame: AudioFrame): void {
-    // Liveness is stamped where organizer audio *enters* the bridge, before the Gemini
-    // check below: a stalled Gemini socket is a different failure with its own recovery,
+  private sendAudioToProvider(frame: AudioFrame): void {
+    // Liveness is stamped where organizer audio *enters* the bridge, before the provider
+    // check below: a stalled provider socket is a different failure with its own recovery,
     // and conflating them would have the watchdog papering over the wrong pipe. Stamp on
     // every organizer frame (silence included) — the input pipe being alive is the point,
     // independent of whether this frame is voice.
@@ -1397,16 +1430,16 @@ export class TranslationBridge {
 
     // Still suspended → a quiet frame with no session to feed. Keep only a short
     // rolling pre-roll (so the resume flush carries the speech onset into the fresh
-    // session) and send nothing — the whole point is not to pay Gemini for silence.
+    // session) and send nothing — the whole point is not to pay for translating silence.
     if (this.suspended) {
       this.bufferFrame(frame.data, { preroll: true, dbfs });
       return;
     }
 
     const canSend =
-      !!this.geminiWs &&
-      this.geminiWs.readyState === WebSocket.OPEN &&
-      this.geminiSetupComplete;
+      !!this.providerWs &&
+      this.providerWs.readyState === WebSocket.OPEN &&
+      this.providerSetupComplete;
 
     if (canSend) {
       this.sendFrameData(frame.data);
@@ -1445,33 +1478,24 @@ export class TranslationBridge {
     }
   }
 
-  /** Serialize and send one PCM16 frame to the active Gemini socket. */
+  /** Serialize and send one PCM16 frame to the active provider socket. */
   private sendFrameData(int16Data: Int16Array): void {
-    if (!this.geminiWs || this.geminiWs.readyState !== WebSocket.OPEN) return;
+    if (!this.providerWs || this.providerWs.readyState !== WebSocket.OPEN) return;
     try {
       const buffer = Buffer.from(int16Data.buffer, int16Data.byteOffset, int16Data.byteLength);
       const base64 = buffer.toString("base64");
 
-      this.framesSentToGemini++;
-      if (this.framesSentToGemini <= 3 || this.framesSentToGemini % 500 === 0) {
+      this.framesSentToProvider++;
+      if (this.framesSentToProvider <= 3 || this.framesSentToProvider % 500 === 0) {
         console.log(
-          `[TranslationBridge:${this.targetLanguage}] Sent audio frame #${this.framesSentToGemini} to Gemini (${base64.length} bytes base64, ${int16Data.length} samples)`
+          `[TranslationBridge:${this.targetLanguage}] Sent audio frame #${this.framesSentToProvider} to ${this.provider.name} (${base64.length} bytes base64, ${int16Data.length} samples)`
         );
       }
 
-      const message = {
-        realtimeInput: {
-          audio: {
-            mimeType: `audio/pcm;rate=${this.inputSampleRate}`,
-            data: base64,
-          },
-        },
-      };
-
-      this.geminiWs.send(JSON.stringify(message));
+      this.providerWs.send(JSON.stringify(this.provider.inputFrameMessage(base64)));
     } catch (error) {
       console.error(
-        `[TranslationBridge:${this.targetLanguage}] Error sending audio to Gemini:`,
+        `[TranslationBridge:${this.targetLanguage}] Error sending audio to ${this.provider.name}:`,
         error
       );
     }

--- a/live-audio/translation-session-manager.test.ts
+++ b/live-audio/translation-session-manager.test.ts
@@ -129,7 +129,8 @@ class FakeBridge {
   health() {
     return {
       status: this.status,
-      gemini: "ready" as const,
+      providerName: "gemini" as const,
+      provider: "ready" as const,
       lastInputFrameAt: 0,
       lastOutputFrameAt: 0,
       reconnects: 0,
@@ -155,6 +156,10 @@ function makeManager(rooms: Map<string, PresentParticipant[]>) {
     // only constructed lazily per session and these tests never await its sync.
     documentManager: null as unknown as DocumentManager,
     livekit: { url: "ws://fake", apiKey: "k", apiSecret: "s" },
+    // Provider selection is a real decision now (Gemini for most languages, OpenAI for
+    // Haitian Creole), and it needs to know which keys exist. Injecting both keeps these
+    // supervisor tests about *demand* rather than about credentials.
+    providerKeys: { gemini: "fake-gemini-key", openai: "fake-openai-key" },
     directory,
     bridgeFactory: (sessionId, targetLanguage) => {
       const bridge = new FakeBridge(sessionId, targetLanguage);

--- a/live-audio/translation-session-manager.ts
+++ b/live-audio/translation-session-manager.ts
@@ -21,6 +21,7 @@ import type { SimulateScenarioKind } from "@livekit/rtc-node";
 import type { DocumentManager } from "@y-sweet/sdk";
 import { RoomServiceClient } from "livekit-server-sdk";
 
+import { parseLanguageList, providerForLanguage, type ProviderKeys } from "./provider-selection.ts";
 import { TranscriptWriter } from "./transcript-writer.ts";
 import { SILENCE_GATING_OFF_DBFS, TranslationBridge } from "./translation-bridge.ts";
 import type { BridgeHealth, BridgeStatus } from "./translation-bridge.ts";
@@ -204,6 +205,14 @@ export class TranslationSessionManager {
   // say in which bridges exist (see computeDesiredLanguages).
   private silenceThresholdDbfs: number = SILENCE_GATING_OFF_DBFS;
 
+  // Languages an operator has pushed onto the OpenAI provider by hand
+  // (`LIVE_AUDIO_OPENAI_LANGUAGES`), for comparing the two backends on a language both
+  // can serve. Empty in the normal case, where routing is decided by capability alone.
+  private openaiLanguages: ReadonlySet<string> = new Set();
+
+  // Set by init() to bypass the environment; null means "read process.env".
+  private injectedProviderKeys: ProviderKeys | null = null;
+
   static getInstance(): TranslationSessionManager {
     if (!TranslationSessionManager.instance) {
       TranslationSessionManager.instance = new TranslationSessionManager();
@@ -221,6 +230,10 @@ export class TranslationSessionManager {
     livekit: LiveKitConfig;
     telemetry?: TelemetryClient;
     silenceThresholdDbfs?: number;
+    /** Override the `LIVE_AUDIO_OPENAI_LANGUAGES` routing list (tests). */
+    openaiLanguages?: Iterable<string>;
+    /** Override the provider API keys read from the environment (tests). */
+    providerKeys?: ProviderKeys;
     directory?: RoomDirectory;
     bridgeFactory?: typeof defaultBridgeFactory;
   }): void {
@@ -228,6 +241,10 @@ export class TranslationSessionManager {
     this.livekitConfig = opts.livekit;
     this.telemetry = opts.telemetry ?? null;
     this.silenceThresholdDbfs = opts.silenceThresholdDbfs ?? SILENCE_GATING_OFF_DBFS;
+    this.openaiLanguages = opts.openaiLanguages
+      ? new Set(opts.openaiLanguages)
+      : parseLanguageList(process.env.LIVE_AUDIO_OPENAI_LANGUAGES);
+    this.injectedProviderKeys = opts.providerKeys ?? null;
     this.directory = opts.directory ?? roomServiceDirectory(opts.livekit);
     if (opts.bridgeFactory) this.bridgeFactory = opts.bridgeFactory;
     this.startSupervisor();
@@ -275,6 +292,20 @@ export class TranslationSessionManager {
       return defaultBridge;
     }
     return this.ensureBridge(sessionId, targetLanguage, organizerIdentity, writer);
+  }
+
+  /**
+   * The API keys available for realtime translation, read fresh so a key added to the
+   * environment doesn't require a manager rebuild. Which languages each key unlocks is
+   * provider-selection.ts's business, not the manager's.
+   */
+  private providerKeys(): ProviderKeys {
+    return (
+      this.injectedProviderKeys ?? {
+        gemini: process.env.GEMINI_API_KEY,
+        openai: process.env.OPENAI_API_KEY,
+      }
+    );
   }
 
   private getStamps(sessionId: string): Map<string, number> {
@@ -335,18 +366,39 @@ export class TranslationSessionManager {
           telemetry.capture({ distinctId: sessionId, event, properties: { ...properties, sessionId } })
       : null;
 
+    const writesSourceTranscript = targetLanguage === TranslationSessionManager.DEFAULT_LANGUAGE;
+
+    // Which realtime backend can speak this language (Gemini for nearly everything,
+    // OpenAI for Haitian Creole). Resolved here, once, so the bridge never has to know
+    // there was a choice — and so an unserveable language fails loudly at start rather
+    // than quietly translating into nothing.
+    const provider = providerForLanguage({
+      language: targetLanguage,
+      keys: this.providerKeys(),
+      openaiLanguages: this.openaiLanguages,
+      transcribeInput: writesSourceTranscript,
+    });
+    if (!provider) {
+      throw new Error(
+        `No realtime provider configured that can translate into "${targetLanguage}"`
+      );
+    }
+
     const config = {
       geminiApiKey: process.env.GEMINI_API_KEY!,
+      provider,
       livekitUrl: this.livekitConfig?.url ?? process.env.LIVEKIT_URL ?? process.env.NEXT_PUBLIC_LIVEKIT_URL ?? "ws://localhost:7880",
       livekitApiKey: this.livekitConfig?.apiKey ?? process.env.LIVEKIT_API_KEY!,
       livekitApiSecret: this.livekitConfig?.apiSecret ?? process.env.LIVEKIT_API_SECRET!,
       writer,
-      writesSourceTranscript: targetLanguage === TranslationSessionManager.DEFAULT_LANGUAGE,
+      writesSourceTranscript,
       recordEvent,
       silenceThresholdDbfs: this.silenceThresholdDbfs,
     };
 
-    console.log(`[SessionManager] Creating new bridge for ${targetLanguage} in session ${sessionId}`);
+    console.log(
+      `[SessionManager] Creating new bridge for ${targetLanguage} in session ${sessionId} on ${provider.name}/${provider.model}`
+    );
 
     const MAX_START_ATTEMPTS = 3;
     let lastError: unknown;

--- a/server.ts
+++ b/server.ts
@@ -188,13 +188,19 @@ app.post('/api/ys-auth', async (req, res) => {
 
 
 // ---------------------------------------------------------------------------
-// Live speech-to-speech translation (Gemini Live + LiveKit)
+// Live speech-to-speech translation (LiveKit + a realtime translation provider)
 //
 // Self-contained, opt-in feature. If the LIVEKIT_* env vars are unset these
 // routes return 503 and the rest of the app is unaffected. The LiveKit room
 // name is the Y-Sweet doc id, so audio rooms line up 1:1 with outline sessions.
 // The speaker (editor) always joins as ORGANIZER_IDENTITY; per-language
 // translator bots subscribe to that identity.
+//
+// Each bot runs on whichever provider can speak its language: Gemini Live
+// Translate for nearly everything, OpenAI Realtime for Haitian Creole (which
+// Gemini cannot produce). That routing lives in
+// live-audio/provider-selection.ts; nothing here has to know about it beyond
+// providing the keys via the environment.
 // ---------------------------------------------------------------------------
 const ORGANIZER_IDENTITY = 'organizer-host';
 
@@ -207,7 +213,7 @@ function getLiveKitConfig(): { url: string; apiKey: string; apiSecret: string } 
 }
 
 // The cost path's only knob: the dBFS level below which the organizer's mic counts as
-// silence, at which point a bridge suspends its Gemini socket. Unset (the default)
+// silence, at which point a bridge suspends its provider socket. Unset (the default)
 // means bridges never suspend. The goaway/reconnect buffering is independent of this
 // and always on, as is the default translator — silence gating no longer decides
 // which bridges exist, only what an existing one does while nobody is speaking.
@@ -228,6 +234,13 @@ const SILENCE_THRESHOLD_DBFS = parseSilenceThresholdDbfs(process.env.LIVE_AUDIO_
       `[server] Live-audio silence gating (cost path): ${
         Number.isFinite(SILENCE_THRESHOLD_DBFS) ? `${SILENCE_THRESHOLD_DBFS} dBFS` : 'disabled'
       }`
+    );
+    // Which realtime backends this deployment can actually reach. Worth one line at
+    // boot: without OPENAI_API_KEY, a listener asking for Haitian Creole gets a bridge
+    // that refuses to start, and this is the log that explains why.
+    console.log(
+      `[server] Live-audio providers: Gemini ${process.env.GEMINI_API_KEY ? 'configured' : 'MISSING'}, ` +
+        `OpenAI ${process.env.OPENAI_API_KEY ? 'configured (Haitian Creole available)' : 'not configured (no Haitian Creole)'}`
     );
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,7 +94,8 @@ function HomePage() {
 
   // The listen pane is keyed by BCP-47 code (a larger set than our text-translation
   // languages). Map the selected language to its code, falling back to the default
-  // listen language if Gemini Live doesn't support it (e.g. Haitian Creole).
+  // listen language if no realtime provider can speak it. (Haitian Creole used to fall
+  // back here — it is now served by the OpenAI provider; see listenLanguages.ts.)
   const listenCode =
     LISTEN_LANGUAGE_CODES.includes(LANGUAGE_BCP47[selectedLang])
       ? LANGUAGE_BCP47[selectedLang]
@@ -222,9 +223,11 @@ function PagePart({ componentStr, onReplace }: { componentStr: string; onReplace
     </select>
   );
 
-  // The listen picker offers the full Gemini-supported language set (keyed by
-  // BCP-47 code), with "Original / English" and favorites pinned on top. Names are
-  // localized via Intl.DisplayNames; the long list is sorted by localized name.
+  // The listen picker offers every language some realtime provider can speak (keyed by
+  // BCP-47 code), with "Original / English" and favorites pinned on top. Which backend
+  // serves which language is listenLanguages.ts's business, not the picker's — so this
+  // list needs no change when a language moves between providers. Names are localized
+  // via Intl.DisplayNames; the long list is sorted by localized name.
   const sortedListenLangs = LISTEN_LANGUAGE_CODES
     .filter((c) => c !== LISTEN_ORIGINAL_CODE && !LISTEN_FAVORITES.includes(c))
     .sort((a, b) =>

--- a/src/listenLanguages.ts
+++ b/src/listenLanguages.ts
@@ -1,15 +1,22 @@
-// Languages supported by the Gemini Live Translate API, used by the "listen"
-// (live speech-to-speech) picker. This is a much larger set than the project's
-// curated text-translation languages (configAtoms.ts), so it lives separately.
+// Languages offered by the "listen" (live speech-to-speech) picker, and — because the
+// two are the same question — which realtime backend can actually produce each one.
+// This is a much larger set than the project's curated text-translation languages
+// (configAtoms.ts), so it lives separately.
 //
 // We store only BCP-47 codes here; display names are localized at render time via
 // `Intl.DisplayNames([locale])` (the pattern already used elsewhere in App.tsx),
 // so we don't hard-code English names or flags.
 //
-// Source: gemini-live-api-examples/.../lib/languages.ts (Haitian Creole is not in
-// that list — Gemini Live Translate doesn't support it — so it's absent here too).
+// This module is the single source of truth for the backend routing too: the server
+// imports these lists in live-audio/provider-selection.ts to decide which provider a
+// requested language gets. Keeping one list means the picker can never offer a language
+// no bridge can serve, and no bridge has to guess about a language the picker offers.
+// (Same reason transcriptKeys.ts is shared between the client and sessionExport.ts.)
+// Kept dependency-free so importing it from either side costs nothing.
 
-export const LISTEN_LANGUAGE_CODES: string[] = [
+// Languages the Gemini Live Translate API can output. Notably absent: Haitian Creole.
+// Source: gemini-live-api-examples/.../lib/languages.ts.
+export const GEMINI_LISTEN_LANGUAGE_CODES: string[] = [
   "af", "ak", "sq", "am", "ar", "hy", "as", "az", "eu", "be", "bn", "bs", "bg",
   "my", "yue", "ca", "ceb", "zh", "hr", "cs", "da", "nl", "en", "et", "fo", "fil",
   "fi", "fr", "gl", "ka", "de", "el", "gu", "ha", "iw", "hi", "hu", "is", "id",
@@ -20,9 +27,26 @@ export const LISTEN_LANGUAGE_CODES: string[] = [
   "uz", "vi", "cy", "fy", "wo", "yo", "zu",
 ];
 
-// Pinned to the top of the picker for quick access. (Gemini Live Translate does
-// not support Haitian Creole, so only French and Spanish are favorited.)
-export const LISTEN_FAVORITES: string[] = ["fr", "es"];
+// Languages served by the OpenAI Realtime provider instead, because Gemini Live
+// Translate has no voice for them at all.
+//
+// Only Haitian Creole is here, and it is the reason that provider exists. Note this is
+// *not* OpenAI's full capability list — OpenAI's own live-translation model can't output
+// Creole either, so this route goes through the general speech-to-speech model with an
+// interpreter prompt (see live-audio/openai-provider.ts). Adding a language here is a
+// claim that a prompted conversational model speaks it acceptably, which is worth
+// verifying by listening before you make it.
+export const OPENAI_LISTEN_LANGUAGE_CODES: string[] = ["ht"];
+
+/** Everything the picker offers, whichever backend ends up serving it. */
+export const LISTEN_LANGUAGE_CODES: string[] = [
+  ...GEMINI_LISTEN_LANGUAGE_CODES,
+  ...OPENAI_LISTEN_LANGUAGE_CODES.filter((c) => !GEMINI_LISTEN_LANGUAGE_CODES.includes(c)),
+];
+
+// Pinned to the top of the picker for quick access — the languages this project's
+// services actually run in.
+export const LISTEN_FAVORITES: string[] = ["fr", "ht", "es"];
 
 // "Original / English": play the speaker's raw audio and show the English source
 // transcript (produced for free via input transcription on the default bridge).

--- a/template-.env
+++ b/template-.env
@@ -9,11 +9,28 @@ ELEVENLABS_API_KEY=...
 # Used by /api/translateItem; the incremental notes path stays on the cheaper default model.
 # GEMINI_STRONG_MODEL=gemini-3.5-flash
 
-# Live speech-to-speech translation via Gemini Live + LiveKit (optional).
+# Live speech-to-speech translation via LiveKit + a realtime provider (optional).
 # When unset, the listen-{language} / broadcast panes are disabled but the app still runs.
 # LIVEKIT_URL=wss://your-project.livekit.cloud
 # LIVEKIT_API_KEY=...
 # LIVEKIT_API_SECRET=...
+
+# Live speech-to-speech for Haitian Creole (optional). Gemini Live Translate has no Creole
+# voice, so `ht` is served by OpenAI Realtime instead; without this key the listen picker
+# still offers Creole but its bridge refuses to start (logged at boot and on each attempt).
+# Every other language stays on Gemini either way.
+# OPENAI_API_KEY=...
+
+# Overrides for the OpenAI provider (optional). The default model is the general
+# speech-to-speech model prompted to interpret — NOT gpt-realtime-translate, whose 13
+# output languages exclude Creole. Set a model id here when a newer one ships.
+# LIVE_AUDIO_OPENAI_MODEL=gpt-realtime-2.1
+# LIVE_AUDIO_OPENAI_VOICE=marin
+
+# Route extra languages to OpenAI instead of Gemini, comma-separated BCP-47 codes. Only
+# needed to compare the two backends on a language both can serve; `ht` is routed by
+# capability and does not need listing.
+# LIVE_AUDIO_OPENAI_LANGUAGES=fr
 
 # Live-audio cost path (optional, default off). Set a dBFS level to make bridges suspend their
 # Gemini session after ~30s below it and reopen on speech; -30 is a guess, not a measured value.

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -27,6 +27,7 @@
     "slideLibrary.ts",
     "slideConversationStore.ts",
     "dump-docs.ts",
+    "creole-voice-spike.ts",
     "*.test.ts"
   ]
 }


### PR DESCRIPTION
Gemini Live Translate has no Haitian Creole voice, so `ht` has been absent from the listen picker. This adds a second realtime backend to serve it, without moving any language that already worked.

**Blast radius: §4 (live audio, including the new Haitian Creole block), §6.**

## The finding that shaped this

OpenAI ships a purpose-built live-translation model, `gpt-realtime-translate`. It is *not* usable here: it translates *from* 70+ languages into only **13**, and Haitian Creole is on the input list, not the output list. It cannot speak Creole. So this uses the general speech-to-speech model (the one behind ChatGPT's voice mode) with an interpreter prompt — which is what "ChatGPT voice can handle Haitian Creole" actually refers to.

That distinction has consequences, and they are documented in `openai-provider.ts`'s header rather than glossed:

- With Gemini's translate model, "only translate, never converse" is a **model property**. Here it is a **prompt**, so breaking character (answering a rhetorical question, adding a preamble) is possible.
- The conversational model is **turn-based**, not continuous. It's configured not to let new speech interrupt a translation in progress — otherwise a speaker at a podium would truncate nearly every translation by continuing to talk — which trades that truncation for growing lag behind a fast speaker.
- **Creole output quality is unverified by ear**, and cannot be verified by CI. `docs/SMOKE_TEST.md` §4 now has a listening block for it that wants a Creole speaker.

A rough Creole translation is worth much more than the nothing available today, so this ships — but the knobs (`LIVE_AUDIO_OPENAI_MODEL`, `LIVE_AUDIO_OPENAI_VOICE`) are env-overridable and the caveats are written down where the next person will find them.

## Changes

**A `RealtimeProvider` seam** (`realtime-provider.ts`). Six things are vendor-specific: where to connect, what to send to configure, how to read a message, how to wrap a PCM16 frame, the two sample rates, and which languages are possible. Everything else in `translation-bridge.ts` — make-before-break reconnect, the gap buffer, the epoch guard, subscription reconcile, the stall watchdog, silence gating — stays shared, so the new provider inherits the incident history in `docs/live-audio-resilience.md` instead of re-earning it.

**`gemini-provider.ts`** is a straight lift of the previous inline behavior: same model, same `setup`/`realtimeInput` messages, same 16 kHz in / 24 kHz out. Byte-identical on the wire.

**`openai-provider.ts`** speaks the GA Realtime protocol: `session.update` with interpreter instructions, PCM16 24 kHz both directions, `input_audio_buffer.append`, and `response.output_audio.delta` / `response.output_audio_transcript.delta` / `conversation.item.input_audio_transcription.delta`. It accepts both the GA and earlier beta spellings of the renamed events — guessing wrong there produces a bridge that connects, reports healthy, and plays silence, which is the exact failure this subsystem exists to prevent.

**Routing** (`provider-selection.ts`) is a pure function over (language, configured keys, operator override): overrides win, then Gemini keeps every language it supports, then OpenAI takes the languages we've decided it can carry. An unknown code resolves to *nothing* and fails bridge start loudly — rather than falling back to OpenAI and paying to translate into a language that doesn't exist. `src/listenLanguages.ts` holds the per-provider language lists for both the picker and the server, so the two cannot drift.

**Telemetry keeps its continuity.** Provider-leg event names are prefixed per provider, so Gemini bridges still emit exactly `gemini_session_closed` and every existing dashboard and saved insight is untouched; OpenAI gets a parallel series, and every event now carries `provider`/`model` so a query can span both. `health.gemini` becomes `health.provider` plus `health.providerName`.

## Testing

`347 passed`, lint and typecheck clean.

- The e2e fake socket now speaks **both** wire protocols, so every existing resilience test is provider-agnostic by construction. It reproduces OpenAI's `session.created`-before-`session.updated` handshake faithfully: a bridge that read the first as ready would stream the opening of a talk into an unconfigured chatbot, so there's a test that a session stuck at `created` never receives a frame and fails to start.
- New end-to-end coverage for the **output** leg, which nothing tested before: provider audio reaching a LiveKit track, and the transcript reaching Yjs under the Creole code rather than overwriting the English one.
- A test that each provider gets its own declared input sample rate from LiveKit — a mismatch there is not an error anywhere, just audio arriving at the wrong speed and pitch.
- New unit suites for both providers' setup/interpret and for the routing decision, including that adding a provider changed nothing for the languages Gemini already served.

## Deploying

Set `OPENAI_API_KEY`. Without it, the picker still offers Creole but its bridge refuses to start (logged at boot and per attempt) — Creole has no Gemini fallback by design, since silently substituting another language would be worse. Everything else is unchanged with or without the key.

---
_Generated by [Claude Code](https://claude.ai/code/session_012T9MYdGZW362uzgxF1F8rP)_