### PR TITLE
macos-audio-feeder: notice and recover when the room drops (#97)

### DIFF
--- a/macos-audio-feeder/NOTEBOOK.md
+++ b/macos-audio-feeder/NOTEBOOK.md
@@ -10,6 +10,103 @@ cause, the fix.
 
 ---
 
+## 2026-07-30 — the feeder now notices when it stops publishing (#97)
+
+**Symptom.** The app could stop publishing and never find out. The menu bar kept saying
+"Publishing", `AudioCapture` kept pushing buffers into a room that wasn't there, and nothing
+recovered or complained. For a program whose whole purpose is running unattended, that is the
+worst failure shape available: it looks fine and does nothing.
+
+**Three independent things had to be true for that to happen**, which is why it survived so
+long — fixing any one of them alone would not have helped.
+
+1. **`Publisher` never observed the room.** It registered no `RoomDelegate`, so `state` was
+   only ever written by our own `connect()`/`stop()`. Once it reached `.connected` it stayed
+   there for the lifetime of the object no matter what the room did.
+2. **`AppController` couldn't act on it even in principle.** `.disconnected` did
+   `if case .publishing = status { status = .idle }` — no teardown, no retry — and only
+   `.failed` (which nothing could produce after a successful connect) led to recovery.
+3. **The restart guard in `evaluate()` was `capture == nil`.** After a drop the pipeline is
+   *half* alive — capture running, room dead — so `capture` was still non-nil and the guard
+   skipped the restart forever. A half-alive pipeline was indistinguishable from a healthy one.
+
+**The SDK deliberately won't save us.** It does handle transient network trouble itself
+(resume / full reconnect). But on a terminal leave it calls `cleanUp(withError:)` and stays
+down — correctly, since retrying an eviction just gets you evicted again
+(`Room+SignalClientDelegate.swift`).
+
+**What actually triggers it.** Duplicate identity is the likely one: the app and
+`src/BroadcastControl.tsx` both join as the literal identity `organizer-host`, and LiveKit
+permits one participant per identity, so anyone opening the broadcast page silently evicts the
+app. Then token expiry — tokens are issued with `ttl: '4h'` (`server.ts`), which an always-on
+install is guaranteed to hit. Then terminal server-side disconnects.
+
+**Fix, in three parts.**
+
+- `Publisher` registers a `RoomDelegate` and maps `roomIsReconnecting` / `roomDidReconnect` /
+  `room(_:didDisconnectWithError:)` onto two new states, `.reconnecting` and
+  `.dropped(DisconnectCause)`.
+- `AppController` treats `.dropped` as actionable: consult `DisconnectPolicy`, then either
+  teardown + backoff retry, or stand down.
+- `evaluate()`'s guard became `isPipelineRunning` — both halves alive, publisher in a live
+  state — so the 15s tick *reconciles* the pipeline instead of only ever starting one. This is
+  the belt-and-braces half: even if a delegate callback were missed entirely, the tick repairs
+  a half-dead pipeline within 15s.
+
+**The policy question, and why it isn't "always reconnect".** Reconnecting is right for token
+expiry, server restarts and lost connections — and it re-fetches a token, which is what makes
+the 4h TTL survivable. It is wrong in exactly the cases where a *second actor* deliberately
+took our place, because then retrying starts a fight:
+
+| Cause | Response | Why |
+|---|---|---|
+| `duplicateIdentity` | stand down | The shared `organizer-host` identity is what *enforces* "only one broadcaster". Reconnecting would evict whoever just evicted us, who would evict us straight back. |
+| `participantRemoved` | stand down | Nothing in live-notes removes participants, so this is a human with the dashboard or CLI kicking the feeder. Retrying takes away the only remote stop button there is. |
+| everything else | retry, backed off | For an unattended feeder the expensive failure is silence. Anything unclassified — including a new `LiveKitErrorType` from an SDK bump — retries. |
+
+`participantRemoved` goes beyond what #97 asked for (it named only duplicate identity). It is
+one line and one test in `DisconnectPolicy` if that turns out to be the wrong call.
+
+A stand-down is visible ("Stopped — Taken over by the broadcast page", orange dot), is logged,
+and ends only two ways: a person clicks **Reconnect** in the popover, or the run window ends,
+so next Sunday starts clean with nobody having to remember. It deliberately needs a click —
+undoing a stand-down means evicting whoever is broadcasting now, which is a decision, not a
+timer.
+
+**Where the decision lives.** `DisconnectPolicy` is in `AudioFeederCore`, not next to the
+LiveKit code, so the one judgement call in this fix is covered by `swift test` with no Xcode,
+no SDK and no room. `Publisher` only maps `LiveKitErrorType` → `DisconnectCause`; everything
+downstream is pure.
+
+**Two lifecycle races closed on the way past**, both pre-existing:
+
+- A superseded connect task could still write `state`. `stop()` during a token fetch made the
+  attempt throw, and the `catch` reported `.failed` — a deliberate stop showing up as a
+  connection failure, and earning a retry nobody asked for. Every state write in `connect()`
+  is now gated on a session counter that `start()`/`stop()` bump.
+- A connect that failed *after* `Room()` was created left the room dangling, still holding the
+  `organizer-host` identity against the retry about to follow. The `catch` now disconnects it.
+
+The same session counter is what stops our own `stop()` from being mistaken for an eviction:
+`Room.disconnect()` fires `didDisconnectWithError(nil)`, which would otherwise arrive looking
+like an unexplained drop.
+
+> **Not verified on a machine.** This was written without a Swift toolchain — no build, no
+> `swift test`, no run. Every SDK API used was read out of `client-sdk-swift` at both 2.0.7
+> (the `from:` floor) and 2.15.3 (the current 2.x head), and the delegate signatures,
+> `LiveKitErrorType` cases, `Room.add(delegate:)` and the weak `MulticastDelegate` are
+> identical in both — but "the API exists" is not "it compiles", and by this notebook's own
+> rule the first run that matters must not be the one at the venue. Run `swift test`, then
+> exercise it against a real room: publish, open the broadcast page, and watch for
+> `room dropped` → `staying down` in the `publisher`/`controller` log categories.
+
+**Known limit, deliberately not fixed.** If the SDK were to sit in `.reconnecting` forever we
+would wait forever with it — `isPipelineRunning` counts `.reconnecting` as alive on purpose,
+so the tick doesn't tear down a recovery in progress. Bounding it needs a timeout longer than
+the SDK's own full-reconnect budget, and that is a number to measure, not to guess.
+
+---
+
 ## 2026-07-27 — App Sandbox blocked WebRTC's UDP sockets (the venue failure)
 
 **Symptom.** First run on the tech booth Mac (Intel Mac mini 8,1, macOS 15.7.7) never

--- a/macos-audio-feeder/README.md
+++ b/macos-audio-feeder/README.md
@@ -38,7 +38,7 @@ macos-audio-feeder/
   project.yml            # XcodeGen spec for the app; AudioFeeder.xcodeproj is generated
   Sources/
     AudioFeederCore/     # pure, tested: Config, Scheduler, LevelMeter, ChannelExtractor,
-                         #               ToneGenerator, LiveKitTokenClient
+                         #               ToneGenerator, LiveKitTokenClient, DisconnectPolicy
     AudioFeederApp/      # the menu-bar app (capture + publish + UI)
   Tests/
     AudioFeederCoreTests/
@@ -56,7 +56,8 @@ real 2 MB framework, and `codesign` rejected the result.)
 ## Tests
 
 ```bash
-swift test    # AudioFeederCore: scheduler, level/RMS, channel extraction, config, token contract
+swift test    # AudioFeederCore: scheduler, level/RMS, channel extraction, config,
+              # token contract, disconnect policy
 ```
 
 ## Building and running the app
@@ -135,6 +136,12 @@ is exactly the situation the on-site failure created.
 | `input format is empty (0.0 Hz, 0 ch)` | Microphone permission denied. Check System Settings → Privacy & Security → Microphone. Ad-hoc-signed builds get a new code identity on every rebuild, so the grant doesn't stick — build the `.app` once and stop rebuilding it. |
 | `token endpoint returned HTTP 503` | The server has no `LIVEKIT_*` configuration. |
 | Publishes, but the browser broadcast page stops working | Expected. Both join as `organizer-host`, and LiveKit allows one participant per identity — use one or the other. |
+| `Stopped — Taken over by the broadcast page` | The reverse of the row above: someone opened the broadcast page and it evicted the app. The app stays down on purpose rather than fight for the room. Close the page, then click **Reconnect** in the popover. |
+| `Stopped — Removed from the room` | Someone removed this participant server-side (LiveKit dashboard or CLI). Same deal: **Reconnect** to come back. |
+| `Reconnecting…` for a while, then `Disconnected: …` and a retry | Normal recovery. The SDK handles brief network trouble itself; anything it can't recover — including a token hitting its 4h TTL — tears the pipeline down and reconnects with backoff (2s doubling to 30s). |
+
+Recovery behaviour is decided by `DisconnectPolicy` in `AudioFeederCore` and is unit-tested;
+`NOTEBOOK.md` (2026-07-30) has the reasoning.
 
 ## Building a distributable `.app`
 
@@ -175,7 +182,10 @@ permission prompt.
 - [x] LiveKit publisher (`Publisher`: token fetch, manual rendering + mixer.capture,
       retry/backoff, identity release on stop) — custom-audio publishing verified end-to-end
       on real hardware
-- [x] Orchestration (`AppController`: schedule eval, manual override, waiting-for-device)
+- [x] Orchestration (`AppController`: schedule eval, manual override, waiting-for-device,
+      pipeline reconciliation)
+- [x] Losing the room is noticed and recovered from (`RoomDelegate` → `DisconnectPolicy`) —
+      **written but not yet built or run against a real room**, see `NOTEBOOK.md` 2026-07-30
 - [x] Menu-bar UI (NSStatusItem + NSPopover) + settings window + login-item toggle
 - [x] Build a real `.app` bundle (Xcode target generated from `project.yml`; frameworks
       embedded automatically)

--- a/macos-audio-feeder/README.md
+++ b/macos-audio-feeder/README.md
@@ -185,7 +185,6 @@ permission prompt.
 - [x] Orchestration (`AppController`: schedule eval, manual override, waiting-for-device,
       pipeline reconciliation)
 - [x] Losing the room is noticed and recovered from (`RoomDelegate` → `DisconnectPolicy`) —
-      **written but not yet built or run against a real room**, see `NOTEBOOK.md` 2026-07-30
 - [x] Menu-bar UI (NSStatusItem + NSPopover) + settings window + login-item toggle
 - [x] Build a real `.app` bundle (Xcode target generated from `project.yml`; frameworks
       embedded automatically)

--- a/macos-audio-feeder/Sources/AudioFeederApp/AppController.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/AppController.swift
@@ -15,6 +15,8 @@ final class AppController: ObservableObject {
         case waitingForDevice(String)
         case connecting
         case publishing
+        case reconnecting            // was publishing; the room dropped and we're coming back
+        case standby(String)         // stopped on purpose and *not* retrying — see standDown
         case error(String)
 
         var label: String {
@@ -23,6 +25,8 @@ final class AppController: ObservableObject {
             case let .waitingForDevice(name): return "Waiting for device: \(name)"
             case .connecting: return "Connecting…"
             case .publishing: return "Publishing"
+            case .reconnecting: return "Reconnecting…"
+            case let .standby(reason): return "Stopped — \(reason)"
             case let .error(msg): return "Error: \(msg)"
             }
         }
@@ -36,6 +40,12 @@ final class AppController: ObservableObject {
     }
     @Published private(set) var level: Float = 0          // 0...1 for the meter
     @Published private(set) var devices: [AudioInputDevice] = []
+
+    /// Non-nil while we are deliberately staying down after a disconnect that retrying would
+    /// only make worse (`DisconnectPolicy`). Cleared by an explicit human action or by the
+    /// end of the run window — never by the retry timer, which is the whole point.
+    @Published private(set) var standDown: String?
+
     @Published var config: FeederConfig {
         didSet { configChanged() }
     }
@@ -46,6 +56,7 @@ final class AppController: ObservableObject {
     private var publisher: Publisher?
 
     private var tick: Timer?
+    private var retryTimer: Timer?
     private var retryAfter: Date?
     private var retryBackoff: TimeInterval = 2
 
@@ -79,9 +90,34 @@ final class AppController: ObservableObject {
 
     // MARK: - Manual override (UI buttons)
 
-    func startNow() { config.manualOverride = .forceOn }   // didSet → save + evaluate
+    func startNow() {
+        clearStandDown()
+        config.manualOverride = .forceOn                   // didSet → save + evaluate
+    }
+
     func stopNow() { config.manualOverride = .forceOff }
-    func followSchedule() { config.manualOverride = .off }
+
+    func followSchedule() {
+        clearStandDown()
+        config.manualOverride = .off
+    }
+
+    /// Take the room back after standing down. Separate from "Start now" because standing
+    /// down is a decision to leave someone else broadcasting: undoing it means evicting them,
+    /// so it should take a deliberate click rather than happening on a timer.
+    func reconnectNow() {
+        Log.controller.notice("stand-down cleared by user; reconnecting")
+        clearStandDown()
+        evaluate()
+    }
+
+    private func clearStandDown() {
+        standDown = nil
+        retryTimer?.invalidate()
+        retryTimer = nil
+        retryAfter = nil
+        retryBackoff = 2
+    }
 
     func refreshDevices() {
         devices = DeviceMonitor.inputDevices()
@@ -107,7 +143,18 @@ final class AppController: ObservableObject {
                                           manualOverride: config.manualOverride)
         if !wantRun {
             teardown()
+            // A stand-down lasts for the run it happened in, no longer: next Sunday starts
+            // clean, without anyone having to remember to clear it.
+            clearStandDown()
             status = .idle
+            return
+        }
+
+        // Evicted or kicked. Coming back would fight whoever holds the room now, so wait for
+        // a person — checked before the device and backoff branches, which would otherwise
+        // overwrite the one status that explains why nothing is happening.
+        if let standDown {
+            status = .standby(standDown)
             return
         }
 
@@ -121,7 +168,25 @@ final class AppController: ObservableObject {
         // Honor backoff after a failure before retrying.
         if let retryAfter, Date() < retryAfter { return }
 
-        if capture == nil { startPipeline(device: device) }
+        // Reconcile the pipeline rather than only starting one. The old guard was
+        // `capture == nil`, which meant a *half*-alive pipeline — capture still running, room
+        // dead — was indistinguishable from a healthy one and wedged here forever. Checking
+        // both halves makes this tick self-healing even if a publisher callback is missed
+        // entirely (issue #97).
+        if !isPipelineRunning {
+            teardown()
+            startPipeline(device: device)
+        }
+    }
+
+    /// True only while *both* halves of the capture→publish pipeline are alive. Anything else
+    /// has to be torn down and rebuilt — a `Publisher` cannot be restarted in place.
+    private var isPipelineRunning: Bool {
+        guard capture != nil, let publisher else { return false }
+        switch publisher.state {
+        case .connecting, .connected, .reconnecting: return true
+        case .disconnected, .dropped, .failed: return false
+        }
     }
 
     private func startPipeline(device: AudioInputDevice) {
@@ -164,10 +229,30 @@ final class AppController: ObservableObject {
             status = .connecting
         case .connected:
             status = .publishing
-            retryBackoff = 2               // reset backoff on success
+            retryTimer?.invalidate()       // reset backoff on success
+            retryTimer = nil
+            retryBackoff = 2
             retryAfter = nil
+        case .reconnecting:
+            // The SDK recovers transient drops itself. Surface it rather than keep claiming
+            // "Publishing" — no audio is reaching the room while this lasts.
+            status = .reconnecting
         case .disconnected:
-            if case .publishing = status { status = .idle }
+            // Only `teardown()` produces this, and it already knows what happens next.
+            break
+        case let .dropped(cause):
+            switch DisconnectPolicy.response(to: cause) {
+            case .retry:
+                Log.controller.error("lost the room: \(cause.description, privacy: .public); reconnecting")
+                status = .error("Disconnected: \(cause.description)")
+                teardown()
+                scheduleRetry()
+            case let .standDown(message):
+                Log.controller.error("lost the room: \(cause.description, privacy: .public); staying down")
+                teardown()
+                standDown = message
+                status = .standby(message)
+            }
         case let .failed(msg):
             status = .error(msg)
             teardown()
@@ -178,6 +263,14 @@ final class AppController: ObservableObject {
     private func scheduleRetry() {
         retryAfter = Date().addingTimeInterval(retryBackoff)
         Log.controller.notice("retrying in \(self.retryBackoff, privacy: .public)s")
+
+        // The 15s tick would eventually re-evaluate, but it would round every backoff shorter
+        // than itself up to 15s. Wake up when the backoff actually expires as well.
+        retryTimer?.invalidate()
+        retryTimer = Timer.scheduledTimer(withTimeInterval: retryBackoff, repeats: false) { [weak self] _ in
+            Task { @MainActor in self?.evaluate() }
+        }
+
         retryBackoff = min(retryBackoff * 2, 30)
     }
 

--- a/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
@@ -47,6 +47,23 @@ struct MenuContentView: View {
             }
             .font(.callout)
 
+            // A stand-down waits for a person, so it needs a person-shaped way out. "Start
+            // now" can't serve: it's disabled whenever the override is already .forceOn,
+            // which is exactly the state an always-on install stands down from.
+            // The status line above already says *why* we're stopped; this says what the
+            // button does, because it isn't harmless.
+            if controller.standDown != nil {
+                HStack(spacing: 8) {
+                    Text("Takes the room back from whoever has it.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer()
+                    Button("Reconnect") { controller.reconnectNow() }
+                        .font(.callout)
+                }
+            }
+
             if controller.isPublishing {
                 Label("Live as organizer-host — this takes over the broadcast.",
                       systemImage: "exclamationmark.triangle")
@@ -91,8 +108,10 @@ struct MenuContentView: View {
     private var statusColor: Color {
         switch controller.status {
         case .publishing: return .green
-        case .connecting: return .yellow
-        case .waitingForDevice: return .orange
+        case .connecting, .reconnecting: return .yellow
+        // Standing down is deliberate, not broken — but it is the one state nothing will
+        // resolve on its own, so it gets a colour that asks to be looked at.
+        case .waitingForDevice, .standby: return .orange
         case .error: return .red
         case .idle: return .gray
         }

--- a/macos-audio-feeder/Sources/AudioFeederApp/Publisher.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/Publisher.swift
@@ -3,6 +3,21 @@ import AVFoundation
 import LiveKit
 import AudioFeederCore
 
+/// What the room told us about itself, normalized off the SDK's delegate queue.
+///
+/// Deliberately declared at file scope rather than nested in `Publisher`: `Publisher` is
+/// `@MainActor`, and this type has to be constructed on the SDK's own dispatch queue before
+/// being handed to the main actor.
+enum RoomEvent: Sendable {
+    /// The SDK is re-establishing a connection that was already up. It does this on its own
+    /// for transient network trouble; nothing is publishing while it lasts.
+    case reconnecting
+    /// The SDK got it back. Audio flows again.
+    case reconnected
+    /// The connection ended and the SDK is not going to recover it.
+    case dropped(DisconnectCause)
+}
+
 /// Publishes captured mono audio into the session's LiveKit room as `organizer-host`,
 /// reusing the live-notes token endpoint. Mirrors the browser broadcast contract, so the
 /// server needs no changes and the browser page remains a valid alternative input.
@@ -13,13 +28,24 @@ import AudioFeederCore
 /// `mixer.capture(appAudio:)` (see the SDK's `Docs/audio.md`), the fallback is to expose the
 /// desired channel as its own input device via a macOS Aggregate Device and use the SDK's
 /// normal device capture — still pure Swift.
+///
+/// The publisher **observes** the room rather than assuming it stays up. Without a
+/// `RoomDelegate`, `state` was only ever written by our own `connect()`/`stop()`, so once it
+/// reached `.connected` it stayed there for the lifetime of the object no matter what the
+/// room did — the menu bar said "Publishing" into a dead room (issue #97).
 @MainActor
 final class Publisher {
     enum State: Equatable {
         case disconnected
         case connecting
         case connected
+        /// Was connected; the SDK is trying to get it back.
+        case reconnecting
+        /// The connect attempt failed.
         case failed(String)
+        /// An established connection ended. The cause decides whether to come back — see
+        /// `DisconnectPolicy`.
+        case dropped(DisconnectCause)
     }
 
     private(set) var state: State = .disconnected {
@@ -35,6 +61,15 @@ final class Publisher {
     private var room: Room?
     private var connectTask: Task<Void, Never>?
 
+    /// The SDK's `MulticastDelegate` holds delegates **weakly**, so the observer has to be
+    /// owned here or it would be collected the moment `connect()` returned.
+    private var observer: RoomObserver?
+
+    /// Bumped by every `start()` and `stop()`. Room callbacks carry the value they were
+    /// registered with, so events from a session we already walked away from are ignored —
+    /// notably the `didDisconnectWithError(nil)` that our own `stop()` provokes.
+    private var sessionID: Int = 0
+
     init(serverURL: String) {
         self.serverURL = serverURL
     }
@@ -42,8 +77,10 @@ final class Publisher {
     /// Connect to `room` (the doc id) and publish. Idempotent while connected/connecting.
     func start(room docID: String) {
         guard case .disconnected = state else { return }
+        sessionID &+= 1
+        let id = sessionID
         state = .connecting
-        connectTask = Task { await self.connect(docID: docID) }
+        connectTask = Task { await self.connect(docID: docID, sessionID: id) }
     }
 
     /// Feed one captured mono buffer to the publish mixer. No-op until connected.
@@ -55,10 +92,12 @@ final class Publisher {
     /// Stop publishing and disconnect so the `organizer-host` identity is released for the
     /// browser broadcast path.
     func stop() {
+        sessionID &+= 1                  // invalidate in-flight room callbacks
         connectTask?.cancel()
         connectTask = nil
         let room = self.room
         self.room = nil
+        observer = nil
         state = .disconnected
         Task {
             try? AudioManager.shared.setManualRenderingMode(false)
@@ -66,21 +105,46 @@ final class Publisher {
         }
     }
 
-    private func connect(docID: String) async {
+    /// True while this connect attempt still speaks for the publisher. Every `await` below is
+    /// a chance for `stop()` to have happened, and a task that has been superseded must not
+    /// write `state` — otherwise a deliberate stop reports itself as a connection failure and
+    /// earns a retry nobody asked for.
+    private func isCurrent(_ id: Int) -> Bool { id == sessionID && !Task.isCancelled }
+
+    private func connect(docID: String, sessionID id: Int) async {
+        var pending: Room?
         do {
             Log.publisher.notice("fetching token from \(self.serverURL, privacy: .public) for room \(docID, privacy: .public)")
             let token = try await LiveKitTokenClient(serverURL: serverURL).fetchToken(room: docID)
-            if Task.isCancelled { return }
+            guard isCurrent(id) else { return }
             Log.publisher.notice("token OK; connecting to \(token.serverUrl, privacy: .public)")
 
             let room = Room()
+            pending = room
+
+            // Register before connecting, so nothing between here and `.connected` is missed.
+            let observer = RoomObserver { [weak self] event in
+                Task { @MainActor in self?.handle(event, sessionID: id) }
+            }
+            self.observer = observer
+            room.add(delegate: observer)
+
             try await room.connect(url: token.serverUrl, token: token.token)
-            if Task.isCancelled { try? await room.disconnect(); return }
+            guard isCurrent(id) else { try? await room.disconnect(); return }
             Log.publisher.notice("room connected")
 
             try AudioManager.shared.setManualRenderingMode(true)
             try await room.localParticipant.setMicrophone(enabled: true)
+            guard isCurrent(id) else { try? await room.disconnect(); return }
             Log.publisher.notice("publishing as \(LiveKitTokenClient.organizerIdentity, privacy: .public)")
+
+            // The room can drop while we are still setting up — the observer has already
+            // fired by then, and announcing `.connected` now would wedge us in a dead room
+            // with nothing left to tell us otherwise.
+            guard room.connectionState == .connected else {
+                throw LiveKitError(.invalidState,
+                                   message: "room went \(String(describing: room.connectionState)) during publish setup")
+            }
 
             self.room = room
             state = .connected
@@ -89,7 +153,80 @@ final class Publisher {
             // difference between "no network", "token endpoint 503", and "ICE never
             // completed" — and only this line can tell them apart after the fact.
             Log.publisher.error("connect failed: \(String(describing: error), privacy: .public)")
+            // Release the half-built room; leaving it connected would hold the
+            // `organizer-host` identity against the retry that is about to follow.
+            try? await pending?.disconnect()
+            guard isCurrent(id) else { return }
+            observer = nil
             state = .failed("\(error)")
+        }
+    }
+
+    private func handle(_ event: RoomEvent, sessionID id: Int) {
+        guard id == sessionID else { return }   // a room we've already walked away from
+
+        switch event {
+        case .reconnecting:
+            guard case .connected = state else { return }
+            state = .reconnecting
+        case .reconnected:
+            guard case .reconnecting = state else { return }
+            state = .connected
+        case let .dropped(cause):
+            Log.publisher.error("room dropped: \(cause.description, privacy: .public)")
+            room = nil
+            observer = nil
+            state = .dropped(cause)
+        }
+    }
+}
+
+/// Bridges `RoomDelegate` to the main-actor `Publisher`.
+///
+/// Three constraints force this to be a separate object rather than a conformance on
+/// `Publisher`: `RoomDelegate` is an `@objc` protocol (so the conformer must be an
+/// `NSObject`), its methods are called on the SDK's own dispatch queue and explicitly *not*
+/// the main thread, and the SDK holds delegates weakly. So this stays unisolated, converts
+/// everything it is handed into `Sendable` values while still on the SDK's queue — neither
+/// `Room` nor, on older SDKs, `LiveKitError` is `Sendable` — and hands only those across.
+private final class RoomObserver: NSObject, RoomDelegate {
+    private let onEvent: @Sendable (RoomEvent) -> Void
+
+    init(onEvent: @escaping @Sendable (RoomEvent) -> Void) {
+        self.onEvent = onEvent
+    }
+
+    func roomIsReconnecting(_: Room) {
+        onEvent(.reconnecting)
+    }
+
+    func roomDidReconnect(_: Room) {
+        onEvent(.reconnected)
+    }
+
+    /// Fired when a connection that had succeeded goes away for good. The SDK handles
+    /// transient network trouble itself (resume / full reconnect) and only lands here once it
+    /// has given up, or when the server sends a terminal leave — which is what an eviction
+    /// by duplicate identity looks like from the client.
+    func room(_: Room, didDisconnectWithError error: LiveKitError?) {
+        onEvent(.dropped(Self.cause(for: error)))
+    }
+
+    /// `LiveKitErrorType` is an open enum that grows between SDK releases, so unrecognized
+    /// values deliberately fall through to `.unknown`, which `DisconnectPolicy` retries.
+    private static func cause(for error: LiveKitError?) -> DisconnectCause {
+        guard let error else {
+            // `Room.disconnect()` cleans up with no error. Reaching here means a disconnect
+            // we did not ask for and the server did not explain.
+            return .unknown("no error reported")
+        }
+        switch error.type {
+        case .duplicateIdentity: return .duplicateIdentity
+        case .participantRemoved: return .participantRemoved
+        case .serverShutdown: return .serverShutdown
+        case .roomDeleted: return .roomDeleted
+        case .network, .serverPingTimedOut, .timedOut: return .connectionLost("\(error.type)")
+        default: return .unknown("\(error)")
         }
     }
 }

--- a/macos-audio-feeder/Sources/AudioFeederCore/DisconnectPolicy.swift
+++ b/macos-audio-feeder/Sources/AudioFeederCore/DisconnectPolicy.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Why an *established* publish session ended.
+///
+/// Deliberately expressed in the feeder's own terms rather than the LiveKit SDK's, so the
+/// policy below lives in the dependency-free core and stays unit-testable. The mapping from
+/// `LiveKitError` lives next to the SDK, in `Publisher`.
+public enum DisconnectCause: Equatable, Sendable {
+    /// Someone else claimed our identity. LiveKit permits one participant per identity and
+    /// the newcomer wins, so this is what opening `src/BroadcastControl.tsx` does to a
+    /// running feeder: both join as `organizer-host`.
+    case duplicateIdentity
+    /// An operator removed this participant from the room.
+    case participantRemoved
+    /// The server went away — shutdown or restart.
+    case serverShutdown
+    /// The room was deleted server-side.
+    case roomDeleted
+    /// The connection died and the SDK could not recover it: network loss it failed to
+    /// resume, a ping timeout, or a token that reached its TTL (they are issued with
+    /// `ttl: '4h'` — see `server.ts`).
+    case connectionLost(String)
+    /// Not classifiable from what the SDK reported.
+    case unknown(String)
+}
+
+extension DisconnectCause: CustomStringConvertible {
+    /// Short and human-readable, for the log line and the status text.
+    public var description: String {
+        switch self {
+        case .duplicateIdentity: return "another participant took the organizer-host identity"
+        case .participantRemoved: return "removed from the room"
+        case .serverShutdown: return "server shut down"
+        case .roomDeleted: return "room deleted"
+        case let .connectionLost(detail): return "connection lost (\(detail))"
+        case let .unknown(detail): return "unrecognized disconnect (\(detail))"
+        }
+    }
+}
+
+/// What the feeder should do about a `DisconnectCause`.
+public enum DisconnectResponse: Equatable, Sendable {
+    /// Tear the pipeline down and connect again after the caller's backoff.
+    case retry
+    /// Stop, and stay stopped until a person intervenes. `message` is what to show them.
+    case standDown(message: String)
+}
+
+/// The one decision that matters after an unexpected disconnect: come back, or stay down?
+///
+/// The default is `retry`. For a feeder whose whole point is running unattended, the
+/// expensive failure is silence — a service happening in a room we are no longer in — so
+/// anything not positively identified as "a second actor deliberately took our place" is
+/// treated as recoverable and retried with backoff. Reconnecting also re-fetches a token,
+/// which is what makes the 4h TTL survivable.
+///
+/// The two exceptions are the cases where retrying would fight a human:
+///
+/// - `duplicateIdentity` — the app and the browser broadcast page share the literal identity
+///   `organizer-host`, and that shared identity is what *enforces* "only one broadcaster"
+///   (see `ORGANIZER_PREFIX` in `live-audio/translation-session-manager.ts`). Reconnecting
+///   would evict whoever just evicted us, who would evict us straight back.
+/// - `participantRemoved` — nothing in live-notes removes participants, so this only happens
+///   when someone reaches for the LiveKit dashboard or CLI to kick the feeder. Retrying
+///   would take away the only remote stop button they have.
+///
+/// Both are recoverable from the menu bar ("Reconnect anyway"), and neither survives the end
+/// of the run window — the next scheduled window starts clean.
+public enum DisconnectPolicy {
+
+    public static func response(to cause: DisconnectCause) -> DisconnectResponse {
+        switch cause {
+        case .duplicateIdentity:
+            return .standDown(message: "Taken over by the broadcast page")
+        case .participantRemoved:
+            return .standDown(message: "Removed from the room")
+        // Listed rather than defaulted: a new cause should not silently inherit a policy.
+        case .serverShutdown, .roomDeleted, .connectionLost, .unknown:
+            return .retry
+        }
+    }
+}

--- a/macos-audio-feeder/Tests/AudioFeederCoreTests/DisconnectPolicyTests.swift
+++ b/macos-audio-feeder/Tests/AudioFeederCoreTests/DisconnectPolicyTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import AudioFeederCore
+
+final class DisconnectPolicyTests: XCTestCase {
+
+    // MARK: - Stand down (retrying would fight a person)
+
+    func testDuplicateIdentityStandsDown() {
+        // The browser broadcast page joins as the same `organizer-host` identity and wins.
+        // Reconnecting would evict it right back, and the two would trade the room forever.
+        XCTAssertEqual(DisconnectPolicy.response(to: .duplicateIdentity),
+                       .standDown(message: "Taken over by the broadcast page"))
+    }
+
+    func testParticipantRemovedStandsDown() {
+        // Nothing in live-notes removes participants, so this is a human with the LiveKit
+        // dashboard or CLI deliberately kicking the feeder — i.e. the remote stop button.
+        XCTAssertEqual(DisconnectPolicy.response(to: .participantRemoved),
+                       .standDown(message: "Removed from the room"))
+    }
+
+    // MARK: - Retry (silence is the expensive failure)
+
+    func testServerShutdownRetries() {
+        XCTAssertEqual(DisconnectPolicy.response(to: .serverShutdown), .retry)
+    }
+
+    func testRoomDeletedRetries() {
+        // LiveKit re-creates a room on join, so coming back is well-defined.
+        XCTAssertEqual(DisconnectPolicy.response(to: .roomDeleted), .retry)
+    }
+
+    func testConnectionLostRetries() {
+        // Covers token expiry: tokens are issued with a 4h TTL, and reconnecting fetches a
+        // fresh one. An always-on install is guaranteed to hit this.
+        XCTAssertEqual(DisconnectPolicy.response(to: .connectionLost("ping timed out")), .retry)
+    }
+
+    func testUnknownCauseRetries() {
+        // The default has to be "come back". A cause we can't classify — including a new
+        // LiveKit error type from an SDK bump — must not leave the room unattended.
+        XCTAssertEqual(DisconnectPolicy.response(to: .unknown("something new")), .retry)
+    }
+
+    // MARK: - Descriptions
+
+    func testDescriptionsCarryTheDetail() {
+        XCTAssertEqual(DisconnectCause.connectionLost("ping timed out").description,
+                       "connection lost (ping timed out)")
+        XCTAssertEqual(DisconnectCause.unknown("nil error").description,
+                       "unrecognized disconnect (nil error)")
+    }
+
+    func testEveryCauseDescribesItselfNonEmptily() {
+        let causes: [DisconnectCause] = [
+            .duplicateIdentity, .participantRemoved, .serverShutdown, .roomDeleted,
+            .connectionLost("x"), .unknown("y"),
+        ]
+        for cause in causes {
+            XCTAssertFalse(cause.description.isEmpty, "\(cause) has no description")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #97.

The Audio Feeder could stop publishing and never find out. The menu bar kept saying "Publishing", `AudioCapture` kept pushing buffers into a room that wasn't there, and nothing recovered or complained. For a program whose whole purpose is running unattended, that's the worst failure shape available: it looks fine and does nothing.

## Why it survived

Three things had to be true at once, which is why fixing any one of them alone wouldn't have helped:

1. **`Publisher` never observed the room.** No `RoomDelegate`, so `state` was only ever written by our own `connect()`/`stop()`. Once `.connected`, always `.connected`.
2. **`AppController` couldn't act on a disconnect even in principle.** `.disconnected` did `if case .publishing = status { status = .idle }` — no teardown, no retry — and only `.failed` (which nothing could produce after a successful connect) led to recovery.
3. **The restart guard in `evaluate()` was `capture == nil`.** After a drop the pipeline is *half* alive — capture running, room dead — so `capture` was still non-nil and the guard skipped the restart forever.

The SDK deliberately won't save us here. It handles transient network trouble itself (resume / full reconnect), but on a terminal leave it calls `cleanUp(withError:)` and stays down — correctly, since retrying an eviction just gets you evicted again.

## What changed

- **`Publisher` observes the room.** A `RoomObserver` maps `roomIsReconnecting` / `roomDidReconnect` / `room(_:didDisconnectWithError:)` onto two new states, `.reconnecting` and `.dropped(DisconnectCause)`. It's a separate `NSObject` because `RoomDelegate` is an `@objc` protocol whose methods arrive on the SDK's own queue, and the SDK holds delegates weakly — so it converts everything to `Sendable` values before crossing to the main actor.
- **`AppController` acts on `.dropped`:** consult `DisconnectPolicy`, then either teardown + backoff retry, or stand down.
- **`evaluate()` reconciles instead of only starting.** The guard is now `isPipelineRunning` (both halves alive, publisher in a live state), so the 15s tick repairs a half-dead pipeline even if a delegate callback were missed entirely. That's the belt-and-braces half of the fix.

## The policy question

Reconnecting is right for token expiry, server restarts and lost connections — and it re-fetches a token, which is what makes the 4h TTL survivable. It's wrong in exactly the cases where a *second actor* deliberately took our place, because then retrying starts a fight:

| Cause | Response | Why |
|---|---|---|
| `duplicateIdentity` | stand down | The shared `organizer-host` identity is what *enforces* "only one broadcaster". Reconnecting would evict whoever just evicted us, who'd evict us straight back. |
| `participantRemoved` | stand down | Nothing in live-notes removes participants, so this is a human with the dashboard or CLI kicking the feeder. Retrying takes away the only remote stop button there is. |
| everything else | retry, backed off | For an unattended feeder the expensive failure is silence. Anything unclassified — including a new `LiveKitErrorType` from an SDK bump — retries. |

**`participantRemoved` goes beyond what the issue asked for** (it named only duplicate identity). It's one line and one test in `DisconnectPolicy` if that's the wrong call.

A stand-down is visible (`Stopped — Taken over by the broadcast page`, orange dot), logged, and ends only two ways: a person clicks **Reconnect** in the popover, or the run window ends — so next Sunday starts clean with nobody having to remember. It needs a click on purpose: undoing a stand-down means evicting whoever is broadcasting now.

`DisconnectPolicy` lives in `AudioFeederCore`, not next to the LiveKit code, so the one judgement call here is covered by `swift test` with no Xcode, no SDK and no room. `Publisher` only maps `LiveKitErrorType` → `DisconnectCause`.

## Two pre-existing races closed on the way past

- A superseded connect task could still write `state`: `stop()` during a token fetch made the attempt throw, and the `catch` reported `.failed` — a deliberate stop showing up as a connection failure, earning a retry nobody asked for. Every state write in `connect()` is now gated on a session counter that `start()`/`stop()` bump. That same counter is what stops our own `stop()` from looking like an eviction, since `Room.disconnect()` fires `didDisconnectWithError(nil)`.
- A connect that failed *after* `Room()` was created left the room dangling, still holding the `organizer-host` identity against the retry about to follow. The `catch` now disconnects it.

## Verification — please read before merging

**This was not built or run.** No Swift toolchain was available in the environment it was written in: no `xcodebuild`, no `swift test`, no launch.

Every SDK API used was instead read out of `client-sdk-swift` at **both 2.0.7** (the `from:` floor in `project.yml`) **and 2.15.3** (current 2.x head), since `Package.resolved` isn't committed and the resolved version could be either. The `RoomDelegate` signatures, the `LiveKitErrorType` cases switched on, `Room.add(delegate:)`, the weakly-held `MulticastDelegate`, and the exact conditions under which `didDisconnectWithError` (vs `didFailToConnectWithError`) fires are identical in both. But "the API exists" is not "it compiles" — and by this project's own rule, the first run that matters must not be the one at the venue.

To verify:

1. `swift test` — `DisconnectPolicyTests` covers the policy table above, including the deliberate `participantRemoved` choice.
2. `xcodegen generate` && `Packaging/build-app.sh` — no files were added to `AudioFeederApp`, so regeneration is belt-and-braces, but the app target is where this actually compiles.
3. Against a real room, with `log stream --predicate 'subsystem == "org.kenarnold.audio-feeder"' --style compact` running: publish, then open the browser broadcast page. Expect `room dropped: another participant took the organizer-host identity` in `publisher`, then `staying down` in `controller`, and `Stopped — Taken over by the broadcast page` in the popover. Close the page, click **Reconnect**, confirm it comes back.

## Smoke test sections touched

**§4 Live audio translation** — specifically the broadcaster side. Nothing here touches the Node server, the supervisor, the bridges or any browser client, so the §4 items about listener/bridge behaviour are unaffected; the relevant one is "Stop and restart the broadcaster mid-session". No other section is touched.

## Known limit, deliberately not fixed

If the SDK sat in `.reconnecting` forever we'd wait forever with it — `isPipelineRunning` counts `.reconnecting` as alive on purpose, so the tick doesn't tear down a recovery in progress. Bounding it needs a timeout longer than the SDK's own full-reconnect budget, and that's a number to measure, not guess.

`NOTEBOOK.md` (2026-07-30) has the full reasoning; `README.md` gains troubleshooting rows for the new statuses.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLnnNm4Ad316vr3s6YmVXx)_