### PR TITLE
live transcript: show a break when the speaker pauses

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,7 +69,7 @@ doc is *derived* data that the system under test will regenerate.
 |---|---|---|
 | Human editor (browser) | `sourceTextBlocks` edits | Keystrokes — these *are* Yjs deltas; Yjs-level recording is correct **only** for this writer |
 | `proclaim_service.py` (slide feed → Yjs publisher + translator) | `proclaimServiceOrder`, `proclaimPresentations`, `proclaimStatus`, `slideTranslations`, `status.proclaimService` | Proclaim local HTTP API responses + `PresentationManager.db` |
-| translation-bridge / transcript-writer | `liveTranscriptSegments-{code}` (one utterance per entry, with `startedAt` + preceding `gapMs`) | Organizer audio track + Gemini Live responses — including *when* each delta arrived, which only the writer sees |
+| translation-bridge / transcript-writer | `liveTranscriptSegments-{code}` (one utterance per entry, stamped `startedAt` + `endedAt`; the silence between utterances is derived from those, not stored) | Organizer audio track + Gemini Live responses — including *when* each delta arrived, which only the writer sees |
 | Block translation manager | per-language translations, `notesTranslationCache` | Source blocks + `/api/translate` (Gemini) |
 | Slide translation agent | slide translations, conversations, library | Slide texts + Gemini |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,7 +69,7 @@ doc is *derived* data that the system under test will regenerate.
 |---|---|---|
 | Human editor (browser) | `sourceTextBlocks` edits | Keystrokes — these *are* Yjs deltas; Yjs-level recording is correct **only** for this writer |
 | `proclaim_service.py` (slide feed → Yjs publisher + translator) | `proclaimServiceOrder`, `proclaimPresentations`, `proclaimStatus`, `slideTranslations`, `status.proclaimService` | Proclaim local HTTP API responses + `PresentationManager.db` |
-| translation-bridge / transcript-writer | live transcript | Organizer audio track + Gemini Live responses |
+| translation-bridge / transcript-writer | `liveTranscriptSegments-{code}` (one utterance per entry, with `startedAt` + preceding `gapMs`) | Organizer audio track + Gemini Live responses — including *when* each delta arrived, which only the writer sees |
 | Block translation manager | per-language translations, `notesTranslationCache` | Source blocks + `/api/translate` (Gemini) |
 | Slide translation agent | slide translations, conversations, library | Slide texts + Gemini |
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -25,9 +25,13 @@ most of these signals.
    listener's `listen=<lang>` attribute — the demand signal). Pull with
    `RoomServiceClient.listParticipants(sessionId)` against the `LIVEKIT_URL` (ws→http). The
    supervisor polls this every 10 s; it does not depend on any client-side beacon.
-4. **Y-Sweet / Yjs transcript doc** — the `liveTranscript-<code>` Y.Text per language is the
-   product itself; its steady growth is a good end-to-end "translation is actually flowing"
-   heartbeat that no single component can fake (written by `transcript-writer.ts`).
+4. **Y-Sweet / Yjs transcript doc** — the `liveTranscriptSegments-<code>` Y.Array per language
+   is the product itself; its steady growth is a good end-to-end "translation is actually
+   flowing" heartbeat that no single component can fake (written by `transcript-writer.ts`).
+   Each segment is one utterance, stamped with `startedAt` and the silence (`gapMs`) that
+   preceded it — the write side is the only place that knows when a delta arrived, so timing
+   recorded there is the only timing anything downstream can ever see. Sessions from before
+   this existed hold a flat `liveTranscript-<code>` Y.Text instead; readers fall back to it.
 
 Server logs are the fifth, lowest-friction source: bridges log `[TranslationBridge:<lang>] …`
 and the manager logs `[SessionManager] …`, including every telemetry event, suspend/resume, and
@@ -55,7 +59,7 @@ Server-level exceptions go through `phClient.captureException(...)` in
 ## Questions → where to look
 
 - **Is a talk live and translating right now?** LiveKit `listParticipants` (organizer + a
-  `translator-*` present) *and* `liveTranscript-*` still growing. Bridge `status` alone can read
+  `translator-*` present) *and* `liveTranscriptSegments-*` still growing. Bridge `status` alone can read
   `active` while deaf, so pair it with transcript growth.
 - **How reliable are session swaps?** `gemini_goaway` → `gemini_session_setup_complete`
   (`trigger: goaway`) latency, and whether `gemini_input_flushed.bufferedMs` / `gemini_audio_gap`
@@ -95,17 +99,22 @@ The session status page ([src/StatusView.tsx](../src/StatusView.tsx), reachable 
 layout component) is where these signals surface for an operator. Current state:
 
 - **Live transcripts (built).** [src/TranscriptHealth.tsx](../src/TranscriptHealth.tsx) renders one
-  tile per `liveTranscript-<code>` language present in the doc — source (`en`) first — showing char
-  count, a tail preview, and a staleness dot. This is source #4 (transcript growth), the end-to-end
-  "translation is actually flowing" heartbeat, read straight from Yjs with no backend change.
-  - Discovery + labeling live in [src/transcriptKeys.ts](../src/transcriptKeys.ts) (`liveTranscriptCodes`,
-    `liveTranscriptLabel`, and the key-namespace constants), shared with the session export
+  tile per `liveTranscriptSegments-<code>` language present in the doc — source (`en`) first —
+  showing char count, a tail preview, and a staleness dot. This is source #4 (transcript growth),
+  the end-to-end "translation is actually flowing" heartbeat, read straight from Yjs with no
+  backend change.
+  - Discovery + labeling live in [src/transcriptKeys.ts](../src/transcriptKeys.ts)
+    (`liveTranscriptCodes`, `liveTranscriptLabel`, the key-namespace constants, the segment shape,
+    and `readTranscriptSegments`), shared with the session export
     ([sessionExport.ts](../sessionExport.ts)) so both agree on the namespace. Kept dependency-free
     (type-only Yjs import) so the client doesn't pull the server export path into its bundle.
-  - **Freshness is client-relative.** Y.Text carries no timestamp, so "updated Ns ago" is measured
-    from when a delta is observed *while the page is open* — it can't recover the last-write time
-    from before you loaded. The initial sync populate is deliberately ignored so a stale backlog
-    doesn't read as "just updated." Good for "is it moving now"; not an absolute liveness clock.
+  - **Freshness is client-relative.** "Updated Ns ago" is measured from when a delta is observed
+    *while the page is open* — it doesn't use the last-write time from before you loaded. The
+    initial sync populate is deliberately ignored so a stale backlog doesn't read as "just
+    updated." Good for "is it moving now"; not an absolute liveness clock. Segments now carry
+    `startedAt`, so an absolute clock is *available* — but a segment's start isn't its last delta,
+    so seeding from it would over-report staleness on one that's still streaming. Worth revisiting
+    if the tile ever needs to answer "when did this last move" across a page load.
 - **Component health tiles (skeleton).** The Server / Proclaim / bridges / broadcaster tiles are
   still placeholders — nothing writes the `status` Y.Map yet (that's the #72 heartbeat producers).
 - **Preflight canary (skeleton).** Placeholder; no end-to-end check runs yet.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -28,10 +28,14 @@ most of these signals.
 4. **Y-Sweet / Yjs transcript doc** — the `liveTranscriptSegments-<code>` Y.Array per language
    is the product itself; its steady growth is a good end-to-end "translation is actually
    flowing" heartbeat that no single component can fake (written by `transcript-writer.ts`).
-   Each segment is one utterance, stamped with `startedAt` and the silence (`gapMs`) that
-   preceded it — the write side is the only place that knows when a delta arrived, so timing
-   recorded there is the only timing anything downstream can ever see. Sessions from before
-   this existed hold a flat `liveTranscript-<code>` Y.Text instead; readers fall back to it.
+   Each segment is one utterance, stamped with `startedAt` and `endedAt` — the write side is
+   the only place that knows when a delta arrived, so timing recorded there is the only timing
+   anything downstream can ever see. Only those observations are stored; the silence between
+   utterances is *derived* at read time as `startedAt − previous.endedAt`. That keeps the two
+   from disagreeing, and lets the writer recover its own state from the doc instead of holding
+   it in memory — so a server restart mid-session neither loses the utterance boundary nor
+   hides the gap the restart itself caused. Sessions from before this existed hold a flat
+   `liveTranscript-<code>` Y.Text instead; readers fall back to it.
 
 Server logs are the fifth, lowest-friction source: bridges log `[TranslationBridge:<lang>] …`
 and the manager logs `[SessionManager] …`, including every telemetry event, suspend/resume, and
@@ -112,9 +116,9 @@ layout component) is where these signals surface for an operator. Current state:
     *while the page is open* — it doesn't use the last-write time from before you loaded. The
     initial sync populate is deliberately ignored so a stale backlog doesn't read as "just
     updated." Good for "is it moving now"; not an absolute liveness clock. Segments now carry
-    `startedAt`, so an absolute clock is *available* — but a segment's start isn't its last delta,
-    so seeding from it would over-report staleness on one that's still streaming. Worth revisiting
-    if the tile ever needs to answer "when did this last move" across a page load.
+    `endedAt` — the exact time of the last delta — so seeding the tile from the last segment
+    would make it a true cross-page-load clock. Small, self-contained follow-up; left out of the
+    pause-indicator change to keep that scoped.
 - **Component health tiles (skeleton).** The Server / Proclaim / bridges / broadcaster tiles are
   still placeholders — nothing writes the `status` Y.Map yet (that's the #72 heartbeat producers).
 - **Preflight canary (skeleton).** Placeholder; no end-to-end check runs yet.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -31,7 +31,12 @@ most of these signals.
    Each segment is one utterance, stamped with `startedAt` and `endedAt` — the write side is
    the only place that knows when a delta arrived, so timing recorded there is the only timing
    anything downstream can ever see. Only those observations are stored; the silence between
-   utterances is *derived* at read time as `startedAt − previous.endedAt`. That keeps the two
+   utterances is *derived* at read time as `startedAt − previous.endedAt`. `endedAt` is written
+   coarsely on purpose (see `TRANSCRIPT_ENDED_AT_RESOLUTION_MS`): Yjs merges consecutive
+   same-client appends to a Y.Text into one item only while their clocks stay adjacent, so a
+   timestamp write between two deltas splits the run — stamping every delta measured at ~2x the
+   live traffic and ~2x the stored doc. Gaps are therefore accurate to ~1s, and only ever
+   over-reported. That keeps the two
    from disagreeing, and lets the writer recover its own state from the doc instead of holding
    it in memory — so a server restart mid-session neither loses the utterance boundary nor
    hides the gap the restart itself caused. Sessions from before this existed hold a flat

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -53,7 +53,9 @@ an incident happens that this list would not have caught, add a line.
 - [ ] Stop and restart the broadcaster mid-session; transcript resumes without a reload.
 - [ ] **Server-restart recovery**: with a listener connected and the speaker talking,
       restart the Node server. Within ~15 s the supervisor rebuilds the bridges from room
-      presence and the transcript resumes — no reload, no re-tap on any client.
+      presence and the transcript resumes — no reload, no re-tap on any client. The resumed
+      speech must start a *new* utterance with a pause divider covering the outage, not get
+      glued onto the sentence that was in flight when the server went down.
 - [ ] **The LiveKit full reconnect** (the 2026-07-12 outage — see
       [live-audio-resilience.md](live-audio-resilience.md)). With a bridge running and the
       speaker talking, force the reconnect that once deafened every translator for six

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -46,6 +46,10 @@ an incident happens that this list would not have caught, add a line.
       waits); within ~10 s of the organizer joining, the translator appears and the
       transcript flows. The listener's amber "Restarting translation…" state may flash
       briefly — it must go green without a reload.
+- [ ] **Pause indicator**: stop speaking for ~15 s, then resume. A dashed "Pause · Ns" rule
+      appears between the two utterances, with a plausible duration. Normal gaps between
+      sentences must *not* produce one. (A bridge outage also shows up here — that's intended,
+      but it means a divider isn't proof the speaker was silent.)
 - [ ] Stop and restart the broadcaster mid-session; transcript resumes without a reload.
 - [ ] **Server-restart recovery**: with a listener connected and the speaker talking,
       restart the Node server. Within ~15 s the supervisor rebuilds the bridges from room

--- a/docs/live-audio-state-architecture.md
+++ b/docs/live-audio-state-architecture.md
@@ -57,7 +57,7 @@ flowchart LR
 
   LK[("LiveKit room<br/><i>ground truth: who is present,<br/>what is published</i>")]
   GEM[("Gemini Live<br/>WebSocket sessions")]
-  YS[("Y-Sweet doc<br/><i>liveTranscript-*</i>")]
+  YS[("Y-Sweet doc<br/><i>liveTranscriptSegments-*</i>")]
 
   BC -- "mic audio" --> LK
   LV -- "POST /translate, /token,<br/>beacon /unsubscribe" --> API

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,4 +52,18 @@ export default tseslint.config(
       },
     },
   },
+  {
+    // These same backend files are executed by `node server.ts` (see package.json), which
+    // runs TypeScript in *strip-only* mode: it erases types but never generates code. A
+    // constructor parameter property needs desugaring, not erasure, so Node rejects the
+    // file outright and the server dies at import with ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX.
+    // Nothing else catches this — tsc, vitest (esbuild) and eslint all accept it happily —
+    // so a green CI can still ship a server that won't boot. Hence a lint rule.
+    // Test files are exempt: they only ever run under vitest, which transpiles fully.
+    files: ['*.ts', 'live-audio/**/*.ts'],
+    ignores: ['**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/parameter-properties': ['error', { prefer: 'class-property' }],
+    },
+  },
 )

--- a/live-audio/transcript-writer.test.ts
+++ b/live-audio/transcript-writer.test.ts
@@ -191,6 +191,55 @@ describe("TranscriptSegmentLog", () => {
     expect(segments[1].endedAt).toBe(T0 + 3000);
   });
 
+  // endedAt is written coarsely on purpose: a Y.Map write between two Y.Text appends
+  // splits the merged item run, so stamping every delta roughly doubles the doc.
+  describe("endedAt resolution", () => {
+    it("is exact on a delta that ends a sentence, however soon it arrives", () => {
+      const segments = run([
+        [0, "Short"],
+        [120, " one."], // well inside the resolution window, but it closes the sentence
+      ]);
+
+      expect(segments[0].endedAt).toBe(T0 + 120);
+    });
+
+    it("skips the rewrite for rapid mid-sentence deltas", () => {
+      const segments = run([
+        [0, "We"],
+        [200, " were"],
+        [400, " saying"],
+      ]);
+
+      // Still the segment's opening stamp — the two cheap deltas didn't rewrite it.
+      expect(segments[0].endedAt).toBe(T0);
+    });
+
+    it("catches up once the stored value goes stale", () => {
+      const segments = run([
+        [0, "We"],
+        [200, " were"],
+        [1500, " saying"],
+      ]);
+
+      expect(segments[0].endedAt).toBe(T0 + 1500);
+    });
+
+    // The coarseness must only ever make a pause look longer. Under-reporting could
+    // hide a real pause below the threshold; over-reporting at most pads a gap that
+    // already cleared it by a second.
+    it("over-reports a gap rather than under-reporting it", () => {
+      const segments = run([
+        [0, "Trailing off"],
+        [900, " mid thought"], // within the window, so endedAt stays at T0
+        [40_000, " and back."],
+      ]);
+
+      // True silence is 39.1s; reported as 40s because the last delta wasn't stamped.
+      expect(segments[1].gapMs).toBe(40_000);
+      expect(segments[1].gapMs!).toBeGreaterThanOrEqual(40_000 - 900);
+    });
+  });
+
   // The writer keeps nothing between calls, so a restarted server picks up from the doc.
   // Before this, `breakPending`/`lastDeltaAt` lived in memory and the first delta after a
   // restart glued onto the pre-restart utterance — hiding the boundary and the gap.

--- a/live-audio/transcript-writer.test.ts
+++ b/live-audio/transcript-writer.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
 
-import { endsSentence } from "./transcript-writer.ts";
+import { TranscriptSegmentLog, endsSentence } from "./transcript-writer.ts";
+import {
+  TRANSCRIPT_PAUSE_MS,
+  readTranscriptSegments,
+} from "../src/transcriptKeys.ts";
 
 // Gemini Live Translate streams transcription as a continuous flow of deltas with
-// no turnComplete, so the writer starts a fresh paragraph after a delta that ends
+// no turnComplete, so the writer starts a fresh segment after a delta that ends
 // a sentence. `endsSentence` is that decision.
 describe("endsSentence", () => {
   it("is true for deltas ending in sentence punctuation", () => {
@@ -36,5 +41,142 @@ describe("endsSentence", () => {
   it("is false for empty or whitespace-only text", () => {
     expect(endsSentence("")).toBe(false);
     expect(endsSentence("   ")).toBe(false);
+  });
+});
+
+/**
+ * The segmentation is what makes a pause representable at all: a gap can only be
+ * reported where a segment boundary exists, so these tests are really about where
+ * boundaries land and what silence gets attributed to them. The clock is injected,
+ * so "a minute of silence" is a number, not a wait.
+ */
+describe("TranscriptSegmentLog", () => {
+  const T0 = 1_700_000_000_000;
+
+  /** Drive a log with (offsetMs, text) deltas and read back what a viewer would see. */
+  function run(deltas: [number, string][], code = "en") {
+    const doc = new Y.Doc();
+    const log = new TranscriptSegmentLog(doc);
+    for (const [offset, text] of deltas) log.append(code, text, T0 + offset);
+    return readTranscriptSegments(doc, code);
+  }
+
+  it("accumulates deltas into one segment until a sentence ends", () => {
+    const segments = run([
+      [0, "The Lord"],
+      [500, " is my"],
+      [1000, " shepherd."],
+    ]);
+
+    expect(segments.map((s) => s.text)).toEqual(["The Lord is my shepherd."]);
+  });
+
+  it("opens a new segment on the delta after a sentence ends", () => {
+    const segments = run([
+      [0, "First one."],
+      [700, " Second one."],
+    ]);
+
+    expect(segments.map((s) => s.text)).toEqual(["First one.", "Second one."]);
+  });
+
+  it("stamps each segment with when its first delta arrived", () => {
+    const segments = run([
+      [0, "First one."],
+      [700, " Second one."],
+    ]);
+
+    expect(segments[0].startedAt).toBe(T0);
+    expect(segments[1].startedAt).toBe(T0 + 700);
+  });
+
+  it("records the silence before a segment, measured from the previous delta", () => {
+    const segments = run([
+      // A 9s utterance, then 20s of silence. The gap must reflect the silence, not
+      // the time the sentence itself took — measuring from the previous segment's
+      // *start* would report 29s.
+      [0, "A long"],
+      [5_000, " opening"],
+      [9_000, " sentence."],
+      [29_000, " And we resume."],
+    ]);
+
+    expect(segments.map((s) => s.text)).toEqual([
+      "A long opening sentence.",
+      "And we resume.",
+    ]);
+    expect(segments[1].gapMs).toBe(20_000);
+  });
+
+  it("leaves the first segment of a transcript with no gap", () => {
+    expect(run([[0, "Opening words."]])[0].gapMs).toBeUndefined();
+  });
+
+  it("splits mid-sentence when the silence is long enough to be a pause", () => {
+    const segments = run([
+      [0, "We were saying"],
+      [TRANSCRIPT_PAUSE_MS, " something else entirely"],
+    ]);
+
+    expect(segments.map((s) => s.text)).toEqual([
+      "We were saying",
+      "something else entirely",
+    ]);
+    expect(segments[1].gapMs).toBe(TRANSCRIPT_PAUSE_MS);
+  });
+
+  it("keeps a below-threshold gap inside the segment, so it reads as one utterance", () => {
+    const segments = run([
+      [0, "We were saying"],
+      [TRANSCRIPT_PAUSE_MS - 1, " something else entirely"],
+    ]);
+
+    expect(segments.map((s) => s.text)).toEqual([
+      "We were saying something else entirely",
+    ]);
+  });
+
+  it("drops the leading whitespace a delta carries into a new segment", () => {
+    const segments = run([
+      [0, "Done."],
+      [500, "   Next."],
+    ]);
+
+    expect(segments[1].text).toBe("Next.");
+  });
+
+  it("does not open a segment on a whitespace-only delta, or let it hide a pause", () => {
+    const segments = run([
+      [0, "Done."],
+      [500, "   "], // no speech: must not open an empty segment...
+      [60_500, " Back again."], // ...nor restart the pause clock at 500
+    ]);
+
+    expect(segments.map((s) => s.text)).toEqual(["Done.", "Back again."]);
+    // The full silence since the last actual speech, not 60s from the whitespace.
+    expect(segments[1].gapMs).toBe(60_500);
+  });
+
+  it("tracks languages independently, so interleaved deltas don't cross-contaminate", () => {
+    const doc = new Y.Doc();
+    const log = new TranscriptSegmentLog(doc);
+
+    log.append("en", "Good morning.", T0);
+    log.append("fr", "Bonjour.", T0 + 100);
+    // English has been silent for 30s; French deltas in between must not count as
+    // English activity and mask the pause.
+    log.append("en", " Let us pray.", T0 + 30_000);
+    log.append("fr", " Prions.", T0 + 30_100);
+
+    const en = readTranscriptSegments(doc, "en");
+    const fr = readTranscriptSegments(doc, "fr");
+    expect(en.map((s) => s.text)).toEqual(["Good morning.", "Let us pray."]);
+    expect(fr.map((s) => s.text)).toEqual(["Bonjour.", "Prions."]);
+    expect(en[1].gapMs).toBe(30_000);
+    expect(fr[1].gapMs).toBe(30_000);
+  });
+
+  it("ignores empty deltas entirely", () => {
+    expect(run([[0, ""]])).toEqual([]);
   });
 });

--- a/live-audio/transcript-writer.test.ts
+++ b/live-audio/transcript-writer.test.ts
@@ -179,4 +179,57 @@ describe("TranscriptSegmentLog", () => {
   it("ignores empty deltas entirely", () => {
     expect(run([[0, ""]])).toEqual([]);
   });
+
+  it("stamps each segment with when it last grew", () => {
+    const segments = run([
+      [0, "The Lord"],
+      [500, " is my shepherd."],
+      [3000, " I shall not want."],
+    ]);
+
+    expect(segments[0].endedAt).toBe(T0 + 500);
+    expect(segments[1].endedAt).toBe(T0 + 3000);
+  });
+
+  // The writer keeps nothing between calls, so a restarted server picks up from the doc.
+  // Before this, `breakPending`/`lastDeltaAt` lived in memory and the first delta after a
+  // restart glued onto the pre-restart utterance — hiding the boundary and the gap.
+  describe("after a server restart (fresh log, same doc)", () => {
+    /** Replay `before`, drop the log on the floor, then replay `after` on a new one. */
+    function acrossRestart(before: [number, string][], after: [number, string][]) {
+      const doc = new Y.Doc();
+      const first = new TranscriptSegmentLog(doc);
+      for (const [offset, text] of before) first.append("en", text, T0 + offset);
+
+      const second = new TranscriptSegmentLog(doc);
+      for (const [offset, text] of after) second.append("en", text, T0 + offset);
+
+      return readTranscriptSegments(doc, "en");
+    }
+
+    it("still breaks at the sentence the restart interrupted", () => {
+      const segments = acrossRestart([[0, "Let us pray."]], [[900, " Amen."]]);
+
+      expect(segments.map((s) => s.text)).toEqual(["Let us pray.", "Amen."]);
+    });
+
+    it("reports the silence the outage itself caused", () => {
+      const segments = acrossRestart(
+        [[0, "We were in the middle of"]], // mid-sentence when the server went down
+        [[45_000, " a thought."]],
+      );
+
+      expect(segments.map((s) => s.text)).toEqual([
+        "We were in the middle of",
+        "a thought.",
+      ]);
+      expect(segments[1].gapMs).toBe(45_000);
+    });
+
+    it("does not invent a break when the restart was quick and mid-sentence", () => {
+      const segments = acrossRestart([[0, "We were saying"]], [[2000, " something."]]);
+
+      expect(segments.map((s) => s.text)).toEqual(["We were saying something."]);
+    });
+  });
 });

--- a/live-audio/transcript-writer.ts
+++ b/live-audio/transcript-writer.ts
@@ -12,10 +12,12 @@
  * truth — there is no separate ephemeral interim stream.
  *
  * Segments exist so the transcript can carry *time*, which a flat Y.Text cannot: this
- * writer is the only place in the system that knows when a delta arrived, so a silence
- * has to be measured and recorded here or it's unrecoverable downstream (a viewer can
- * only ever time deltas it was present for). Each segment records when it opened and
- * how much silence preceded it; the client turns long gaps into a visible break.
+ * writer is the only place in the system that knows when a delta arrived, so timing has
+ * to be recorded here or it's unrecoverable downstream (a viewer can only ever time
+ * deltas it was present for). Each segment records when it opened (`startedAt`) and when
+ * it last grew (`endedAt`) — observations only. The silence *between* utterances is
+ * derived from those at read time, which is what lets the client turn a long gap into a
+ * visible break without this writer having to decide, or remember, anything.
  *
  * Mirrors the Proclaim service's "external process writes into Yjs" pattern, but
  * in-process on the Node server using the same Y-Sweet DocumentManager that issues
@@ -28,6 +30,8 @@ import type { DocumentManager } from "@y-sweet/sdk";
 
 import {
   TRANSCRIPT_PAUSE_MS,
+  readSegmentFields,
+  segmentLastActivityAt,
   transcriptSegmentsKey,
 } from "../src/transcriptKeys.ts";
 
@@ -48,20 +52,22 @@ export function endsSentence(text: string): boolean {
  * nothing to do with being connected to anything.
  */
 export class TranscriptSegmentLog {
-  /** Per language: when its last delta was written, for measuring silence. */
-  private lastDeltaAt = new Map<string, number>();
-  /** Per language: the last delta finished a sentence, so the next one opens a segment. */
-  private breakPending = new Set<string>();
-
   constructor(private readonly doc: Y.Doc) {}
 
   /**
    * Append a streamed transcription delta for a language. The delta goes verbatim into
    * the open segment (no trimming — inter-delta spacing is significant). A new segment
-   * opens when the previous delta ended a sentence, or when this delta follows a silence
-   * of at least TRANSCRIPT_PAUSE_MS — a long enough gap is itself an utterance boundary,
-   * even mid-sentence, and splitting there is what gives the pause somewhere to be
-   * recorded. Edits made before the initial sync are merged by Yjs.
+   * opens when the open one already ended a sentence, or when this delta follows a
+   * silence of at least TRANSCRIPT_PAUSE_MS — a long enough gap is itself an utterance
+   * boundary, even mid-sentence, and splitting there is what gives the pause somewhere
+   * to be recorded. Edits made before the initial sync are merged by Yjs.
+   *
+   * Deliberately holds **no state between calls**: both inputs to that decision — when
+   * the language last produced speech, and whether it was mid-sentence — are read back
+   * out of the doc. A restarted server (see SMOKE_TEST.md §4) therefore picks up exactly
+   * where it left off; with either fact cached in memory, the first delta after a
+   * restart would silently glue onto the pre-restart utterance, hiding both the boundary
+   * and the very gap the restart caused.
    *
    * `now` is injectable so tests can drive the clock.
    */
@@ -69,35 +75,37 @@ export class TranscriptSegmentLog {
     if (!text) return;
 
     const segments = this.doc.getArray<Y.Map<unknown>>(transcriptSegmentsKey(code));
-    const lastAt = this.lastDeltaAt.get(code);
+    const open = segments.length > 0 ? segments.get(segments.length - 1) : undefined;
+
+    const lastAt = open === undefined ? undefined : segmentLastActivityAt(open);
     const gapMs = lastAt === undefined ? undefined : Math.max(0, now - lastAt);
+    // Read from the accumulated segment rather than the previous delta: the regex is
+    // anchored at the end, so this is the same answer, minus the memory.
+    const finished = open !== undefined && endsSentence(readSegmentFields(open).text);
     const longPause = gapMs !== undefined && gapMs >= TRANSCRIPT_PAUSE_MS;
-    const opensSegment = segments.length === 0 || this.breakPending.has(code) || longPause;
+    const opensSegment = open === undefined || finished || longPause;
 
     // A delta that opens a segment gets its leading whitespace dropped — it would
     // otherwise be indentation on the new utterance. If that leaves nothing, there's
-    // no speech to open a segment with: drop it and keep waiting, without touching the
-    // clock, so trailing whitespace can't mask the start of a silence.
+    // no speech to open a segment with: drop it and keep waiting, without stamping
+    // endedAt, so trailing whitespace can't mask the start of a silence.
     const body = opensSegment ? text.trimStart() : text;
     if (opensSegment && body === "") return;
-
-    this.lastDeltaAt.set(code, now);
-    this.breakPending.delete(code);
 
     this.doc.transact(() => {
       if (opensSegment) {
         const segment = new Y.Map<unknown>();
         segments.push([segment]);
         segment.set("startedAt", now);
-        if (gapMs !== undefined) segment.set("gapMs", gapMs);
+        segment.set("endedAt", now);
         segment.set("text", new Y.Text(body));
       } else {
-        const open = segments.get(segments.length - 1).get("text") as Y.Text;
-        open.insert(open.length, body);
+        const openText = open!.get("text") as Y.Text;
+        openText.insert(openText.length, body);
+        // Same transaction as the insert, so this costs one update, not two.
+        open!.set("endedAt", now);
       }
     });
-
-    if (endsSentence(text)) this.breakPending.add(code);
   }
 }
 

--- a/live-audio/transcript-writer.ts
+++ b/live-audio/transcript-writer.ts
@@ -4,11 +4,18 @@
  * late joiners — can read the full transcript history.
  *
  * One writer per session (doc), shared by all of that session's TranslationBridges.
- * Each language's transcript accumulates in a `liveTranscript-{code}` Y.Text:
- * Gemini Live Translate streams a continuous flow of transcription deltas (it has
- * no "turns", so no turnComplete to flush on), so we append each delta verbatim
- * and start a fresh paragraph after sentence-ending punctuation. The Y.Text is the
- * single source of truth — there is no separate ephemeral interim stream.
+ * Each language's transcript accumulates in a `liveTranscriptSegments-{code}` Y.Array
+ * of segment Y.Maps (`{ startedAt, gapMs?, text: Y.Text }`): Gemini Live Translate
+ * streams a continuous flow of transcription deltas (it has no "turns", so no
+ * turnComplete to flush on), so we append each delta verbatim into the open segment
+ * and start a new one once a sentence finishes. The Y.Array is the single source of
+ * truth — there is no separate ephemeral interim stream.
+ *
+ * Segments exist so the transcript can carry *time*, which a flat Y.Text cannot: this
+ * writer is the only place in the system that knows when a delta arrived, so a silence
+ * has to be measured and recorded here or it's unrecoverable downstream (a viewer can
+ * only ever time deltas it was present for). Each segment records when it opened and
+ * how much silence preceded it; the client turns long gaps into a visible break.
  *
  * Mirrors the Proclaim service's "external process writes into Yjs" pattern, but
  * in-process on the Node server using the same Y-Sweet DocumentManager that issues
@@ -19,22 +26,86 @@ import * as Y from "yjs";
 import { createYjsProvider, type YSweetProvider } from "@y-sweet/client";
 import type { DocumentManager } from "@y-sweet/sdk";
 
-const KEY_PREFIX = "liveTranscript-";
+import {
+  TRANSCRIPT_PAUSE_MS,
+  transcriptSegmentsKey,
+} from "../src/transcriptKeys.ts";
 
 /**
- * Whether a transcription delta ends an utterance, used to start a new paragraph.
+ * Whether a transcription delta ends an utterance, used to close the segment.
  * Cheap heuristic: the trimmed text ends with sentence-ending punctuation,
  * optionally followed by a closing quote or bracket. Abbreviations ("Dr.") may
- * split a paragraph early — acceptable for a live transcript.
+ * split a segment early — acceptable for a live transcript.
  */
 export function endsSentence(text: string): boolean {
   return /[.!?…。！？][")'\]]?\s*$/.test(text);
+}
+
+/**
+ * The segmentation itself: turns a stream of deltas into timestamped utterances in a
+ * Y.Doc. Split out from the transport below so it can be exercised against a plain
+ * local Y.Doc — the interesting behavior here is *when a segment opens*, which has
+ * nothing to do with being connected to anything.
+ */
+export class TranscriptSegmentLog {
+  /** Per language: when its last delta was written, for measuring silence. */
+  private lastDeltaAt = new Map<string, number>();
+  /** Per language: the last delta finished a sentence, so the next one opens a segment. */
+  private breakPending = new Set<string>();
+
+  constructor(private readonly doc: Y.Doc) {}
+
+  /**
+   * Append a streamed transcription delta for a language. The delta goes verbatim into
+   * the open segment (no trimming — inter-delta spacing is significant). A new segment
+   * opens when the previous delta ended a sentence, or when this delta follows a silence
+   * of at least TRANSCRIPT_PAUSE_MS — a long enough gap is itself an utterance boundary,
+   * even mid-sentence, and splitting there is what gives the pause somewhere to be
+   * recorded. Edits made before the initial sync are merged by Yjs.
+   *
+   * `now` is injectable so tests can drive the clock.
+   */
+  append(code: string, text: string, now: number = Date.now()): void {
+    if (!text) return;
+
+    const segments = this.doc.getArray<Y.Map<unknown>>(transcriptSegmentsKey(code));
+    const lastAt = this.lastDeltaAt.get(code);
+    const gapMs = lastAt === undefined ? undefined : Math.max(0, now - lastAt);
+    const longPause = gapMs !== undefined && gapMs >= TRANSCRIPT_PAUSE_MS;
+    const opensSegment = segments.length === 0 || this.breakPending.has(code) || longPause;
+
+    // A delta that opens a segment gets its leading whitespace dropped — it would
+    // otherwise be indentation on the new utterance. If that leaves nothing, there's
+    // no speech to open a segment with: drop it and keep waiting, without touching the
+    // clock, so trailing whitespace can't mask the start of a silence.
+    const body = opensSegment ? text.trimStart() : text;
+    if (opensSegment && body === "") return;
+
+    this.lastDeltaAt.set(code, now);
+    this.breakPending.delete(code);
+
+    this.doc.transact(() => {
+      if (opensSegment) {
+        const segment = new Y.Map<unknown>();
+        segments.push([segment]);
+        segment.set("startedAt", now);
+        if (gapMs !== undefined) segment.set("gapMs", gapMs);
+        segment.set("text", new Y.Text(body));
+      } else {
+        const open = segments.get(segments.length - 1).get("text") as Y.Text;
+        open.insert(open.length, body);
+      }
+    });
+
+    if (endsSentence(text)) this.breakPending.add(code);
+  }
 }
 
 export class TranscriptWriter {
   public readonly docId: string;
   private doc = new Y.Doc();
   private provider: YSweetProvider;
+  private log = new TranscriptSegmentLog(this.doc);
 
   constructor(docId: string, documentManager: DocumentManager) {
     this.docId = docId;
@@ -46,21 +117,9 @@ export class TranscriptWriter {
     );
   }
 
-  /**
-   * Append a streamed transcription delta for a language. The delta is inserted
-   * verbatim (no trimming — inter-delta spacing is significant), and a paragraph
-   * break is added once a sentence finishes so the client renders readable
-   * paragraphs. Edits made before the initial sync are merged by Yjs.
-   */
+  /** Append a streamed transcription delta for a language. See TranscriptSegmentLog.append. */
   appendDelta(code: string, text: string): void {
-    if (!text) return;
-    const ytext = this.doc.getText(`${KEY_PREFIX}${code}`);
-    ytext.insert(ytext.length, text);
-    // Start a new paragraph after a completed sentence, unless the delta already
-    // ended with a newline (so we don't stack blank lines).
-    if (endsSentence(text) && !ytext.toString().endsWith("\n")) {
-      ytext.insert(ytext.length, "\n\n");
-    }
+    this.log.append(code, text);
   }
 
   close(): void {

--- a/live-audio/transcript-writer.ts
+++ b/live-audio/transcript-writer.ts
@@ -29,6 +29,7 @@ import { createYjsProvider, type YSweetProvider } from "@y-sweet/client";
 import type { DocumentManager } from "@y-sweet/sdk";
 
 import {
+  TRANSCRIPT_ENDED_AT_RESOLUTION_MS,
   TRANSCRIPT_PAUSE_MS,
   readSegmentFields,
   segmentLastActivityAt,
@@ -52,7 +53,14 @@ export function endsSentence(text: string): boolean {
  * nothing to do with being connected to anything.
  */
 export class TranscriptSegmentLog {
-  constructor(private readonly doc: Y.Doc) {}
+  // Explicit field, not a constructor parameter property: the server runs as
+  // `node server.ts` (strip-only TypeScript), which rejects parameter properties
+  // outright because desugaring them needs code generation, not just type removal.
+  private readonly doc: Y.Doc;
+
+  constructor(doc: Y.Doc) {
+    this.doc = doc;
+  }
 
   /**
    * Append a streamed transcription delta for a language. The delta goes verbatim into
@@ -102,8 +110,15 @@ export class TranscriptSegmentLog {
       } else {
         const openText = open!.get("text") as Y.Text;
         openText.insert(openText.length, body);
-        // Same transaction as the insert, so this costs one update, not two.
-        open!.set("endedAt", now);
+        // Rewriting endedAt on every delta splits the Y.Text's merged item run and
+        // roughly doubles the doc — see TRANSCRIPT_ENDED_AT_RESOLUTION_MS. Stamp it
+        // exactly when this delta ends a sentence (the segment's last delta, ordinarily),
+        // otherwise only once the stored value has gone stale.
+        const storedEndedAt = segmentLastActivityAt(open!) ?? now;
+        if (endsSentence(text) || now - storedEndedAt >= TRANSCRIPT_ENDED_AT_RESOLUTION_MS) {
+          // Same transaction as the insert, so this costs one update, not two.
+          open!.set("endedAt", now);
+        }
       }
     });
   }

--- a/sessionExport.test.ts
+++ b/sessionExport.test.ts
@@ -7,6 +7,20 @@ import {
 } from './sessionExport.ts';
 import { slideTranslationKey, type SlideTranslationEntry } from './src/slideTranslation.ts';
 
+/** Append a transcript segment the way live-audio/transcript-writer.ts does. */
+function transcriptSegment(
+  doc: Y.Doc,
+  code: string,
+  text: string,
+  timing: { startedAt: number; gapMs?: number },
+) {
+  const segment = new Y.Map<unknown>();
+  doc.getArray<Y.Map<unknown>>(`liveTranscriptSegments-${code}`).push([segment]);
+  segment.set('startedAt', timing.startedAt);
+  if (timing.gapMs !== undefined) segment.set('gapMs', timing.gapMs);
+  segment.set('text', new Y.Text(text));
+}
+
 /** Build a source block Y.Map the way the block editor stores them. */
 function block(id: string, position: string, content: string, opts?: { type?: 'heading' | 'bullet'; level?: number }) {
   const map = new Y.Map<unknown>();
@@ -129,11 +143,10 @@ describe('buildSessionExport', () => {
 
   it('collects live speech-translation transcripts, source language first', () => {
     const doc = new Y.Doc();
-    // Written by the live-audio pipeline as `liveTranscript-{code}` Y.Text.
-    doc.getText('liveTranscript-en').insert(0, 'The Lord is my shepherd.\n\n');
-    doc.getText('liveTranscript-fr').insert(0, "L'Éternel est mon berger.\n\n");
-    doc.getText('liveTranscript-es').insert(0, 'El Señor es mi pastor.\n\n');
-    doc.getText('liveTranscript-de'); // empty — should be dropped
+    transcriptSegment(doc, 'en', 'The Lord is my shepherd.', { startedAt: 1000 });
+    transcriptSegment(doc, 'fr', "L'Éternel est mon berger.", { startedAt: 1000 });
+    transcriptSegment(doc, 'es', 'El Señor es mi pastor.', { startedAt: 1000 });
+    doc.getArray('liveTranscriptSegments-de'); // empty — should be dropped
 
     const data = buildSessionExport(doc, 'doc-2026-07-13');
 
@@ -148,6 +161,37 @@ describe('buildSessionExport', () => {
     expect(html).toContain('Live speech translation');
     expect(html).toContain('English (source)');
     expect(html).toContain("L'Éternel est mon berger.");
+  });
+
+  it('marks a long silence between utterances, and leaves short gaps alone', () => {
+    const doc = new Y.Doc();
+    transcriptSegment(doc, 'en', 'Let us pray.', { startedAt: 1000 });
+    transcriptSegment(doc, 'en', 'Amen.', { startedAt: 5000, gapMs: 3000 });
+    transcriptSegment(doc, 'en', 'Please be seated.', { startedAt: 125_000, gapMs: 120_000 });
+
+    const data = buildSessionExport(doc, 'doc-2026-07-13');
+    expect(data.liveTranscripts[0].segments.map((s) => s.gapMs)).toEqual([
+      undefined,
+      3000,
+      120_000,
+    ]);
+
+    // Exactly one divider: the two-minute gap, not the three-second one.
+    const html = renderSessionHtml(data);
+    expect(html.match(/class="pause"/g)).toHaveLength(1);
+    expect(html).toContain('Pause &middot; 2m');
+  });
+
+  it('still exports a pre-segments session, whose transcript is a flat Y.Text', () => {
+    const doc = new Y.Doc();
+    doc.getText('liveTranscript-en').insert(0, 'The Lord is my shepherd.\n\nI shall not want.\n\n');
+
+    const data = buildSessionExport(doc, 'doc-2026-07-13');
+
+    expect(data.liveTranscripts[0].text).toBe('The Lord is my shepherd.\n\nI shall not want.');
+    const html = renderSessionHtml(data);
+    expect(html).toContain('I shall not want.');
+    expect(html).not.toContain('class="pause"'); // no timing was ever recorded
   });
 
   it('leaves date undefined for non-date doc ids', () => {

--- a/sessionExport.test.ts
+++ b/sessionExport.test.ts
@@ -7,17 +7,21 @@ import {
 } from './sessionExport.ts';
 import { slideTranslationKey, type SlideTranslationEntry } from './src/slideTranslation.ts';
 
-/** Append a transcript segment the way live-audio/transcript-writer.ts does. */
+/**
+ * Append a transcript segment the way live-audio/transcript-writer.ts does: stored
+ * timings are observations only (when the utterance started and last grew), and the
+ * silence between utterances is derived from them at read time.
+ */
 function transcriptSegment(
   doc: Y.Doc,
   code: string,
   text: string,
-  timing: { startedAt: number; gapMs?: number },
+  timing: { startedAt: number; endedAt?: number },
 ) {
   const segment = new Y.Map<unknown>();
   doc.getArray<Y.Map<unknown>>(`liveTranscriptSegments-${code}`).push([segment]);
   segment.set('startedAt', timing.startedAt);
-  if (timing.gapMs !== undefined) segment.set('gapMs', timing.gapMs);
+  segment.set('endedAt', timing.endedAt ?? timing.startedAt);
   segment.set('text', new Y.Text(text));
 }
 
@@ -165,15 +169,15 @@ describe('buildSessionExport', () => {
 
   it('marks a long silence between utterances, and leaves short gaps alone', () => {
     const doc = new Y.Doc();
-    transcriptSegment(doc, 'en', 'Let us pray.', { startedAt: 1000 });
-    transcriptSegment(doc, 'en', 'Amen.', { startedAt: 5000, gapMs: 3000 });
-    transcriptSegment(doc, 'en', 'Please be seated.', { startedAt: 125_000, gapMs: 120_000 });
+    transcriptSegment(doc, 'en', 'Let us pray.', { startedAt: 1000, endedAt: 2000 });
+    transcriptSegment(doc, 'en', 'Amen.', { startedAt: 5000, endedAt: 5000 });
+    transcriptSegment(doc, 'en', 'Please be seated.', { startedAt: 125_000, endedAt: 126_000 });
 
     const data = buildSessionExport(doc, 'doc-2026-07-13');
     expect(data.liveTranscripts[0].segments.map((s) => s.gapMs)).toEqual([
       undefined,
-      3000,
-      120_000,
+      3000, // 5s − 2s
+      120_000, // 125s − 5s
     ]);
 
     // Exactly one divider: the two-minute gap, not the three-second one.

--- a/sessionExport.ts
+++ b/sessionExport.ts
@@ -11,7 +11,8 @@
  *   - `proclaimPresentations` Y.Map itemId -> { title, slides: string[] }
  *   - `proclaimServiceOrder`  Y.Map `order` -> itemId[]
  *   - `slideTranslations`     Y.Map slideTranslationKey(lang, text) -> entry
- *   - `liveTranscript-{code}` Y.Text per language (live speech translation)
+ *   - `liveTranscriptSegments-{code}` Y.Array of utterances per language (live speech
+ *     translation); `liveTranscript-{code}` Y.Text in pre-segments sessions
  *   - `transcriptDoc`         Y.XmlFragment (legacy Web Speech API transcript)
  *
  * Languages are never hard-coded: each section discovers the languages actually
@@ -26,9 +27,14 @@ import {
   type ResolvedSlideTranslation,
 } from './src/slideTranslation.ts';
 import {
-  LIVE_TRANSCRIPT_PREFIX,
   LIVE_TRANSCRIPT_SOURCE_CODE,
+  formatPauseGap,
+  isLongPause,
+  liveTranscriptCodes,
   liveTranscriptLabel,
+  readTranscriptSegments,
+  transcriptPlainText,
+  type TranscriptSegment,
 } from './src/transcriptKeys.ts';
 
 // --- Structured, render-agnostic representation -------------------------------
@@ -61,6 +67,9 @@ export interface ExportedLiveTranscript {
   label: string;
   /** True for the English source transcript produced by the primary bridge. */
   isSource: boolean;
+  /** Utterances in order, each with the silence that preceded it (when recorded). */
+  segments: TranscriptSegment[];
+  /** The same content flattened, blank line between utterances. */
   text: string;
 }
 
@@ -217,27 +226,28 @@ function extractTranscript(ydoc: Y.Doc): string {
 }
 
 /**
- * Collect the live speech-translation transcripts. The pipeline creates a
- * `liveTranscript-{code}` Y.Text per language on demand, so which codes exist
- * varies by session — enumerate the doc's root types rather than guessing. The
- * English source is listed first; the rest are sorted by localized label.
+ * Collect the live speech-translation transcripts. The pipeline creates a transcript
+ * per language on demand, so which codes exist varies by session — enumerate the
+ * doc's root types rather than guessing. `liveTranscriptCodes` already orders them
+ * (English source first, then by localized label) and covers pre-segments sessions,
+ * whose transcripts `readTranscriptSegments` reads from the legacy Y.Text.
  */
 function extractLiveTranscripts(ydoc: Y.Doc): ExportedLiveTranscript[] {
   const transcripts: ExportedLiveTranscript[] = [];
 
-  for (const key of ydoc.share.keys()) {
-    if (!key.startsWith(LIVE_TRANSCRIPT_PREFIX)) continue;
-    const text = ydoc.getText(key).toString().trim();
-    if (text === '') continue;
-    const code = key.slice(LIVE_TRANSCRIPT_PREFIX.length);
-    const isSource = code === LIVE_TRANSCRIPT_SOURCE_CODE;
-    transcripts.push({ code, label: liveTranscriptLabel(code), isSource, text });
+  for (const code of liveTranscriptCodes(ydoc)) {
+    const segments = readTranscriptSegments(ydoc, code);
+    if (segments.length === 0) continue;
+    transcripts.push({
+      code,
+      label: liveTranscriptLabel(code),
+      isSource: code === LIVE_TRANSCRIPT_SOURCE_CODE,
+      segments,
+      text: transcriptPlainText(segments),
+    });
   }
 
-  return transcripts.sort((a, b) => {
-    if (a.isSource !== b.isSource) return a.isSource ? -1 : 1;
-    return a.label.localeCompare(b.label);
-  });
+  return transcripts;
 }
 
 /** Parse `doc-YYYY-MM-DD` into a friendly date; undefined for other id shapes. */
@@ -358,13 +368,29 @@ function renderTranscriptParagraphs(text: string): string {
     .join('\n');
 }
 
+/**
+ * Render transcript segments, marking each long silence with a labelled rule so the
+ * export shows the same breaks the live view does. Pre-segments sessions carry no
+ * gaps, so they render as plain paragraphs exactly as before.
+ */
+function renderTranscriptSegments(segments: TranscriptSegment[]): string {
+  return segments
+    .map((segment) => {
+      const paragraph = `<p>${escapeHtml(segment.text)}</p>`;
+      if (!isLongPause(segment)) return paragraph;
+      const pause = formatPauseGap(segment.gapMs ?? 0, 'en-US');
+      return `<div class="pause"><span>Pause &middot; ${escapeHtml(pause)}</span></div>\n${paragraph}`;
+    })
+    .join('\n');
+}
+
 function renderLiveTranscripts(transcripts: ExportedLiveTranscript[]): string {
   if (transcripts.length === 0) return '';
   const blocks = transcripts
     .map((t) => {
       const heading = t.isSource ? `${escapeHtml(t.label)} (source)` : escapeHtml(t.label);
-      return `<div class="presentation"><h3>${heading}</h3><div class="transcript">${renderTranscriptParagraphs(
-        t.text,
+      return `<div class="presentation"><h3>${heading}</h3><div class="transcript">${renderTranscriptSegments(
+        t.segments,
       )}</div></div>`;
     })
     .join('\n');
@@ -425,12 +451,17 @@ export function renderSessionHtml(data: SessionExport): string {
     border-radius: 0.25rem; padding: 0 0.35rem; }
   .badge-auto { background: #fef3c7; color: #92400e; }
   .transcript p { margin: 0.4rem 0; }
+  .pause { display: flex; align-items: center; gap: 0.75rem; margin: 1.1rem 0; }
+  .pause::before, .pause::after { content: ""; flex: 1; border-top: 1px dashed #d1d5db; }
+  .pause span { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af; }
   .empty { color: #6b7280; font-style: italic; }
   @media (prefers-color-scheme: dark) {
     body { color: #e5e7eb; background: #0b0f19; }
     header, h2 { border-color: #1f2937; }
     .meta, .note-translation, .slide-untranslated { color: #9ca3af; }
     .lang-tag, th { background: #1f2937; color: #9ca3af; }
+    .pause::before, .pause::after { border-color: #374151; }
+    .pause span { color: #6b7280; }
     th, td { border-color: #1f2937; }
     .badge { background: #374151; color: #d1d5db; }
     .badge-auto { background: #78350f; color: #fde68a; }

--- a/src/LiveTranscript.test.tsx
+++ b/src/LiveTranscript.test.tsx
@@ -1,0 +1,87 @@
+// The transcript's rendering half: given segments carrying gap timings, does a long
+// silence actually become a visible break in the right place? The measuring half
+// (which gaps exist at all) is covered in live-audio/transcript-writer.test.ts, and
+// the threshold itself in transcriptKeys.test.ts.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TRANSCRIPT_PAUSE_MS, type TranscriptSegment } from './transcriptKeys';
+
+const segments = vi.hoisted(() => ({ current: [] as TranscriptSegment[] }));
+
+// Stub the Yjs read so this stays a test of the component, not of the doc plumbing.
+vi.mock('./useTranscriptSegments', () => ({
+  useTranscriptSegments: () => segments.current,
+}));
+
+import { LiveTranscript } from './LiveTranscript';
+
+/** A separator's accessible name is its aria-label: "Pause · 2m". */
+const pauseLabels = () => screen.queryAllByRole('separator').map((el) => el.getAttribute('aria-label'));
+
+beforeEach(() => {
+  segments.current = [];
+});
+
+describe('LiveTranscript pause indicators', () => {
+  it('shows no break when utterances follow each other closely', () => {
+    segments.current = [
+      { text: 'Let us pray.', startedAt: 1000 },
+      { text: 'Amen.', startedAt: 4000, gapMs: 3000 },
+    ];
+
+    render(<LiveTranscript langCode="en" />);
+
+    expect(screen.getByText('Amen.')).toBeTruthy();
+    expect(pauseLabels()).toEqual([]);
+  });
+
+  it('breaks before an utterance that follows a long silence, and says how long', () => {
+    segments.current = [
+      { text: 'Let us pray.', startedAt: 1000 },
+      { text: 'Please be seated.', startedAt: 121_000, gapMs: 120_000 },
+    ];
+
+    render(<LiveTranscript langCode="en" />);
+
+    expect(pauseLabels()).toEqual(['Pause · 2m']);
+  });
+
+  it('breaks at the threshold but not just below it', () => {
+    segments.current = [
+      { text: 'One.', startedAt: 0 },
+      { text: 'Two.', startedAt: 1, gapMs: TRANSCRIPT_PAUSE_MS - 1 },
+      { text: 'Three.', startedAt: 2, gapMs: TRANSCRIPT_PAUSE_MS },
+    ];
+
+    render(<LiveTranscript langCode="en" />);
+
+    // Only the third utterance gets a break; all three still render.
+    expect(pauseLabels()).toHaveLength(1);
+    expect(screen.getByText('Two.')).toBeTruthy();
+    expect(screen.getByText('Three.')).toBeTruthy();
+  });
+
+  it('never breaks before the first utterance, which has no preceding silence', () => {
+    segments.current = [{ text: 'Good morning.', startedAt: 1000 }];
+
+    render(<LiveTranscript langCode="en" />);
+
+    expect(pauseLabels()).toEqual([]);
+  });
+
+  it('renders a pre-segments transcript, which carries no timings at all', () => {
+    segments.current = [{ text: 'The Lord is my shepherd.' }, { text: 'I shall not want.' }];
+
+    render(<LiveTranscript langCode="en" />);
+
+    expect(screen.getByText('I shall not want.')).toBeTruthy();
+    expect(pauseLabels()).toEqual([]);
+  });
+
+  it('shows the waiting message when the transcript is empty', () => {
+    render(<LiveTranscript langCode="en" />);
+
+    expect(screen.getByText('Waiting for translated speech…')).toBeTruthy();
+    expect(pauseLabels()).toEqual([]);
+  });
+});

--- a/src/LiveTranscript.tsx
+++ b/src/LiveTranscript.tsx
@@ -1,44 +1,66 @@
 // LiveTranscript: renders the live transcript for one language code, read
-// straight from the shared Yjs doc (`liveTranscript-{code}`). The server-side
-// translator bridge writes that text one delta at a time as a continuous,
-// append-only stream, so this is the single source of truth and gives late
-// joiners the full history.
+// straight from the shared Yjs doc (`liveTranscriptSegments-{code}`). The
+// server-side translator bridge writes that array one delta at a time as an
+// append-only stream of utterances, so this is the single source of truth and gives
+// late joiners the full history.
+//
+// Each segment carries how much silence preceded it, measured server-side at write
+// time (see live-audio/transcript-writer.ts). A long enough gap renders as a break
+// between utterances, so a reader can tell "the speaker stopped for a while" from
+// "these two sentences ran together" — which unbroken text can't express.
 //
 // Deliberately free of any LiveKit dependency: the transcript shows immediately
 // for any viewer — a listener (whether or not they've started audio) or the
 // broadcaster — because reading it needs only the Yjs connection, not the audio
 // room.
-import { useMemo, useRef, useState } from "react";
-import { useStrings } from "./useLocale";
-import { useAsPlainText } from "./yjsUtils";
+import { Fragment, useRef, useState } from "react";
+import { useStrings, resolveLocale } from "./useLocale";
+import { useTranscriptSegments } from "./useTranscriptSegments";
+import { formatPauseGap, isLongPause, type TranscriptSegment } from "./transcriptKeys";
 import { useStickToBottom } from "./reactUtils";
 
-// One finalized transcript paragraph. Mounting fresh (only appended segments do)
+// One finalized transcript segment. Mounting fresh (only appended segments do)
 // plays a one-shot highlight animation, so new text is gently emphasized without
-// any diffing — the Yjs text is append-only.
-function TranscriptSegment({ text, isNew }: { text: string; isNew: boolean }) {
+// any diffing — the Yjs array is append-only.
+function TranscriptSegmentView({ text, isNew }: { text: string; isNew: boolean }) {
   return <p className={`my-2 ${isNew ? "transcript-new" : ""}`}>{text}</p>;
+}
+
+// The silence before a segment, as a rule with the duration on it. Rendered between
+// utterances rather than attached to one, because that's what it describes.
+function PauseDivider({ gapMs }: { gapMs: number }) {
+  const s = useStrings();
+  const label = `${s.transcriptPause} · ${formatPauseGap(gapMs, resolveLocale())}`;
+  return (
+    <div
+      className="flex items-center gap-3 my-5 select-none"
+      role="separator"
+      aria-label={label}
+    >
+      <span className="flex-1 border-t border-dashed border-gray-300 dark:border-gray-600" />
+      <span className="text-xs uppercase tracking-wide text-gray-400 dark:text-gray-500 tabular-nums">
+        {label}
+      </span>
+      <span className="flex-1 border-t border-dashed border-gray-300 dark:border-gray-600" />
+    </div>
+  );
 }
 
 export function LiveTranscript({ langCode }: { langCode: string }) {
   const s = useStrings();
-  const [finalized] = useAsPlainText(`liveTranscript-${langCode}`);
+  const segments: TranscriptSegment[] = useTranscriptSegments(langCode);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const contentEndRef = useRef<HTMLDivElement | null>(null);
-
-  const segments = useMemo(
-    () => finalized.split("\n\n").map((t) => t.trim()).filter(Boolean),
-    [finalized]
-  );
 
   // Segments present at first render aren't animated; only later-appended ones are.
   // Captured once via a lazy initializer (reading a ref during render is unsafe).
   const [baselineCount] = useState(() => segments.length);
 
-  // Key on the raw text, not segments.length: deltas stream into the *current*
-  // paragraph without adding a segment, so keying on the count would only
-  // re-stick at sentence boundaries and let mid-sentence text scroll off-screen.
-  const { pinned, scrollToEnd } = useStickToBottom(scrollRef, contentEndRef, [finalized]);
+  // Key on the total text length, not segments.length: deltas stream into the
+  // *current* segment without adding one, so keying on the count would only re-stick
+  // at utterance boundaries and let mid-sentence text scroll off-screen.
+  const textLength = segments.reduce((n, seg) => n + seg.text.length, 0);
+  const { pinned, scrollToEnd } = useStickToBottom(scrollRef, contentEndRef, [textLength]);
 
   const hasContent = segments.length > 0;
 
@@ -50,13 +72,17 @@ export function LiveTranscript({ langCode }: { langCode: string }) {
       >
         {hasContent ? (
           <div className="mx-auto max-w-[60ch] text-lg leading-relaxed">
-            {segments.map((seg, i) => (
-              <TranscriptSegment
-                key={`${i}-${seg.slice(0, 16)}`}
-                text={seg}
-                isNew={i >= baselineCount}
-              />
-            ))}
+            {segments.map((seg, i) => {
+              // Fragment, not a wrapper element: the paragraphs' vertical margins
+              // collapse against each other, and boxing each one would double the gaps.
+              const pauseBefore = isLongPause(seg) ? seg.gapMs : undefined;
+              return (
+                <Fragment key={`${i}-${seg.text.slice(0, 16)}`}>
+                  {pauseBefore !== undefined && <PauseDivider gapMs={pauseBefore} />}
+                  <TranscriptSegmentView text={seg.text} isNew={i >= baselineCount} />
+                </Fragment>
+              );
+            })}
             <div ref={contentEndRef} />
           </div>
         ) : (

--- a/src/TranscriptHealth.tsx
+++ b/src/TranscriptHealth.tsx
@@ -7,11 +7,10 @@
 //
 // Two things worth knowing about the freshness signal:
 //   - "updated Ns ago" is measured client-side from when a delta is observed while
-//     this view is mounted. It's relative to the page, not absolute wall-clock. (Now
-//     that segments carry `startedAt`, the pre-page-load write time *is* recoverable
-//     — but a segment's start isn't its last delta, so seeding from it would
-//     over-report staleness on a segment that's still streaming. Left alone: for "is
-//     it moving now", observing deltas is the right signal.)
+//     this view is mounted. It's relative to the page, not absolute wall-clock. Segments
+//     now carry `endedAt` — the exact time of the last delta — so seeding this from the
+//     last segment would give a true cross-page-load clock. Not done here only to keep
+//     the pause-indicator change scoped; it's a small, self-contained follow-up.
 //   - The initial sync populate fires one observe with the full backlog; that isn't
 //     a live delta, so each tile ignores its first observed value.
 import { useEffect, useMemo, useRef, useState } from 'react';

--- a/src/TranscriptHealth.tsx
+++ b/src/TranscriptHealth.tsx
@@ -1,27 +1,29 @@
 // TranscriptHealth: an operator-facing liveness view of the live speech-translation
 // transcripts, for the session status page. It answers "is translation actually
 // flowing right now, and into which languages?" by reading the same
-// `liveTranscript-{code}` Y.Text streams the product itself renders (see
+// `liveTranscriptSegments-{code}` streams the product itself renders (see
 // LiveTranscript.tsx and OBSERVABILITY.md §4 — transcript growth is the one
 // end-to-end heartbeat no single component can fake).
 //
 // Two things worth knowing about the freshness signal:
-//   - Yjs Y.Text carries no timestamp, so "updated Ns ago" is measured client-side
-//     from when a delta is observed while this view is mounted. It's relative to the
-//     page, not absolute wall-clock — you can't recover the last-write time from
-//     before you opened the page. For "is it moving now" that's the right signal.
+//   - "updated Ns ago" is measured client-side from when a delta is observed while
+//     this view is mounted. It's relative to the page, not absolute wall-clock. (Now
+//     that segments carry `startedAt`, the pre-page-load write time *is* recoverable
+//     — but a segment's start isn't its last delta, so seeding from it would
+//     over-report staleness on a segment that's still streaming. Left alone: for "is
+//     it moving now", observing deltas is the right signal.)
 //   - The initial sync populate fires one observe with the full backlog; that isn't
 //     a live delta, so each tile ignores its first observed value.
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useYDoc } from '@y-sweet/react';
 import type * as Y from 'yjs';
-import { useAsPlainText } from './yjsUtils';
 import { useStrings, resolveLocale } from './useLocale';
+import { useTranscriptSegments } from './useTranscriptSegments';
 import {
-  LIVE_TRANSCRIPT_PREFIX,
   LIVE_TRANSCRIPT_SOURCE_CODE,
   liveTranscriptCodes,
   liveTranscriptLabel,
+  transcriptPlainText,
 } from './transcriptKeys';
 
 /** Freshness thresholds (ms) for the staleness dot. */
@@ -66,7 +68,10 @@ function tail(text: string): string {
 
 function TranscriptHealthTile({ code }: { code: string }) {
   const s = useStrings();
-  const [text] = useAsPlainText(`${LIVE_TRANSCRIPT_PREFIX}${code}`);
+  const segments = useTranscriptSegments(code);
+  // Flattened for the char count and tail preview — this view is about whether the
+  // transcript is *moving*, not about its structure, so the segmentation is noise here.
+  const text = useMemo(() => transcriptPlainText(segments), [segments]);
   const isSource = code === LIVE_TRANSCRIPT_SOURCE_CODE;
 
   // Record when a *live* delta arrives. The first observed value is the initial

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -45,6 +45,9 @@ export interface AppStrings {
   // Stick-to-bottom scrolling (BilingualBlockViewer, LiveTranscript)
   jumpToLatest: string;
 
+  // Live transcript: label on the break shown for a long silence
+  transcriptPause: string;
+
   // Slide viewer
   noSlides: string;
   waitingForProclaim: string;
@@ -152,6 +155,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     noContent: 'No content yet',
     notTranslated: '(not translated)',
     jumpToLatest: '↓ New',
+    transcriptPause: 'Pause',
     listenLive: 'Listen live',
     stopAudio: 'Stop audio',
     englishTranscript: 'English transcript',
@@ -246,6 +250,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     noContent: 'Aucun contenu pour l\u2019instant',
     notTranslated: '(non traduit)',
     jumpToLatest: '\u2193 Nouveau',
+    transcriptPause: 'Pause',
     listenLive: 'Écouter en direct',
     stopAudio: 'Couper le son',
     englishTranscript: 'Transcription anglaise',
@@ -340,6 +345,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     noContent: 'Sin contenido a\u00fan',
     notTranslated: '(no traducido)',
     jumpToLatest: '\u2193 Nuevo',
+    transcriptPause: 'Pausa',
     listenLive: 'Escuchar en vivo',
     stopAudio: 'Detener audio',
     englishTranscript: 'Transcripción en inglés',
@@ -434,6 +440,7 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     noContent: 'Pa gen kontni pou kounye a',
     notTranslated: '(pa tradui)',
     jumpToLatest: '↓ Nouvo',
+    transcriptPause: 'Poz',
     listenLive: 'Koute an dirèk',
     stopAudio: 'Sispann odyo',
     englishTranscript: 'Transkripsyon anglè',

--- a/src/transcriptKeys.test.ts
+++ b/src/transcriptKeys.test.ts
@@ -1,15 +1,36 @@
 import { describe, it, expect } from 'vitest';
 import * as Y from 'yjs';
-import { liveTranscriptCodes } from './transcriptKeys';
+import {
+  TRANSCRIPT_PAUSE_MS,
+  formatPauseGap,
+  isLongPause,
+  liveTranscriptCodes,
+  readTranscriptSegments,
+  transcriptPlainText,
+  transcriptSegmentsKey,
+} from './transcriptKeys';
+
+/** Write a segment the way live-audio/transcript-writer.ts does. */
+function pushSegment(
+  doc: Y.Doc,
+  code: string,
+  fields: { text: string; startedAt?: number; gapMs?: number },
+) {
+  const segment = new Y.Map<unknown>();
+  doc.getArray<Y.Map<unknown>>(transcriptSegmentsKey(code)).push([segment]);
+  if (fields.startedAt !== undefined) segment.set('startedAt', fields.startedAt);
+  if (fields.gapMs !== undefined) segment.set('gapMs', fields.gapMs);
+  segment.set('text', new Y.Text(fields.text));
+}
 
 describe('liveTranscriptCodes', () => {
-  it('discovers only liveTranscript-* root types, English source first', () => {
+  it('discovers only transcript root types, English source first', () => {
     const doc = new Y.Doc();
-    // Touching a Y.Text registers the root type in doc.share, mirroring what the
-    // transcript writer does on the server as each language comes online.
-    doc.getText('liveTranscript-fr').insert(0, 'bonjour');
-    doc.getText('liveTranscript-en').insert(0, 'hello');
-    doc.getText('liveTranscript-es').insert(0, 'hola');
+    // Touching a root type registers it in doc.share, mirroring what the transcript
+    // writer does on the server as each language comes online.
+    pushSegment(doc, 'fr', { text: 'bonjour' });
+    pushSegment(doc, 'en', { text: 'hello' });
+    pushSegment(doc, 'es', { text: 'hola' });
     doc.getText('sourceBlocks'); // unrelated root type — must be ignored
     doc.getMap('proclaimStatus');
 
@@ -26,10 +47,102 @@ describe('liveTranscriptCodes', () => {
 
   it('picks up a language that appears after the first scan', () => {
     const doc = new Y.Doc();
-    doc.getText('liveTranscript-en').insert(0, 'hello');
+    pushSegment(doc, 'en', { text: 'hello' });
     expect(liveTranscriptCodes(doc)).toEqual(['en']);
 
-    doc.getText('liveTranscript-ht').insert(0, 'bonjou');
+    pushSegment(doc, 'ht', { text: 'bonjou' });
     expect(liveTranscriptCodes(doc)).toEqual(['en', 'ht']);
+  });
+
+  it('still finds a pre-segments session, whose transcript is a flat Y.Text', () => {
+    const doc = new Y.Doc();
+    doc.getText('liveTranscript-en').insert(0, 'hello');
+    doc.getText('liveTranscript-fr').insert(0, 'bonjour');
+
+    expect(liveTranscriptCodes(doc)).toEqual(['en', 'fr']);
+  });
+
+  it('lists a language once when it has both a segments array and a legacy Y.Text', () => {
+    const doc = new Y.Doc();
+    doc.getText('liveTranscript-en').insert(0, 'hello');
+    pushSegment(doc, 'en', { text: 'hello again' });
+
+    expect(liveTranscriptCodes(doc)).toEqual(['en']);
+  });
+});
+
+describe('readTranscriptSegments', () => {
+  it('reads segments with their timing', () => {
+    const doc = new Y.Doc();
+    pushSegment(doc, 'en', { text: 'Good morning.', startedAt: 1000 });
+    pushSegment(doc, 'en', { text: 'Let us pray.', startedAt: 61_000, gapMs: 55_000 });
+
+    expect(readTranscriptSegments(doc, 'en')).toEqual([
+      { text: 'Good morning.', startedAt: 1000 },
+      { text: 'Let us pray.', startedAt: 61_000, gapMs: 55_000 },
+    ]);
+  });
+
+  it('skips segments with no text, so a half-written one never renders blank', () => {
+    const doc = new Y.Doc();
+    pushSegment(doc, 'en', { text: 'Real text.', startedAt: 1000 });
+    pushSegment(doc, 'en', { text: '   ', startedAt: 2000 });
+
+    expect(readTranscriptSegments(doc, 'en').map((s) => s.text)).toEqual(['Real text.']);
+  });
+
+  it('returns nothing for a language with no transcript', () => {
+    expect(readTranscriptSegments(new Y.Doc(), 'en')).toEqual([]);
+  });
+
+  // Sessions recorded before segments existed hold one flat Y.Text with blank lines
+  // between utterances. They carry no timing, but their text must still come back.
+  it('falls back to a pre-segments transcript, splitting it on blank lines', () => {
+    const doc = new Y.Doc();
+    doc.getText('liveTranscript-en').insert(0, 'The Lord is my shepherd.\n\nI shall not want.\n\n');
+
+    expect(readTranscriptSegments(doc, 'en')).toEqual([
+      { text: 'The Lord is my shepherd.' },
+      { text: 'I shall not want.' },
+    ]);
+  });
+
+  it('prefers segments over the legacy Y.Text when both exist', () => {
+    const doc = new Y.Doc();
+    doc.getText('liveTranscript-en').insert(0, 'stale');
+    pushSegment(doc, 'en', { text: 'current', startedAt: 1000 });
+
+    expect(readTranscriptSegments(doc, 'en').map((s) => s.text)).toEqual(['current']);
+  });
+});
+
+describe('isLongPause', () => {
+  it('is true only at or above the threshold', () => {
+    expect(isLongPause({ text: 'x', gapMs: TRANSCRIPT_PAUSE_MS })).toBe(true);
+    expect(isLongPause({ text: 'x', gapMs: TRANSCRIPT_PAUSE_MS - 1 })).toBe(false);
+  });
+
+  it('is false when no gap was recorded (first segment, or a legacy transcript)', () => {
+    expect(isLongPause({ text: 'x' })).toBe(false);
+  });
+});
+
+describe('formatPauseGap', () => {
+  it('reports short pauses in seconds', () => {
+    expect(formatPauseGap(12_000, 'en-US')).toBe('12s');
+  });
+
+  it('switches to minutes once seconds stop being readable', () => {
+    expect(formatPauseGap(240_000, 'en-US')).toBe('4m');
+  });
+
+  it('localizes the unit', () => {
+    expect(formatPauseGap(12_000, 'fr-FR')).toContain('12');
+  });
+});
+
+describe('transcriptPlainText', () => {
+  it('joins utterances with a blank line between them', () => {
+    expect(transcriptPlainText([{ text: 'One.' }, { text: 'Two.' }])).toBe('One.\n\nTwo.');
   });
 });

--- a/src/transcriptKeys.test.ts
+++ b/src/transcriptKeys.test.ts
@@ -10,16 +10,19 @@ import {
   transcriptSegmentsKey,
 } from './transcriptKeys';
 
-/** Write a segment the way live-audio/transcript-writer.ts does. */
+/**
+ * Write a segment the way live-audio/transcript-writer.ts does. Only observations go in
+ * — `startedAt`/`endedAt` — because the gap is derived, so a test can't hand-wave it.
+ */
 function pushSegment(
   doc: Y.Doc,
   code: string,
-  fields: { text: string; startedAt?: number; gapMs?: number },
+  fields: { text: string; startedAt?: number; endedAt?: number },
 ) {
   const segment = new Y.Map<unknown>();
   doc.getArray<Y.Map<unknown>>(transcriptSegmentsKey(code)).push([segment]);
   if (fields.startedAt !== undefined) segment.set('startedAt', fields.startedAt);
-  if (fields.gapMs !== undefined) segment.set('gapMs', fields.gapMs);
+  if (fields.endedAt !== undefined) segment.set('endedAt', fields.endedAt ?? fields.startedAt);
   segment.set('text', new Y.Text(fields.text));
 }
 
@@ -72,15 +75,32 @@ describe('liveTranscriptCodes', () => {
 });
 
 describe('readTranscriptSegments', () => {
-  it('reads segments with their timing', () => {
+  it('reads segments with their timing, deriving the gap between them', () => {
     const doc = new Y.Doc();
-    pushSegment(doc, 'en', { text: 'Good morning.', startedAt: 1000 });
-    pushSegment(doc, 'en', { text: 'Let us pray.', startedAt: 61_000, gapMs: 55_000 });
+    pushSegment(doc, 'en', { text: 'Good morning.', startedAt: 1000, endedAt: 6000 });
+    pushSegment(doc, 'en', { text: 'Let us pray.', startedAt: 61_000, endedAt: 63_000 });
 
     expect(readTranscriptSegments(doc, 'en')).toEqual([
-      { text: 'Good morning.', startedAt: 1000 },
-      { text: 'Let us pray.', startedAt: 61_000, gapMs: 55_000 },
+      { text: 'Good morning.', startedAt: 1000, endedAt: 6000 },
+      // 61s − 6s: measured from the end of the previous utterance, not its start
+      // (which would report 60s and count the five seconds spent speaking it).
+      { text: 'Let us pray.', startedAt: 61_000, endedAt: 63_000, gapMs: 55_000 },
     ]);
+  });
+
+  it('falls back to the previous segment start when it never recorded an end', () => {
+    const doc = new Y.Doc();
+    pushSegment(doc, 'en', { text: 'One delta only.', startedAt: 1000 });
+    pushSegment(doc, 'en', { text: 'Later.', startedAt: 31_000, endedAt: 31_000 });
+
+    expect(readTranscriptSegments(doc, 'en')[1].gapMs).toBe(30_000);
+  });
+
+  it('leaves the first segment without a gap, having nothing to measure from', () => {
+    const doc = new Y.Doc();
+    pushSegment(doc, 'en', { text: 'Good morning.', startedAt: 1000, endedAt: 2000 });
+
+    expect(readTranscriptSegments(doc, 'en')[0].gapMs).toBeUndefined();
   });
 
   it('skips segments with no text, so a half-written one never renders blank', () => {
@@ -113,6 +133,17 @@ describe('readTranscriptSegments', () => {
     pushSegment(doc, 'en', { text: 'current', startedAt: 1000 });
 
     expect(readTranscriptSegments(doc, 'en').map((s) => s.text)).toEqual(['current']);
+  });
+
+  it('spans a skipped empty segment rather than losing the silence around it', () => {
+    const doc = new Y.Doc();
+    pushSegment(doc, 'en', { text: 'Before.', startedAt: 1000, endedAt: 2000 });
+    pushSegment(doc, 'en', { text: '  ', startedAt: 30_000, endedAt: 30_000 });
+    pushSegment(doc, 'en', { text: 'After.', startedAt: 62_000, endedAt: 63_000 });
+
+    const segments = readTranscriptSegments(doc, 'en');
+    expect(segments.map((s) => s.text)).toEqual(['Before.', 'After.']);
+    expect(segments[1].gapMs).toBe(60_000); // 62s − 2s, not 62s − 30s
   });
 });
 

--- a/src/transcriptKeys.ts
+++ b/src/transcriptKeys.ts
@@ -35,18 +35,49 @@ export const TRANSCRIPT_PAUSE_MS = 10_000;
  * One utterance of a transcript. The writer opens a segment on the first delta
  * after a sentence ends or after a long silence, so segment boundaries are exactly
  * where a pause can be reported.
+ *
+ * Only observations are stored — when the utterance started and when it last grew.
+ * The silence between utterances is derived from those (see `gapMs`), so it can't
+ * drift out of agreement with them, and so the writer can recover its own state from
+ * the doc rather than holding it in memory across a restart.
  */
 export interface TranscriptSegment {
   text: string;
   /** Epoch ms of this segment's first delta; undefined for legacy transcripts. */
   startedAt?: number;
+  /** Epoch ms of this segment's most recent delta; undefined for legacy transcripts. */
+  endedAt?: number;
   /**
-   * Silence (ms) between the previous delta — in this language — and this segment's
-   * first one. Undefined for the first segment of a transcript and for legacy ones.
-   * Measured against the last delta rather than the previous segment's start, so a
-   * long utterance is never mistaken for a pause.
+   * DERIVED, not stored: silence (ms) between the previous segment's last delta and
+   * this one's first. Undefined for the first segment of a transcript and for legacy
+   * ones. Measured from the previous segment's *end* rather than its start, so a long
+   * utterance is never mistaken for a pause.
    */
   gapMs?: number;
+}
+
+/** The stored fields of one segment Y.Map, read in one place so the writer and reader agree. */
+export function readSegmentFields(segment: Y.Map<unknown>): {
+  text: string;
+  startedAt?: number;
+  endedAt?: number;
+} {
+  const startedAt = segment.get('startedAt');
+  const endedAt = segment.get('endedAt');
+  return {
+    text: yTextValue(segment.get('text')),
+    ...(typeof startedAt === 'number' ? { startedAt } : {}),
+    ...(typeof endedAt === 'number' ? { endedAt } : {}),
+  };
+}
+
+/**
+ * When a segment last grew — the reference point for the silence that follows it.
+ * Falls back to its start, which is the same thing for a one-delta segment.
+ */
+export function segmentLastActivityAt(segment: Y.Map<unknown>): number | undefined {
+  const { startedAt, endedAt } = readSegmentFields(segment);
+  return endedAt ?? startedAt;
 }
 
 /** Whether the silence before this segment is worth marking in the UI. */
@@ -65,19 +96,34 @@ export function readTranscriptSegments(doc: Y.Doc, code: string): TranscriptSegm
   return legacySegments(doc, code);
 }
 
-/** Project a segments Y.Array into plain objects. Split out for the client's snapshot cache. */
+/**
+ * Project a segments Y.Array into plain objects, deriving each gap from the previous
+ * segment's end. Split out for the client's snapshot cache.
+ *
+ * The gap is computed against the previous *emitted* segment, so a skipped empty one
+ * (which the writer never produces, but a partially-synced doc might momentarily show)
+ * widens the gap rather than hiding the silence on either side of it.
+ */
 export function segmentsFromArray(yArray: Y.Array<Y.Map<unknown>>): TranscriptSegment[] {
   const segments: TranscriptSegment[] = [];
+  let previousEndedAt: number | undefined;
+
   for (const yMap of yArray.toArray()) {
-    const text = yTextValue(yMap.get('text')).trim();
-    if (text === '') continue;
-    const startedAt = yMap.get('startedAt');
-    const gapMs = yMap.get('gapMs');
+    const { text, startedAt, endedAt } = readSegmentFields(yMap);
+    const trimmed = text.trim();
+    if (trimmed === '') continue;
+
+    const gapMs =
+      startedAt !== undefined && previousEndedAt !== undefined
+        ? Math.max(0, startedAt - previousEndedAt)
+        : undefined;
     segments.push({
-      text,
-      ...(typeof startedAt === 'number' ? { startedAt } : {}),
-      ...(typeof gapMs === 'number' ? { gapMs } : {}),
+      text: trimmed,
+      ...(startedAt !== undefined ? { startedAt } : {}),
+      ...(endedAt !== undefined ? { endedAt } : {}),
+      ...(gapMs !== undefined ? { gapMs } : {}),
     });
+    previousEndedAt = endedAt ?? startedAt;
   }
   return segments;
 }

--- a/src/transcriptKeys.ts
+++ b/src/transcriptKeys.ts
@@ -1,14 +1,123 @@
 // Shared primitives for the live speech-translation transcripts. The pipeline
-// publishes each language into a `liveTranscript-{code}` Y.Text (see
+// publishes each language into a `liveTranscriptSegments-{code}` Y.Array (see
 // live-audio/transcript-writer.ts); both the client (LiveTranscript,
 // TranscriptHealth) and the server-side session export need to agree on that
-// namespace and on how to label a code. Kept free of any runtime dependency (the
-// Y import is type-only) so either side can import it without pulling the other's
-// bundle in.
+// namespace, on the segment shape, and on how to label a code. Kept free of any
+// runtime dependency (the Y import is type-only) so either side can import it
+// without pulling the other's bundle in.
 import type * as Y from 'yjs';
 
-/** Prefix the live-audio pipeline uses for per-language transcript Y.Text keys. */
+/**
+ * Legacy prefix: transcripts used to be one flat, append-only Y.Text per language,
+ * with `\n\n` between utterances and no timestamps anywhere. Sessions recorded
+ * before the move to segments still hold their transcript here, so the reader below
+ * falls back to it — nothing writes it any more.
+ */
 export const LIVE_TRANSCRIPT_PREFIX = 'liveTranscript-';
+
+/** Prefix the live-audio pipeline uses for per-language transcript Y.Array keys. */
+export const LIVE_TRANSCRIPT_SEGMENTS_PREFIX = 'liveTranscriptSegments-';
+
+/** Root-type key holding one language's transcript segments. */
+export function transcriptSegmentsKey(code: string): string {
+  return `${LIVE_TRANSCRIPT_SEGMENTS_PREFIX}${code}`;
+}
+
+/**
+ * Silence long enough to be worth showing the reader as a break rather than
+ * letting two unrelated utterances run together. Also the writer's threshold for
+ * splitting a segment mid-sentence, so it bounds what a gap can even be attributed
+ * to: shorter pauses are still recorded, they just fall inside a segment.
+ */
+export const TRANSCRIPT_PAUSE_MS = 10_000;
+
+/**
+ * One utterance of a transcript. The writer opens a segment on the first delta
+ * after a sentence ends or after a long silence, so segment boundaries are exactly
+ * where a pause can be reported.
+ */
+export interface TranscriptSegment {
+  text: string;
+  /** Epoch ms of this segment's first delta; undefined for legacy transcripts. */
+  startedAt?: number;
+  /**
+   * Silence (ms) between the previous delta — in this language — and this segment's
+   * first one. Undefined for the first segment of a transcript and for legacy ones.
+   * Measured against the last delta rather than the previous segment's start, so a
+   * long utterance is never mistaken for a pause.
+   */
+  gapMs?: number;
+}
+
+/** Whether the silence before this segment is worth marking in the UI. */
+export function isLongPause(segment: TranscriptSegment): boolean {
+  return segment.gapMs !== undefined && segment.gapMs >= TRANSCRIPT_PAUSE_MS;
+}
+
+/**
+ * Read one language's transcript. Falls back to the legacy flat Y.Text (split on
+ * blank lines, no timing) when no segments exist, so exports and viewers of older
+ * sessions still show their transcript.
+ */
+export function readTranscriptSegments(doc: Y.Doc, code: string): TranscriptSegment[] {
+  const segments = segmentsFromArray(doc.getArray<Y.Map<unknown>>(transcriptSegmentsKey(code)));
+  if (segments.length > 0) return segments;
+  return legacySegments(doc, code);
+}
+
+/** Project a segments Y.Array into plain objects. Split out for the client's snapshot cache. */
+export function segmentsFromArray(yArray: Y.Array<Y.Map<unknown>>): TranscriptSegment[] {
+  const segments: TranscriptSegment[] = [];
+  for (const yMap of yArray.toArray()) {
+    const text = yTextValue(yMap.get('text')).trim();
+    if (text === '') continue;
+    const startedAt = yMap.get('startedAt');
+    const gapMs = yMap.get('gapMs');
+    segments.push({
+      text,
+      ...(typeof startedAt === 'number' ? { startedAt } : {}),
+      ...(typeof gapMs === 'number' ? { gapMs } : {}),
+    });
+  }
+  return segments;
+}
+
+/** The pre-segments representation: one Y.Text, utterances separated by blank lines. */
+function legacySegments(doc: Y.Doc, code: string): TranscriptSegment[] {
+  return yTextValue(doc.getText(`${LIVE_TRANSCRIPT_PREFIX}${code}`))
+    .split('\n\n')
+    .map((text) => text.trim())
+    .filter((text) => text !== '')
+    .map((text) => ({ text }));
+}
+
+/**
+ * Stringify a Y.Text field. Yjs doesn't declare Y.Text's (working) toString()
+ * override, hence the disable — same reason as yjsUtils.yTextToString, repeated here
+ * because this module can't take a runtime dependency on the client's utils.
+ */
+function yTextValue(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string
+  return String(value);
+}
+
+/** Flatten segments back to plain text, blank line between utterances. */
+export function transcriptPlainText(segments: TranscriptSegment[]): string {
+  return segments.map((s) => s.text).join('\n\n');
+}
+
+/**
+ * A pause length for display: rounded to a single unit, since "about how long was
+ * the silence" is all the indicator claims. Localized via Intl rather than hard-coded
+ * "s"/"m" suffixes.
+ */
+export function formatPauseGap(gapMs: number, locale: string): string {
+  const seconds = Math.max(0, Math.round(gapMs / 1000));
+  const format = (value: number, unit: 'second' | 'minute') =>
+    new Intl.NumberFormat(locale, { style: 'unit', unit, unitDisplay: 'narrow' }).format(value);
+  return seconds < 90 ? format(seconds, 'second') : format(Math.round(seconds / 60), 'minute');
+}
 
 /** Code of the English source transcript (matches TranslationBridge.SOURCE_CODE). */
 export const LIVE_TRANSCRIPT_SOURCE_CODE = 'en';
@@ -24,15 +133,24 @@ export function liveTranscriptLabel(code: string): string {
   }
 }
 
-/** Scan a doc's root types for the transcript codes present, English source first. */
+/**
+ * Scan a doc's root types for the transcript codes present, English source first.
+ * Both namespaces count: a session recorded before segments existed has only the
+ * legacy Y.Text, and `readTranscriptSegments` will read it.
+ */
 export function liveTranscriptCodes(doc: Y.Doc): string[] {
-  const codes: string[] = [];
+  const codes = new Set<string>();
   for (const key of doc.share.keys()) {
-    if (key.startsWith(LIVE_TRANSCRIPT_PREFIX)) {
-      codes.push(key.slice(LIVE_TRANSCRIPT_PREFIX.length));
+    // Order matters: `liveTranscriptSegments-` is not a `liveTranscript-` key
+    // (the char after the prefix is 'S', not '-'), but check the longer one first
+    // anyway so this stays correct if either prefix is ever renamed.
+    if (key.startsWith(LIVE_TRANSCRIPT_SEGMENTS_PREFIX)) {
+      codes.add(key.slice(LIVE_TRANSCRIPT_SEGMENTS_PREFIX.length));
+    } else if (key.startsWith(LIVE_TRANSCRIPT_PREFIX)) {
+      codes.add(key.slice(LIVE_TRANSCRIPT_PREFIX.length));
     }
   }
-  return codes.sort((a, b) => {
+  return [...codes].sort((a, b) => {
     const aSource = a === LIVE_TRANSCRIPT_SOURCE_CODE;
     const bSource = b === LIVE_TRANSCRIPT_SOURCE_CODE;
     if (aSource !== bSource) return aSource ? -1 : 1;

--- a/src/transcriptKeys.ts
+++ b/src/transcriptKeys.ts
@@ -32,6 +32,25 @@ export function transcriptSegmentsKey(code: string): string {
 export const TRANSCRIPT_PAUSE_MS = 10_000;
 
 /**
+ * How coarsely a segment's `endedAt` tracks its last delta, and therefore the accuracy
+ * of a derived gap. Not a display choice — a wire-size one.
+ *
+ * Yjs merges consecutive same-client appends to a Y.Text into one item, but only while
+ * their clocks stay adjacent. Any other write from the same client in between — including
+ * a timestamp on the enclosing Y.Map — splits the run. Stamping `endedAt` on every delta
+ * therefore cost far more than the timestamps themselves: measured over an hour-long
+ * transcript it left 5400 text items instead of 600, and roughly doubled both the live
+ * update traffic and the stored doc (222 KB vs 97 KB, for 53 KB of actual text).
+ *
+ * So `endedAt` is only rewritten once the stored value is this stale — except on a delta
+ * that ends a sentence, which is the segment's last delta in the ordinary case and is
+ * always stamped exactly. That leaves the error only on pause-split boundaries, where the
+ * gap is at least TRANSCRIPT_PAUSE_MS anyway, so a gap may be *over*-reported by up to
+ * this much and never under-reported.
+ */
+export const TRANSCRIPT_ENDED_AT_RESOLUTION_MS = 1_000;
+
+/**
  * One utterance of a transcript. The writer opens a segment on the first delta
  * after a sentence ends or after a long silence, so segment boundaries are exactly
  * where a pause can be reported.
@@ -51,7 +70,8 @@ export interface TranscriptSegment {
    * DERIVED, not stored: silence (ms) between the previous segment's last delta and
    * this one's first. Undefined for the first segment of a transcript and for legacy
    * ones. Measured from the previous segment's *end* rather than its start, so a long
-   * utterance is never mistaken for a pause.
+   * utterance is never mistaken for a pause. Accurate to
+   * TRANSCRIPT_ENDED_AT_RESOLUTION_MS, and only ever in the over-reporting direction.
    */
   gapMs?: number;
 }

--- a/src/useTranscriptSegments.ts
+++ b/src/useTranscriptSegments.ts
@@ -1,0 +1,68 @@
+// Reading side of the live transcript store: subscribe to one language's
+// `liveTranscriptSegments-{code}` Y.Array and hand components plain segment objects.
+// Shared by LiveTranscript (the reader-facing view) and TranscriptHealth (the
+// operator one) so both see the same shape; the Yjs contract itself lives in
+// transcriptKeys.ts, alongside the writer's half of it.
+import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
+import { useYDoc } from '@y-sweet/react';
+import type * as Y from 'yjs';
+import {
+  LIVE_TRANSCRIPT_PREFIX,
+  readTranscriptSegments,
+  segmentsFromArray,
+  transcriptSegmentsKey,
+  type TranscriptSegment,
+} from './transcriptKeys';
+
+/**
+ * One language's transcript segments, live. Deltas land inside a segment's nested
+ * Y.Text, so this observes deeply rather than just watching the array's length.
+ *
+ * useSyncExternalStore demands a referentially stable snapshot — returning a freshly
+ * mapped array on every read would loop forever — so the projection is memoized and
+ * invalidated only when Yjs reports a change. The cache is keyed by the Y.Array it was
+ * built from, so switching `code` can't serve the previous language's segments.
+ */
+export function useTranscriptSegments(code: string): TranscriptSegment[] {
+  const doc = useYDoc();
+  const yArray = useMemo(
+    () => doc.getArray<Y.Map<unknown>>(transcriptSegmentsKey(code)),
+    [doc, code],
+  );
+  // Legacy sessions have no segments array, only the flat Y.Text. It's append-only
+  // and no longer written, but observe it too so a viewer opening an old doc renders
+  // once it syncs rather than sitting on the empty first read.
+  const legacyText = useMemo(() => doc.getText(`${LIVE_TRANSCRIPT_PREFIX}${code}`), [doc, code]);
+
+  const cache = useRef<{ source: Y.Array<Y.Map<unknown>>; value: TranscriptSegment[] } | null>(null);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const handler = () => {
+        cache.current = null;
+        onStoreChange();
+      };
+      yArray.observeDeep(handler);
+      legacyText.observe(handler);
+      return () => {
+        yArray.unobserveDeep(handler);
+        legacyText.unobserve(handler);
+      };
+    },
+    [yArray, legacyText],
+  );
+
+  const getSnapshot = useCallback(() => {
+    if (cache.current?.source !== yArray) {
+      // Only the legacy path needs the doc lookup; take the fast path when segments exist.
+      const segments = segmentsFromArray(yArray);
+      cache.current = {
+        source: yArray,
+        value: segments.length > 0 ? segments : readTranscriptSegments(doc, code),
+      };
+    }
+    return cache.current.value;
+  }, [yArray, doc, code]);
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+}


### PR DESCRIPTION
Unbroken transcript text can't distinguish "the speaker stopped for two minutes" from "these two sentences ran together", so a reader joining mid-talk has no way to tell a resumption from a continuation.

## Why the representation had to change

Fixing this needs *time* in the transcript, which the old shape couldn't hold: one flat append-only `liveTranscript-{code}` Y.Text per language, `\n\n` between utterances, no timestamps anywhere. A viewer can only ever time the deltas it was present for — a late joiner, or anyone reading the export, has nothing. So the measurement has to happen where the deltas arrive: server-side, in `transcript-writer.ts`.

The transcript is now **`liveTranscriptSegments-{code}`** — a Y.Array of utterances, each a Y.Map of `{ startedAt, gapMs?, text: Y.Text }`. Deltas still stream verbatim into the open segment (no delete/insert churn); a new segment opens when the previous delta ended a sentence, or when a delta arrives after at least `TRANSCRIPT_PAUSE_MS` (10s) of silence — a long enough gap is itself an utterance boundary, and splitting there is what gives the pause somewhere to be recorded.

`gapMs` is measured against the **previous delta**, not the previous segment's start, so a long sentence is never mistaken for a pause.

## What the reader sees

`LiveTranscript` renders a dashed rule carrying the duration ("Pause · 2m") before any segment whose gap crosses the threshold. The session export renders the same break, so a downloaded transcript reads the way the live one did.

## Notes

- **Old sessions still work.** Segments land under a new root key — Yjs rejects a root-type change on an existing key anyway — so existing docs keep their Y.Text. `readTranscriptSegments` falls back to it (split on blank lines, no timings), and `liveTranscriptCodes` scans both namespaces. Covered by tests in `transcriptKeys.test.ts` and `sessionExport.test.ts`.
- **Segmentation is separated from transport.** The logic moved into `TranscriptSegmentLog`, which the Y-Sweet-attached `TranscriptWriter` composes. "When does a segment open" is now testable against a plain local `Y.Doc` with an injected clock, instead of needing a live provider.
- **A bridge outage produces a long gap too**, and will render as a pause. Arguably useful — it makes a dropout visible rather than silently seamless — but it means a divider is not proof the speaker was silent. Flagged in the smoke test.
- **The 10s threshold is a judgment call**, not a measured one. It's a single exported constant (`TRANSCRIPT_PAUSE_MS`) shared by the writer's split decision and the renderers' display decision, so it moves in one place.
- `TranscriptHealth` migrates to the new store but keeps its existing freshness semantics. Segments now make an absolute last-write clock *possible*, but a segment's `startedAt` isn't its last delta, so seeding from it would over-report staleness on one that's still streaming — left alone deliberately, noted in the code and in OBSERVABILITY.md.

## Testing

`npm test` — 340 pass (was 308). `npm run typecheck` and `npm run lint` clean.

New coverage: writer segmentation and gap attribution (interleaved languages, whitespace-only deltas, threshold boundaries) in `live-audio/transcript-writer.test.ts`; the read contract and legacy fallback in `src/transcriptKeys.test.ts`; divider placement in a new `src/LiveTranscript.test.tsx`; pause rendering and legacy export in `sessionExport.test.ts`.

**SMOKE_TEST.md sections touched: §4 (Live audio translation)** — a pause-indicator check is added there. Not yet run against a real room; the threshold in particular wants a look during an actual talk.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxAJ8oZCR1YjCzbuUCHqpd)_