### PR TITLE
Status page: list connected clients from Yjs awareness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,6 +419,9 @@ The app has two modes determined by URL hash (`#editor`):
 - [BilingualBlockViewer.tsx](src/BilingualBlockViewer.tsx) - Shows blocks with original text and translation side-by-side
 - [BilingualBlockViewerContainer.tsx](src/BilingualBlockViewerContainer.tsx) - Yjs connector for BilingualBlockViewer
 - [CurrentSlideViewer.tsx](src/CurrentSlideViewer.tsx) - Proclaim slide viewer with pure component and Yjs container
+- [ClientPresenceView.tsx](src/ClientPresenceView.tsx) - Status-page list of connected clients (page, device, role), read from Yjs awareness
+- [presence.ts](src/presence.ts) - Pure presence helpers: device classification, awareness-state validation, grouping — plus the constraints that come with riding awareness
+- [usePublishPresence.ts](src/usePublishPresence.ts) - Publishes this client's presence; mounted once in App so it runs on every page
 
 ### TTS System
 - [useTTS.ts](src/useTTS.ts) - Low-level TTS hook managing audio playback lifecycle

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -106,6 +106,28 @@ layout component) is where these signals surface for an operator. Current state:
     from when a delta is observed *while the page is open* — it can't recover the last-write time
     from before you loaded. The initial sync populate is deliberately ignored so a stale backlog
     doesn't read as "just updated." Good for "is it moving now"; not an absolute liveness clock.
+- **Connected clients (built).** [src/ClientPresenceView.tsx](../src/ClientPresenceView.tsx) lists
+  every browser on the session — the page it has open, device class, editor/viewer role, UI locale,
+  and how long it's been connected — grouped by URL so a glance answers "how many people are on the
+  French view right now?". This is a *fifth* source: **Yjs awareness**, distinct from the transcript
+  doc (#4). Notes on why it works and what constrains it:
+  - **No backend, no heartbeat producer.** y-protocols' `Awareness` constructor already calls
+    `setLocalState({})`, so every client announces itself, re-announces every ~15 s, and is dropped
+    after a 30 s timeout. Membership *is* the liveness signal, and the list is self-cleaning.
+  - **Read-only viewers can publish.** y-sweet gates writes on `SyncStep2`/`Update` messages but
+    relays `Message::Awareness` with no authorization check, so the viewers issued read-only tokens
+    in [server.ts](../server.ts) — most of the population — do appear.
+  - **Publish from every page.** `@y-sweet/react`'s `usePresence` skips clients with an empty
+    awareness state, so `PresencePublisher` is mounted above the layout in
+    [src/App.tsx](../src/App.tsx). A corollary: the server-side Yjs writers that use `YSweetProvider`
+    ([transcript-writer.ts](../live-audio/transcript-writer.ts), `slideConversationStore.ts`) stay
+    invisible until they deliberately publish a presence identity — see next steps.
+  - **Every field must be stable per connection.** Awareness re-broadcasts the whole state to every
+    peer on each announce, so a ticking value costs O(n²) messages with a congregation's worth of
+    phones on the doc. `connectedSince` is a fixed instant the viewer subtracts from, never an age.
+  - **Presence is broadcast to everyone**, not only to whoever opened `/status`. Any viewer with
+    devtools can read it, which is why it carries a coarse device class and never the raw
+    user-agent string.
 - **Component health tiles (skeleton).** The Server / Proclaim / bridges / broadcaster tiles are
   still placeholders — nothing writes the `status` Y.Map yet (that's the #72 heartbeat producers).
 - **Preflight canary (skeleton).** Placeholder; no end-to-end check runs yet.
@@ -127,3 +149,10 @@ layout component) is where these signals surface for an operator. Current state:
    translators, so this wants a small new endpoint or field.
 4. **Preflight canary** — a ~30 s end-to-end check run before a service; the `simulateScenario` hook
    on the session manager is a starting point, but wiring a real canary is a feature, not a wire-up.
+5. **Presence identities for the backend Yjs clients** — [transcript-writer.ts](../live-audio/transcript-writer.ts)
+   and `slideConversationStore.ts` already hold `YSweetProvider` connections; having them publish a
+   presence state (`{ role: 'transcript-writer', language }`) would make them real rows in the
+   connected-clients list for the cost of one `setLocalState`, covering part of step 3 without a
+   `status`-map producer. The client presence view validates every awareness state
+   ([src/presence.ts](../src/presence.ts) `readClientPresence`), so non-browser identities want a
+   `role` the viewer knows how to render rather than being silently dropped.

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -85,7 +85,21 @@ startup log line reports which):
 - [ ] Tap a translated line: audio plays. Tap again: cancels.
 - [ ] Auto-speak advances line to line.
 
-## 6. Teardown sanity
+## 6. Status page — connected clients
+
+- [ ] Open `/status` on the session. Under **Connected clients**, confirm this device appears,
+      marked "this device", on the URL you actually have open.
+- [ ] Open a second tab on a translated view (e.g. `/translatedText-French`) and, ideally, a
+      phone on the same session. Both should appear within a couple of seconds, grouped under
+      their URLs, with a plausible device class — a phone must not read as "Desktop".
+- [ ] Confirm the note-taker tab (`#editor`) carries the "editor" badge and viewers do not.
+      Viewers hold read-only tokens; if they're missing from the list entirely, awareness is
+      being dropped, not just the doc writes.
+- [ ] Switch language with the selector on a viewer tab (which rewrites the URL in place). That
+      client's row should move to the new URL group within a few seconds.
+- [ ] Close a tab; its row should disappear within ~30 s (the awareness timeout).
+
+## 7. Teardown sanity
 
 - [ ] Close all listener tabs; confirm the supervisor winds the translator bots down within
       ~2 minutes (60 s demand grace + a reconcile tick; watch for `[SessionManager] Supervisor

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { BilingualBlockViewerContainer } from "./BilingualBlockViewerContainer";
 import { SlideReviewContainer } from "./SlideReviewContainer";
 import { SlideTranslationViewerContainer } from "./SlideTranslationViewer";
 import { StatusViewContainer } from "./StatusView";
+import { PresencePublisher } from "./usePublishPresence";
 import { getDocId } from "./getDocId";
 
 // Lazy-loaded so the heavy LiveKit client SDK is only fetched when a live-audio
@@ -480,6 +481,12 @@ const App = () => {
 
   return (
     <YDocProvider docId={docId} authEndpoint={authEndpoint}>
+      {/*
+        Publishes this client's presence over awareness. Mounted here, above the
+        page, so it runs on every layout — the status page can only list clients
+        that publish, and viewers are most of who we want to see there.
+      */}
+      <PresencePublisher />
       {pageComponent}
     </YDocProvider>
   );

--- a/src/ClientPresenceView.test.tsx
+++ b/src/ClientPresenceView.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { ClientPresenceView } from './ClientPresenceView';
+import type { ClientPresence } from './presence';
+
+function client(
+  clientId: number,
+  overrides: Partial<ClientPresence> = {},
+): { clientId: number; presence: ClientPresence } {
+  return {
+    clientId,
+    presence: {
+      url: '/translatedText-French',
+      role: 'viewer',
+      device: { kind: 'phone', platform: 'iOS', browser: 'Safari' },
+      locale: 'fr',
+      connectedSince: Date.now(),
+      ...overrides,
+    },
+  };
+}
+
+describe('ClientPresenceView', () => {
+  it('tells the operator when nobody is publishing presence', () => {
+    render(<ClientPresenceView clients={[]} />);
+    expect(screen.getByText(/no clients are reporting presence/i)).toBeInTheDocument();
+  });
+
+  it('lists each connected client with its device and page', () => {
+    render(<ClientPresenceView clients={[client(1), client(2, { url: '/sourceText' })]} />);
+    expect(screen.getByText('/translatedText-French')).toBeInTheDocument();
+    expect(screen.getByText('/sourceText')).toBeInTheDocument();
+    expect(screen.getAllByText('Phone').length).toBe(2);
+    expect(screen.getAllByText('iOS · Safari').length).toBe(2);
+  });
+
+  it('reports the total number of connected clients', () => {
+    render(
+      <ClientPresenceView clients={[client(1), client(2), client(3, { url: '/sourceText' })]} />,
+    );
+    expect(screen.getByText(/connected now \(3\)/i)).toBeInTheDocument();
+  });
+
+  it('groups clients on the same page together, biggest group first', () => {
+    render(
+      <ClientPresenceView
+        clients={[client(1, { url: '/sourceText' }), client(2), client(3)]}
+      />,
+    );
+    const groups = screen.getAllByRole('list');
+    // The two-client French group sorts ahead of the single-client source group.
+    expect(within(groups[0]).getAllByRole('listitem')).toHaveLength(2);
+    expect(within(groups[1]).getAllByRole('listitem')).toHaveLength(1);
+  });
+
+  it('badges editors so the operator can find the note-taker', () => {
+    render(
+      <ClientPresenceView
+        clients={[client(1, { role: 'editor', url: '/sourceText' }), client(2)]}
+      />,
+    );
+    expect(screen.getAllByText('editor')).toHaveLength(1);
+  });
+
+  it('marks the operator’s own device', () => {
+    render(<ClientPresenceView clients={[client(1), client(2)]} selfClientId={2} />);
+    expect(screen.getAllByText('this device')).toHaveLength(1);
+  });
+
+  it('shows how long each client has been connected', () => {
+    render(
+      <ClientPresenceView
+        clients={[
+          client(1, { connectedSince: Date.now() - 5 * 60_000 }),
+          client(2, { connectedSince: Date.now() - 2_000 }),
+        ]}
+      />,
+    );
+    expect(screen.getByText(/5 minutes ago/i)).toBeInTheDocument();
+    expect(screen.getByText(/just now/i)).toBeInTheDocument();
+  });
+
+  it('renders devices it cannot identify without dropping the client', () => {
+    render(
+      <ClientPresenceView
+        clients={[client(1, { device: { kind: 'unknown', platform: '' }, locale: '' })]}
+      />,
+    );
+    expect(screen.getByText('Unknown device')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+  });
+});

--- a/src/ClientPresenceView.tsx
+++ b/src/ClientPresenceView.tsx
@@ -1,0 +1,139 @@
+// ClientPresenceView: an operator-facing list of who is connected to this session
+// right now — which page each client has open, and what kind of device it's on.
+//
+// Fed by Yjs awareness rather than the `status` Y.Map, so it needs no backend and
+// no heartbeat producer: awareness membership already expires 30s after a client
+// stops announcing, which makes the list self-cleaning. See presence.ts for the
+// constraints that come with that choice.
+import { useEffect, useState } from 'react';
+import { useAwareness, usePresence } from '@y-sweet/react';
+import { useStrings, resolveLocale } from './useLocale';
+import {
+  DEVICE_ICON,
+  type ClientPresence,
+  type DeviceKind,
+  groupByUrl,
+  readClientPresence,
+} from './presence';
+
+export interface ClientPresenceViewProps {
+  clients: { clientId: number; presence: ClientPresence }[];
+  /** The local client's id, marked in the list so an operator can spot themselves. */
+  selfClientId?: number;
+}
+
+/** A "now" that re-renders once a minute, for the connected-for ages. */
+function useNow(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, [active]);
+  return now;
+}
+
+/** "5 minutes ago", localized. Anything under a minute reads as "now". */
+function formatAge(connectedSince: number, now: number, s: ReturnType<typeof useStrings>): string {
+  if (!connectedSince) return '';
+  const seconds = Math.round((now - connectedSince) / 1000);
+  if (seconds < 60) return s.statusPresenceJustNow;
+  const format = new Intl.RelativeTimeFormat(resolveLocale(), { numeric: 'auto' });
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return format.format(-minutes, 'minute');
+  return format.format(-Math.round(minutes / 60), 'hour');
+}
+
+function deviceLabel(kind: DeviceKind, s: ReturnType<typeof useStrings>): string {
+  switch (kind) {
+    case 'phone':
+      return s.statusDevicePhone;
+    case 'tablet':
+      return s.statusDeviceTablet;
+    case 'desktop':
+      return s.statusDeviceDesktop;
+    default:
+      return s.statusDeviceUnknown;
+  }
+}
+
+export function ClientPresenceView({ clients, selfClientId }: ClientPresenceViewProps) {
+  const s = useStrings();
+  const now = useNow(clients.length > 0);
+
+  if (clients.length === 0) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400">{s.statusPresenceEmpty}</p>;
+  }
+
+  const groups = groupByUrl(clients);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        {s.statusPresenceConnected} ({clients.length})
+      </p>
+      {groups.map((group) => (
+        <div
+          key={group.url}
+          className="rounded border border-gray-200 dark:border-gray-700 p-3 flex flex-col gap-2"
+        >
+          <div className="flex items-baseline gap-2">
+            <code className="text-xs break-all">{group.url}</code>
+            <span className="ml-auto text-xs tabular-nums text-gray-500 dark:text-gray-400 shrink-0">
+              {group.clients.length}
+            </span>
+          </div>
+          <ul className="flex flex-col gap-1">
+            {group.clients.map(({ clientId, presence }) => (
+              <li key={clientId} className="flex items-center gap-2 text-xs">
+                <span aria-hidden="true">{DEVICE_ICON[presence.device.kind]}</span>
+                <span>{deviceLabel(presence.device.kind, s)}</span>
+                {presence.device.platform && (
+                  <span className="text-gray-500 dark:text-gray-400">
+                    {[presence.device.platform, presence.device.browser].filter(Boolean).join(' · ')}
+                  </span>
+                )}
+                {presence.role === 'editor' && (
+                  <span className="px-1.5 rounded bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                    {s.statusPresenceEditor}
+                  </span>
+                )}
+                {clientId === selfClientId && (
+                  <span className="px-1.5 rounded bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200">
+                    {s.statusPresenceYou}
+                  </span>
+                )}
+                {presence.locale && (
+                  <span className="text-gray-400 dark:text-gray-500 uppercase">{presence.locale}</span>
+                )}
+                <span className="ml-auto tabular-nums text-gray-500 dark:text-gray-400 shrink-0">
+                  {formatAge(presence.connectedSince, now, s)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Yjs connector: reads awareness presence for every client on this session. */
+export function ClientPresenceViewContainer() {
+  // includeSelf so the operator's own device is accounted for in the count —
+  // otherwise "1 connected" on a page you're looking at reads as a bug.
+  const presence = usePresence<ClientPresence>({ includeSelf: true });
+  const awareness = useAwareness();
+
+  const clients: { clientId: number; presence: ClientPresence }[] = [];
+  presence.forEach((raw, clientId) => {
+    // Awareness carries whatever any client puts there, including states from
+    // older builds and other features, so validate instead of casting.
+    const parsed = readClientPresence(raw);
+    if (parsed) clients.push({ clientId, presence: parsed });
+  });
+
+  return <ClientPresenceView clients={clients} selfClientId={awareness?.clientID} />;
+}
+
+export default ClientPresenceView;

--- a/src/StatusView.test.tsx
+++ b/src/StatusView.test.tsx
@@ -52,6 +52,24 @@ describe('StatusView', () => {
     expect(screen.getByText(/update pending/i)).toBeInTheDocument();
   });
 
+  it('shows a connected-clients section, empty until the container injects presence', () => {
+    render(<StatusView docId="doc-2026-07-13" statusEntries={{}} />);
+    expect(screen.getByText('Connected clients')).toBeInTheDocument();
+    expect(screen.getByText(/no clients are reporting presence/i)).toBeInTheDocument();
+  });
+
+  it('renders injected client presence in place of the empty state', () => {
+    render(
+      <StatusView
+        docId="doc-2026-07-13"
+        statusEntries={{}}
+        clientPresence={<p>3 phones on the French view</p>}
+      />,
+    );
+    expect(screen.getByText('3 phones on the French view')).toBeInTheDocument();
+    expect(screen.queryByText(/no clients are reporting presence/i)).not.toBeInTheDocument();
+  });
+
   it('reports how many components are heartbeating once the status map fills', () => {
     render(
       <StatusView

--- a/src/StatusView.tsx
+++ b/src/StatusView.tsx
@@ -3,6 +3,7 @@ import { useMap, useYDoc } from '@y-sweet/react';
 import { useStrings } from './useLocale';
 import { getDocId } from './getDocId';
 import { TranscriptHealth } from './TranscriptHealth';
+import { ClientPresenceViewContainer } from './ClientPresenceView';
 
 /**
  * Session status / admin page.
@@ -61,9 +62,19 @@ export interface StatusViewProps {
    * observers). Kept as a slot so the pure component stays testable without Yjs.
    */
   liveTranscripts?: ReactNode;
+  /**
+   * Connected-client list, injected by the container (it reads Yjs awareness).
+   * Same slot pattern as `liveTranscripts`, for the same reason.
+   */
+  clientPresence?: ReactNode;
 }
 
-export function StatusView({ docId, statusEntries, liveTranscripts }: StatusViewProps) {
+export function StatusView({
+  docId,
+  statusEntries,
+  liveTranscripts,
+  clientPresence,
+}: StatusViewProps) {
   const s = useStrings();
   const exportHref = `/api/session/export?doc=${encodeURIComponent(docId)}`;
   const reportingCount = Object.keys(statusEntries).length;
@@ -137,6 +148,12 @@ export function StatusView({ docId, statusEntries, liveTranscripts }: StatusView
           )}
         </section>
 
+        {/* Connected clients — real presence, read from Yjs awareness. */}
+        <section className={sectionClass}>
+          <h2 className={sectionTitleClass}>{s.statusPresenceTitle}</h2>
+          {clientPresence ?? <p className={placeholderClass}>{s.statusPresenceEmpty}</p>}
+        </section>
+
         {/* Preflight canary — placeholder until #72. */}
         <section className={sectionClass}>
           <h2 className={sectionTitleClass}>{s.statusCanaryTitle}</h2>
@@ -180,6 +197,7 @@ export function StatusViewContainer() {
       docId={getDocId()}
       statusEntries={statusEntries}
       liveTranscripts={<TranscriptHealth />}
+      clientPresence={<ClientPresenceViewContainer />}
     />
   );
 }

--- a/src/presence.test.ts
+++ b/src/presence.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type ClientPresence,
+  currentUrl,
+  describeDevice,
+  groupByUrl,
+  readClientPresence,
+} from './presence';
+
+// Real user-agent strings, because every interesting case here is a quirk of a
+// specific device lying about what it is.
+const UA = {
+  iphone:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+  ipadOld:
+    'Mozilla/5.0 (iPad; CPU OS 12_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Mobile/15E148 Safari/604.1',
+  // iPadOS 13+ claims to be a Mac; only maxTouchPoints gives it away.
+  ipadDesktopClass:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15',
+  androidPhone:
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36',
+  androidTablet:
+    'Mozilla/5.0 (Linux; Android 13; SM-X700) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+  mac: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+  windows:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0',
+  firefox:
+    'Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0',
+};
+
+describe('describeDevice', () => {
+  it('classifies an iPhone as a phone on iOS', () => {
+    const device = describeDevice({ userAgent: UA.iphone, maxTouchPoints: 5 });
+    expect(device.kind).toBe('phone');
+    expect(device.platform).toBe('iOS');
+    expect(device.browser).toBe('Safari');
+  });
+
+  it('classifies an older iPad as a tablet', () => {
+    expect(describeDevice({ userAgent: UA.ipadOld, maxTouchPoints: 5 }).kind).toBe('tablet');
+  });
+
+  it('classifies a desktop-class iPad as a tablet, not a Mac', () => {
+    // The UA is identical to a Mac's; maxTouchPoints is the only distinguishing signal.
+    expect(describeDevice({ userAgent: UA.ipadDesktopClass, maxTouchPoints: 5 }).kind).toBe(
+      'tablet',
+    );
+  });
+
+  it('classifies a real Mac as a desktop', () => {
+    const device = describeDevice({ userAgent: UA.mac, maxTouchPoints: 0 });
+    expect(device.kind).toBe('desktop');
+    expect(device.platform).toBe('macOS');
+    expect(device.browser).toBe('Chrome');
+  });
+
+  it('splits Android phones from Android tablets on the Mobile token', () => {
+    expect(describeDevice({ userAgent: UA.androidPhone }).kind).toBe('phone');
+    expect(describeDevice({ userAgent: UA.androidTablet }).kind).toBe('tablet');
+    expect(describeDevice({ userAgent: UA.androidPhone }).platform).toBe('Android');
+  });
+
+  it('prefers the Chromium platform hint over sniffing the user-agent', () => {
+    const device = describeDevice({
+      userAgent: UA.windows,
+      userAgentData: { mobile: false, platform: 'Windows' },
+    });
+    expect(device.kind).toBe('desktop');
+    expect(device.platform).toBe('Windows');
+  });
+
+  it('reads userAgentData.mobile when the user-agent gives no platform away', () => {
+    const device = describeDevice({
+      userAgent: 'Mozilla/5.0',
+      userAgentData: { mobile: true, platform: 'Unknown' },
+    });
+    expect(device.kind).toBe('phone');
+  });
+
+  it('picks the most specific browser token', () => {
+    // Edge claims Chrome and Safari; Chrome claims Safari.
+    expect(describeDevice({ userAgent: UA.windows }).browser).toBe('Edge');
+    expect(describeDevice({ userAgent: UA.firefox }).browser).toBe('Firefox');
+  });
+
+  it('falls back to unknown rather than guessing', () => {
+    const device = describeDevice({ userAgent: '' });
+    expect(device.kind).toBe('unknown');
+    expect(device.platform).toBe('');
+    expect(device.browser).toBeUndefined();
+  });
+});
+
+describe('currentUrl', () => {
+  it('joins path, query, and hash without the origin', () => {
+    expect(
+      currentUrl({ pathname: '/translatedText-French', search: '?doc=doc-1', hash: '#editor' }),
+    ).toBe('/translatedText-French?doc=doc-1#editor');
+  });
+});
+
+describe('readClientPresence', () => {
+  const valid = {
+    url: '/sourceText',
+    role: 'editor',
+    device: { kind: 'desktop', platform: 'macOS', browser: 'Chrome' },
+    locale: 'en',
+    connectedSince: 1_700_000_000_000,
+  };
+
+  it('accepts a well-formed presence state', () => {
+    expect(readClientPresence(valid)).toEqual(valid);
+  });
+
+  it('rejects states that are not client presence', () => {
+    // Awareness is a shared channel: other features and older builds put things there.
+    expect(readClientPresence({})).toBeNull();
+    expect(readClientPresence(null)).toBeNull();
+    expect(readClientPresence('nope')).toBeNull();
+    expect(readClientPresence({ cursor: { x: 1 } })).toBeNull();
+    expect(readClientPresence({ ...valid, role: 'admin' })).toBeNull();
+  });
+
+  it('defaults the fields a partial state is missing', () => {
+    const parsed = readClientPresence({ url: '/status', role: 'viewer' });
+    expect(parsed).toEqual({
+      url: '/status',
+      role: 'viewer',
+      device: { kind: 'unknown', platform: '' },
+      locale: '',
+      connectedSince: 0,
+    });
+  });
+});
+
+describe('groupByUrl', () => {
+  const client = (
+    clientId: number,
+    url: string,
+    connectedSince: number,
+  ): { clientId: number; presence: ClientPresence } => ({
+    clientId,
+    presence: {
+      url,
+      role: 'viewer',
+      device: { kind: 'phone', platform: 'iOS' },
+      locale: 'fr',
+      connectedSince,
+    },
+  });
+
+  it('groups clients by URL, largest group first', () => {
+    const groups = groupByUrl([
+      client(1, '/sourceText', 100),
+      client(2, '/translatedText-French', 100),
+      client(3, '/translatedText-French', 100),
+    ]);
+    expect(groups.map((g) => [g.url, g.clients.length])).toEqual([
+      ['/translatedText-French', 2],
+      ['/sourceText', 1],
+    ]);
+  });
+
+  it('orders clients within a group by connection time, oldest first', () => {
+    const groups = groupByUrl([client(9, '/status', 300), client(4, '/status', 100)]);
+    expect(groups[0].clients.map((c) => c.clientId)).toEqual([4, 9]);
+  });
+
+  it('returns nothing for no clients', () => {
+    expect(groupByUrl([])).toEqual([]);
+  });
+});

--- a/src/presence.ts
+++ b/src/presence.ts
@@ -1,0 +1,204 @@
+// Client presence: what each connected browser publishes about itself over Yjs
+// awareness, so the status page can answer "who is on this session right now, on
+// what page, from what kind of device?".
+//
+// This rides awareness rather than the `status` Y.Map, and that choice carries a
+// few constraints worth knowing before adding fields:
+//
+//   - Awareness is already running. y-protocols' Awareness constructor calls
+//     setLocalState({}), so every client announces itself, re-announces every
+//     ~15s, and is dropped after 30s of silence. Membership *is* the liveness
+//     signal; nothing here needs a heartbeat.
+//   - Every field must be stable for the lifetime of a connection (or change
+//     only on real user action). Each re-announce broadcasts the whole state to
+//     every other client, so a ticking value — an age, a counter — turns into
+//     O(n²) chatter with a congregation's worth of phones on the doc. That's why
+//     `connectedSince` is a fixed timestamp the viewer subtracts from, not an age.
+//   - Awareness is broadcast to *all* clients, not just whoever opened /status.
+//     Anything published here is readable by any viewer with devtools, so this
+//     deliberately carries a coarse device kind and never the raw user-agent.
+//
+// Read-only viewers can publish presence: y-sweet gates writes on SyncStep2 and
+// Update messages, but relays Message::Awareness without an authorization check.
+// That matters, because viewers are most of who we want to see here.
+
+/** Coarse device classes. Deliberately coarse — see the privacy note above. */
+export type DeviceKind = 'phone' | 'tablet' | 'desktop' | 'unknown';
+
+export interface DeviceInfo {
+  kind: DeviceKind;
+  /** OS family, e.g. 'iOS', 'Android', 'macOS', 'Windows'. '' when unknown. */
+  platform: string;
+  /** Browser family, e.g. 'Safari', 'Chrome'. Omitted when unrecognizable. */
+  browser?: string;
+}
+
+/** What a client publishes about itself. Keep every field stable per connection. */
+export interface ClientPresence {
+  /** pathname + search + hash — the layout string is the interesting part. */
+  url: string;
+  role: 'editor' | 'viewer';
+  device: DeviceInfo;
+  /** Resolved UI locale ('en' | 'fr' | 'ht' | 'es'). */
+  locale: string;
+  /** Epoch ms when this client connected. A fixed instant, never an age. */
+  connectedSince: number;
+}
+
+/**
+ * The slice of `navigator` device detection needs. Declared structurally so tests
+ * can pass a plain object and so the Chromium-only `userAgentData` stays optional.
+ */
+export interface DeviceNavigator {
+  userAgent: string;
+  maxTouchPoints?: number;
+  userAgentData?: {
+    mobile?: boolean;
+    platform?: string;
+  };
+}
+
+function detectPlatform(ua: string): string {
+  // Order matters: Android UAs also contain "Linux", and iPadOS contains "Mac OS X".
+  if (/Android/i.test(ua)) return 'Android';
+  if (/iPhone|iPad|iPod/i.test(ua)) return 'iOS';
+  if (/Macintosh|Mac OS X/i.test(ua)) return 'macOS';
+  if (/Windows/i.test(ua)) return 'Windows';
+  if (/CrOS/i.test(ua)) return 'ChromeOS';
+  if (/Linux/i.test(ua)) return 'Linux';
+  return '';
+}
+
+function detectBrowser(ua: string): string | undefined {
+  // Order matters: every Chromium browser claims "Safari", and Edge/Opera also
+  // claim "Chrome", so the most specific token has to be tested first.
+  if (/Edg\//.test(ua)) return 'Edge';
+  if (/OPR\/|Opera/.test(ua)) return 'Opera';
+  if (/Firefox\/|FxiOS/.test(ua)) return 'Firefox';
+  if (/CriOS/.test(ua)) return 'Chrome';
+  if (/Chrome\//.test(ua)) return 'Chrome';
+  if (/Safari\//.test(ua)) return 'Safari';
+  return undefined;
+}
+
+/**
+ * Classify the device from whatever signals are available.
+ *
+ * `userAgentData.mobile` (Chromium) is the only first-class signal and settles
+ * phone-vs-desktop when present, but it doesn't distinguish tablets, so the UA
+ * still decides that. The case that needs real care is iPadOS 13+, which
+ * identifies as "Macintosh" — `maxTouchPoints > 1` is what separates an iPad from
+ * a Mac, and without it every iPad in the room reads as a desktop.
+ */
+export function describeDevice(nav: DeviceNavigator): DeviceInfo {
+  const ua = nav.userAgent ?? '';
+  const touchPoints = nav.maxTouchPoints ?? 0;
+  const platform = detectPlatform(ua);
+  const browser = detectBrowser(ua);
+
+  // A touch-capable "Macintosh" is an iPad claiming desktop-class Safari. This has
+  // to match "Macintosh" specifically, not "Mac OS X": every iPhone UA also says
+  // "like Mac OS X", and iPhones have touch points too.
+  const isIpadOS = /Macintosh/i.test(ua) && touchPoints > 1;
+
+  let kind: DeviceKind;
+  if (/iPhone|iPod/i.test(ua)) {
+    kind = 'phone';
+  } else if (/iPad/i.test(ua) || isIpadOS) {
+    kind = 'tablet';
+  } else if (/Android/i.test(ua)) {
+    // Android tablets are the ones that drop "Mobile" from the UA.
+    kind = /Mobile/i.test(ua) ? 'phone' : 'tablet';
+  } else if (nav.userAgentData?.mobile === true) {
+    kind = 'phone';
+  } else if (platform) {
+    kind = 'desktop';
+  } else {
+    kind = 'unknown';
+  }
+
+  return {
+    kind,
+    // Chromium's platform hint is more trustworthy than UA sniffing when present.
+    platform: nav.userAgentData?.platform || platform,
+    ...(browser ? { browser } : {}),
+  };
+}
+
+/** The current location as published — path, query, and hash, no origin. */
+export function currentUrl(location: Pick<Location, 'pathname' | 'search' | 'hash'>): string {
+  return `${location.pathname}${location.search}${location.hash}`;
+}
+
+/**
+ * Narrow an awareness state into a ClientPresence, or null if it isn't one.
+ *
+ * Awareness carries whatever any client chooses to put there, including states
+ * from other features and from clients running older builds, so the status view
+ * validates rather than casts.
+ */
+export function readClientPresence(raw: unknown): ClientPresence | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const { url, role, device, locale, connectedSince } = raw as Record<string, unknown>;
+  if (typeof url !== 'string') return null;
+  if (role !== 'editor' && role !== 'viewer') return null;
+
+  const deviceRecord = (device && typeof device === 'object' ? device : {}) as Record<string, unknown>;
+  const kind = deviceRecord.kind;
+  return {
+    url,
+    role,
+    device: {
+      kind:
+        kind === 'phone' || kind === 'tablet' || kind === 'desktop' ? kind : 'unknown',
+      platform: typeof deviceRecord.platform === 'string' ? deviceRecord.platform : '',
+      ...(typeof deviceRecord.browser === 'string' && deviceRecord.browser
+        ? { browser: deviceRecord.browser }
+        : {}),
+    },
+    locale: typeof locale === 'string' ? locale : '',
+    connectedSince: typeof connectedSince === 'number' ? connectedSince : 0,
+  };
+}
+
+/** Emoji marker per device class, for the presence rows. */
+export const DEVICE_ICON: Record<DeviceKind, string> = {
+  phone: '📱',
+  tablet: '📖',
+  desktop: '🖥️',
+  unknown: '❔',
+};
+
+export interface PresenceGroup {
+  url: string;
+  clients: { clientId: number; presence: ClientPresence }[];
+}
+
+/**
+ * Group clients by the URL they're on, which is how an operator actually reads
+ * this ("12 on the French view, 1 editor broadcasting"). Groups are ordered
+ * largest first, and clients within a group oldest connection first, so the list
+ * stays stable as people join and leave.
+ */
+export function groupByUrl(
+  clients: { clientId: number; presence: ClientPresence }[],
+): PresenceGroup[] {
+  const groups = new Map<string, PresenceGroup>();
+  for (const client of clients) {
+    let group = groups.get(client.presence.url);
+    if (!group) {
+      group = { url: client.presence.url, clients: [] };
+      groups.set(client.presence.url, group);
+    }
+    group.clients.push(client);
+  }
+  const ordered = [...groups.values()];
+  for (const group of ordered) {
+    group.clients.sort(
+      (a, b) =>
+        a.presence.connectedSince - b.presence.connectedSince || a.clientId - b.clientId,
+    );
+  }
+  ordered.sort((a, b) => b.clients.length - a.clients.length || a.url.localeCompare(b.url));
+  return ordered;
+}

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -93,6 +93,16 @@ export interface AppStrings {
   statusTranscriptSource: string;
   statusTranscriptNoUpdates: string;
   statusUpdatePending: string;
+  statusPresenceTitle: string;
+  statusPresenceEmpty: string;
+  statusPresenceConnected: string;
+  statusPresenceEditor: string;
+  statusPresenceYou: string;
+  statusPresenceJustNow: string;
+  statusDevicePhone: string;
+  statusDeviceTablet: string;
+  statusDeviceDesktop: string;
+  statusDeviceUnknown: string;
 
   // Layout diagram component labels
   componentSourceText: string;
@@ -194,6 +204,16 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     statusTranscriptSource: 'source',
     statusTranscriptNoUpdates: 'No updates since page load',
     statusUpdatePending: 'Update pending — restart the service',
+    statusPresenceTitle: 'Connected clients',
+    statusPresenceEmpty: 'No clients are reporting presence yet.',
+    statusPresenceConnected: 'Connected now',
+    statusPresenceEditor: 'editor',
+    statusPresenceYou: 'this device',
+    statusPresenceJustNow: 'just now',
+    statusDevicePhone: 'Phone',
+    statusDeviceTablet: 'Tablet',
+    statusDeviceDesktop: 'Desktop',
+    statusDeviceUnknown: 'Unknown device',
     componentSourceText: 'Source Text',
     componentTranslatedText: 'Translated Text',
     componentBilingual: 'Bilingual View',
@@ -288,6 +308,16 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     statusTranscriptSource: 'source',
     statusTranscriptNoUpdates: 'Aucune mise à jour depuis le chargement de la page',
     statusUpdatePending: 'Mise à jour en attente — redémarrez le service',
+    statusPresenceTitle: 'Clients connectés',
+    statusPresenceEmpty: 'Aucun client ne signale sa présence pour l’instant.',
+    statusPresenceConnected: 'Connectés maintenant',
+    statusPresenceEditor: 'éditeur',
+    statusPresenceYou: 'cet appareil',
+    statusPresenceJustNow: 'à l’instant',
+    statusDevicePhone: 'Téléphone',
+    statusDeviceTablet: 'Tablette',
+    statusDeviceDesktop: 'Ordinateur',
+    statusDeviceUnknown: 'Appareil inconnu',
     componentSourceText: 'Texte source',
     componentTranslatedText: 'Texte traduit',
     componentBilingual: 'Vue bilingue',
@@ -382,6 +412,16 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     statusTranscriptSource: 'fuente',
     statusTranscriptNoUpdates: 'Sin actualizaciones desde que se cargó la página',
     statusUpdatePending: 'Actualización pendiente — reinicie el servicio',
+    statusPresenceTitle: 'Clientes conectados',
+    statusPresenceEmpty: 'Todavía ningún cliente informa su presencia.',
+    statusPresenceConnected: 'Conectados ahora',
+    statusPresenceEditor: 'editor',
+    statusPresenceYou: 'este dispositivo',
+    statusPresenceJustNow: 'ahora mismo',
+    statusDevicePhone: 'Teléfono',
+    statusDeviceTablet: 'Tableta',
+    statusDeviceDesktop: 'Computadora',
+    statusDeviceUnknown: 'Dispositivo desconocido',
     componentSourceText: 'Texto fuente',
     componentTranslatedText: 'Texto traducido',
     componentBilingual: 'Vista biling\u00fce',
@@ -476,6 +516,16 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     statusTranscriptSource: 'sous',
     statusTranscriptNoUpdates: 'Pa gen mizajou depi paj la chaje',
     statusUpdatePending: 'Gen yon mizajou k ap tann — rekòmanse sèvis la',
+    statusPresenceTitle: 'Kliyan ki konekte',
+    statusPresenceEmpty: 'Poko gen kliyan k ap siyale prezans yo.',
+    statusPresenceConnected: 'Konekte kounye a',
+    statusPresenceEditor: 'editè',
+    statusPresenceYou: 'aparèy sa a',
+    statusPresenceJustNow: 'kounye a',
+    statusDevicePhone: 'Telefòn',
+    statusDeviceTablet: 'Tablèt',
+    statusDeviceDesktop: 'Òdinatè',
+    statusDeviceUnknown: 'Aparèy enkoni',
     componentSourceText: 'Teks sous',
     componentTranslatedText: 'Teks tradui',
     componentBilingual: 'Vi Bileng',

--- a/src/usePublishPresence.test.tsx
+++ b/src/usePublishPresence.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import type { ClientPresence } from './presence';
+import { PresencePublisher } from './usePublishPresence';
+
+// The hook only needs the presence setter from the provider; stubbing it keeps
+// this a test of *what we publish and when*, with no Y-Sweet connection involved.
+const setPresence = vi.fn();
+vi.mock('@y-sweet/react', () => ({
+  usePresenceSetter: () => setPresence,
+}));
+
+/** The presence object from the Nth publish. */
+function published(n: number): ClientPresence {
+  return setPresence.mock.calls[n][0] as ClientPresence;
+}
+
+function navigateInPlace(url: string) {
+  // What App.tsx's language selector does: rewrite the URL with no event and no
+  // remount. This is the case a one-shot read at mount would miss.
+  window.history.replaceState(null, '', url);
+}
+
+describe('PresencePublisher', () => {
+  beforeEach(() => {
+    setPresence.mockClear();
+    window.history.replaceState(null, '', '/translatedText-French');
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('publishes the current page, role, and device on mount', () => {
+    render(<PresencePublisher />);
+    expect(setPresence).toHaveBeenCalledTimes(1);
+    const presence = published(0);
+    expect(presence.url).toBe('/translatedText-French');
+    expect(presence.role).toBe('viewer');
+    expect(presence.device.kind).toBeDefined();
+    expect(presence.connectedSince).toBeGreaterThan(0);
+  });
+
+  it('re-publishes after an in-place URL change', () => {
+    render(<PresencePublisher />);
+    act(() => {
+      navigateInPlace('/translatedText-Spanish');
+      vi.advanceTimersByTime(2500);
+    });
+    expect(setPresence.mock.calls.length).toBeGreaterThan(1);
+    expect(published(setPresence.mock.calls.length - 1).url).toBe('/translatedText-Spanish');
+  });
+
+  it('keeps connectedSince fixed across re-publishes', () => {
+    // A ticking field would re-broadcast to every peer on every change; the age is
+    // the viewer's job to compute. See presence.ts.
+    render(<PresencePublisher />);
+    const first = published(0).connectedSince;
+    act(() => {
+      navigateInPlace('/sourceText');
+      vi.advanceTimersByTime(2500);
+    });
+    expect(published(setPresence.mock.calls.length - 1).connectedSince).toBe(first);
+  });
+
+  it('does not re-publish while the URL is unchanged', () => {
+    render(<PresencePublisher />);
+    setPresence.mockClear();
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(setPresence).not.toHaveBeenCalled();
+  });
+
+  it('picks up hash changes', () => {
+    render(<PresencePublisher />);
+    act(() => {
+      navigateInPlace('/sourceText#editor');
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+    expect(published(setPresence.mock.calls.length - 1).url).toBe('/sourceText#editor');
+  });
+});

--- a/src/usePublishPresence.ts
+++ b/src/usePublishPresence.ts
@@ -1,0 +1,79 @@
+// Publishes this client's presence over Yjs awareness. Mounted once inside the
+// session's YDocProvider (App.tsx) so it runs on *every* page, not just /status:
+// @y-sweet/react's usePresence skips clients whose awareness state is empty, so a
+// client that never publishes is invisible to the status view.
+import { useEffect, useRef, useState } from 'react';
+import { usePresenceSetter } from '@y-sweet/react';
+import { useAtomValue } from 'jotai';
+import { isEditorAtom } from './configAtoms';
+import { resolveLocale } from './useLocale';
+import { type ClientPresence, currentUrl, describeDevice } from './presence';
+
+/** How often to re-read the URL. See useCurrentUrl for why polling. */
+const URL_POLL_MS = 2000;
+
+/**
+ * The current path/query/hash, kept fresh however it changes.
+ *
+ * The language selector rewrites the layout with `history.replaceState`
+ * (App.tsx), which fires no event and doesn't remount, so a one-shot read at
+ * mount goes stale the moment someone switches language. Rather than thread
+ * routing state out of LayoutPage, this listens to the events that do exist and
+ * polls at a low rate to catch replaceState. Deliberately dumber than the
+ * alternative, and it can't miss a mutation path we didn't think of.
+ */
+function useCurrentUrl(): string {
+  const [url, setUrl] = useState(() => currentUrl(window.location));
+  useEffect(() => {
+    const read = () => setUrl(currentUrl(window.location));
+    read(); // the URL may have changed between the initializer and this effect
+    window.addEventListener('popstate', read);
+    window.addEventListener('hashchange', read);
+    const id = setInterval(read, URL_POLL_MS);
+    return () => {
+      window.removeEventListener('popstate', read);
+      window.removeEventListener('hashchange', read);
+      clearInterval(id);
+    };
+  }, []);
+  return url;
+}
+
+/**
+ * Publish this client's presence, refreshing it when the URL changes.
+ *
+ * Every field is stable for the connection's lifetime apart from `url`: awareness
+ * re-broadcasts the whole state to every peer on each announce, so a value that
+ * ticks would cost O(n²) messages across a room full of phones. `connectedSince`
+ * is therefore a fixed instant captured once, and the viewer renders the age.
+ */
+export function usePublishPresence(): void {
+  const setPresence = usePresenceSetter<ClientPresence>();
+  const isEditor = useAtomValue(isEditorAtom);
+  const url = useCurrentUrl();
+
+  // The connection's fixed identity: captured on the first publish (i.e. at mount)
+  // and reused afterwards, so re-publishing on navigation doesn't reset the clock
+  // or re-sniff the device. Both reads are impure, hence the effect rather than
+  // a render-time initializer.
+  const identity = useRef<{ connectedSince: number; device: ClientPresence['device'] } | null>(
+    null,
+  );
+
+  useEffect(() => {
+    identity.current ??= { connectedSince: Date.now(), device: describeDevice(navigator) };
+    setPresence({
+      url,
+      role: isEditor ? 'editor' : 'viewer',
+      device: identity.current.device,
+      locale: resolveLocale(),
+      connectedSince: identity.current.connectedSince,
+    });
+  }, [setPresence, url, isEditor]);
+}
+
+/** Renders nothing; exists so App can mount the publisher inside YDocProvider. */
+export function PresencePublisher(): null {
+  usePublishPresence();
+  return null;
+}


### PR DESCRIPTION
Adds a **Connected clients** section to `/status`: every browser on the session, with the page it has open, device class, editor/viewer role, UI locale, and how long it's been connected — grouped by URL, so a glance answers "how many people are on the French view right now?".

## Why awareness, not the `status` Y.Map

This needs no backend and no heartbeat producer, unlike the Health tiles still waiting on #72. y-protocols' `Awareness` constructor already calls `setLocalState({})`, so every client announces itself, re-announces every ~15 s, and is dropped after a 30 s timeout. **Membership is the liveness signal**, and the list is self-cleaning.

## Constraints that shaped it

Documented in `src/presence.ts` and `docs/OBSERVABILITY.md`, since each one is a trap for the next change here:

- **Read-only viewers can publish presence.** This was the main risk, since viewers get `read-only` tokens. y-sweet gates writes on `SyncStep2`/`Update` messages but relays `Message::Awareness` with no authorization check — so viewers, most of who we want to see, do appear.
- **Publish from every page.** `usePresence` skips clients whose awareness state is empty, so `PresencePublisher` is mounted above the layout in `App.tsx`. Corollary: the server-side `YSweetProvider` clients (`transcript-writer.ts`, `slideConversationStore.ts`) stay invisible until they opt in — filed as next-step 5 in OBSERVABILITY.md, where it covers part of #72 for one `setLocalState`.
- **Every field is stable per connection.** Awareness re-broadcasts the whole state on each announce, so a ticking value would cost O(n²) messages with a congregation's worth of phones on the doc. `connectedSince` is a fixed instant; the viewer renders the age.
- **The URL moves without an event.** `history.replaceState` (the language selector, and `YDocProvider`'s `setQueryParam`) rewrites the URL with no remount, so `useCurrentUrl` listens to `popstate`/`hashchange` *and* polls at a low rate. Deliberately dumber than threading state out of `LayoutPage`, and it can't miss a mutation path.
- **No re-render storm.** `usePresence` subscribes to `'change'`, not `'update'`, so the 15 s clock renewals cost nothing; re-renders happen on join/leave only.

## Privacy

Awareness is broadcast to *all* clients, not only to whoever opened `/status` — anything published here is readable by any viewer with devtools. So this carries a coarse device class (`phone`/`tablet`/`desktop`) and never the raw user-agent string. The URL itself already reveals which language someone chose.

## Device classification

`describeDevice` handles the cases that actually lie: iPadOS 13+ reports as `Macintosh` and is separated by `maxTouchPoints`; Android tablets are the ones that drop the `Mobile` token; Edge and Chrome both claim Safari, so the most specific token wins. An iPhone UA also contains "like Mac OS X" — which is why the iPadOS check matches `Macintosh` specifically. A test caught that one classifying every iPhone as a tablet.

## Changes

New: `src/presence.ts` (pure — device classification, awareness-state validation, grouping), `src/usePublishPresence.ts` (the publisher), `src/ClientPresenceView.tsx` (pure component + Yjs container), plus tests for each.

Edited: `App.tsx` mounts the publisher inside `YDocProvider`; `StatusView.tsx` gains a section using the same injected-slot pattern as `liveTranscripts`, so the pure component stays Yjs-free; `strings.ts` adds 10 keys across all four locales.

## Testing

`npm test` 339 passing (28 files, 22 new), `npm run typecheck` clean, `npm run lint` clean, `npm run build` succeeds.

Smoke test: adds **section 6 — Status page, connected clients** (`docs/SMOKE_TEST.md`), covering self-identification, a second device, the editor badge, the in-place language switch moving a client between URL groups, and the ~30 s disappearance on close. No existing section is touched — the change is additive and confined to `/status` plus a null-rendering publisher.

Not verified against a running stack: no Y-Sweet instance or API keys in this environment, so the awareness round-trip between real clients is exactly what section 6 exists to check.

---
_Generated by [Claude Code](https://claude.ai/code/session_014KvKvcyKYVfQKa1VZh6mw6)_