### PR TITLE
Render blank slides blank in the translation viewer

### DIFF
--- a/sessionExport.ts
+++ b/sessionExport.ts
@@ -20,6 +20,7 @@
  */
 import * as Y from 'yjs';
 import {
+  isBlankSlide,
   resolveSlideTranslation,
   slideTranslationKey,
   type SlideTranslationEntry,
@@ -174,7 +175,7 @@ function extractPresentations(ydoc: Y.Doc): { presentations: ExportedPresentatio
 
     const exportedSlides: ExportedSlide[] = slides.map((text, index) => {
       const translations: Record<string, ResolvedSlideTranslation> = {};
-      if (text.trim() !== '') {
+      if (!isBlankSlide(text)) {
         for (const lang of languages) {
           const resolved = resolveSlideTranslation(lang, text, lookup);
           if (resolved) translations[lang] = resolved;

--- a/src/SlideTranslationViewer.test.tsx
+++ b/src/SlideTranslationViewer.test.tsx
@@ -68,6 +68,18 @@ describe('SlideTranslationViewer', () => {
     expect(screen.getByText('(not translated)')).toBeInTheDocument();
   });
 
+  it('renders a blank slide blank, not as untranslated', () => {
+    render(
+      <SlideTranslationViewer
+        slides={['Praise the Lord', '   ']}
+        currentIndex={1}
+        language="French"
+        resolvedBySlide={[resolved('Louez le Seigneur', 'reviewed', 'French', 'French'), undefined]}
+      />,
+    );
+    expect(screen.queryByText('(not translated)')).not.toBeInTheDocument();
+  });
+
   it('renders a placeholder when there are no slides', () => {
     render(
       <SlideTranslationViewer

--- a/src/SlideTranslationViewer.tsx
+++ b/src/SlideTranslationViewer.tsx
@@ -2,6 +2,7 @@ import { useMap } from '@y-sweet/react';
 import { useStrings } from './useLocale';
 import { SlideText } from './SlideText';
 import {
+  isBlankSlide,
   resolveSlideTranslation,
   slideTextLines,
   slideTranslationKey,
@@ -25,6 +26,8 @@ export interface SlideTranslationViewerProps {
  * - An `auto` (machine, unreviewed) translation gets a subtle "unreviewed" badge.
  * - When the displayed language differs from the requested one (e.g. reviewed French
  *   shown to a Haitian Creole viewer), a small language tag is shown.
+ * - A blank source slide renders blank: there is nothing to translate, so the
+ *   "not translated" placeholder would be misleading.
  */
 export function SlideTranslationViewer({
   slides,
@@ -44,6 +47,13 @@ export function SlideTranslationViewer({
   // Clamp: Proclaim publishes status and presentation separately, so the index
   // can transiently point past the slides.
   const clampedIndex = Math.min(Math.max(currentIndex, 0), slides.length - 1);
+
+  // A blank source slide mirrors as a blank translation — the source viewer shows
+  // nothing here, so this pane should match rather than claim it is untranslated.
+  if (isBlankSlide(slides[clampedIndex])) {
+    return <SlideText lines={[]} />;
+  }
+
   const resolved = resolvedBySlide[clampedIndex];
   const isUnreviewed = resolved?.entry.status === 'auto';
 
@@ -97,7 +107,7 @@ export function SlideTranslationViewerContainer({ language }: { language: string
       translationsMap.get(slideTranslationKey(lang, slideText)) as SlideTranslationEntry | undefined;
 
     const resolvedBySlide = slides.map((slideText) =>
-      slideText.trim() === '' ? undefined : resolveSlideTranslation(language, slideText, lookup),
+      isBlankSlide(slideText) ? undefined : resolveSlideTranslation(language, slideText, lookup),
     );
 
     view = { slides, slideIndex, resolvedBySlide };

--- a/src/slideTranslation.ts
+++ b/src/slideTranslation.ts
@@ -62,6 +62,15 @@ export function normalizeSlideText(text: string): string {
     .trim();
 }
 
+/**
+ * Whether a slide has no text at all. Blank slides are real slides (Proclaim emits
+ * them for image slideshows and spacer screens), but there is nothing to translate —
+ * so they render blank rather than as an untranslated slide.
+ */
+export function isBlankSlide(slideText: string): boolean {
+  return slideText.trim() === '';
+}
+
 /** Content-addressed key combining language and normalized slide text. */
 export function slideTranslationKey(language: string, slideText: string): string {
   return `${language}:${normalizeSlideText(slideText)}`;


### PR DESCRIPTION
## What

A blank source slide showed `(not translated)` in the translated-slide pane instead of showing nothing.

Blank slides are real slides — Proclaim emits them for image slideshows and spacer screens. The Yjs container already skips resolving a translation for them (nothing to translate), so `resolvedBySlide[i]` is `undefined`, and `SlideTranslationViewer` fell through to the "not translated" placeholder. That reads as "a translation is missing here" when in fact the source pane is showing nothing at all.

## Changes

- `src/SlideTranslationViewer.tsx`: check the current source slide before consulting the resolution — a blank slide renders an empty `SlideText`, matching what `CurrentSlideViewer` shows for the same slide.
- `src/slideTranslation.ts`: new `isBlankSlide()` so the blank test lives in one place; the viewer, its container, and `sessionExport.ts` now all use it instead of open-coding `text.trim() === ''`.
- `src/SlideTranslationViewer.test.tsx`: covers a blank current slide not rendering the placeholder.

The review UI (`SlideReviewContainer`) and the session export already filtered blank slides, so no behavior changes there — only the shared helper.

## Testing

- `npm test` — 309 tests pass (25 files)
- `npm run typecheck` and `npm run lint` clean

## Smoke test sections touched

[docs/SMOKE_TEST.md](docs/SMOKE_TEST.md) **§3 Proclaim sync** — advancing to a blank slide should leave the translated pane blank rather than showing `(not translated)`. No other section is affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSzGWMrRADRqoE84Cfzxz3)_