### PR TITLE
Add shared-key write authorization, defaulting to observe mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,9 @@ Optional environment variables:
   `WRITE_KEYS` is empty). `observe` records every privileged request and allows it anyway —
   the rollout state. `enforce` refuses unauthorized ones.
 - `TTS_MAX_CONCURRENT` - Max concurrent TTS requests (default: 2)
+- `TTS_RATE_LIMIT_PER_MIN` / `TRANSLATE_RATE_LIMIT_PER_MIN` - Per-caller caps on the two
+  endpoints viewers call and a write key can't protect (defaults 600 / 1200; 0 disables).
+  Sized to stop a script, not a congregation — see [rateLimit.ts](rateLimit.ts).
 - `GEMINI_STRONG_MODEL` - Stronger Gemini model for whole-item slide drafting via `/api/translateItem` (default: `gemini-3.5-flash`)
 - `LIVE_AUDIO_SILENCE_THRESHOLD_DBFS` - dBFS voice bar for the live-audio cost path; a bridge suspends its Gemini session after ~30s below it (`-30` is a guess, never validated against a real room). Unset = off, no suspending. Beware the sign: dBFS is negative, so `0` gates hardest, not least. goaway/reconnect fixes and the always-on default translator are independent of this. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
 - `VITE_PUBLIC_POSTHOG_KEY` - PostHog analytics key (for usage tracking)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,12 @@ Required environment variables (`.env`):
 - `ELEVENLABS_API_KEY` - ElevenLabs API key for text-to-speech
 
 Optional environment variables:
+- `WRITE_KEYS` - Shared per-device keys authorizing writes (editing, the microphone, the
+  model/TTS endpoints). Comma-separated `label:key` or bare `key`. Reading needs no key.
+  See [docs/WRITE_KEYS.md](docs/WRITE_KEYS.md).
+- `WRITE_AUTH_MODE` - `off` | `observe` | `enforce` (default `observe`; forced to `off` when
+  `WRITE_KEYS` is empty). `observe` records every privileged request and allows it anyway —
+  the rollout state. `enforce` refuses unauthorized ones.
 - `TTS_MAX_CONCURRENT` - Max concurrent TTS requests (default: 2)
 - `GEMINI_STRONG_MODEL` - Stronger Gemini model for whole-item slide drafting via `/api/translateItem` (default: `gemini-3.5-flash`)
 - `LIVE_AUDIO_SILENCE_THRESHOLD_DBFS` - dBFS voice bar for the live-audio cost path; a bridge suspends its Gemini session after ~30s below it (`-30` is a guess, never validated against a real room). Unset = off, no suspending. Beware the sign: dBFS is negative, so `0` gates hardest, not least. goaway/reconnect fixes and the always-on default translator are independent of this. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
@@ -143,11 +149,20 @@ docker compose down
 
 ## Architecture
 
+### Write Authorization
+
+Shared per-device keys, not user logins ([writeAuth.ts](writeAuth.ts), browser side
+[src/writeKey.ts](src/writeKey.ts), Python side [write_key.py](write_key.py)). Viewers need
+no key; a key is what buys a *writable* Y-Sweet token, the broadcaster's microphone, and the
+endpoints that spend money. Clients present it as `X-Write-Key`. Defaults to `observe` mode,
+which records every privileged request and allows it anyway. Full picture:
+[docs/WRITE_KEYS.md](docs/WRITE_KEYS.md).
+
 ### Core Collaboration Flow
 
 The app uses **Yjs** for real-time collaborative state management:
 
-1. **Y-Sweet authentication** ([server.ts:90-101](server.ts#L90-L101)): Backend issues read-only or full access tokens based on editor status
+1. **Y-Sweet authentication** ([server.ts:90-101](server.ts#L90-L101)): Backend issues read-only or full access tokens based on editor status, gated on a write key (an unauthorized editor request is downgraded to read-only, not refused)
 2. **Shared Y.Doc** per session: Each session (identified by `?doc=doc-YYYY-MM-DD`) has a shared Yjs document
 3. **Key shared data structures**:
    - `translatedText-{language}` (Y.Text): Translated output for each language

--- a/PROCLAIM_SERVICE_SETUP.md
+++ b/PROCLAIM_SERVICE_SETUP.md
@@ -37,7 +37,33 @@ Options:
 |---|---|
 | `--server-url=<url>` | Y-Sweet / API server (default `https://notelate.com`) |
 | `--branch=<branch>` | Release branch to track (default `proclaim-stable`) |
+| `--write-key=<key>` | Shared key authorizing this machine's writes (see below). Omit on a reinstall to keep the installed key |
 | `--no-auto-update` | Install without the pull-on-launch update; runs whatever is checked out |
+
+### Write key
+
+The server gates writes — full Y-Sweet tokens and `/api/translateItem` — on a shared
+per-device key ([docs/WRITE_KEYS.md](docs/WRITE_KEYS.md)). Give this machine its key at
+install time:
+
+```bash
+bash install_proclaim_service.sh --server-url=https://notelate.com --write-key=THEKEY
+```
+
+It is stored in the plist as `PROCLAIM_WRITE_KEY`, and is never fetched from the server
+(`/api/config` is public). A reinstall without `--write-key=` carries the existing key
+forward, so routine reinstalls don't de-authorize the machine.
+
+To check that it took, look for this line at startup — it reports whether a key is
+configured, never what it is:
+
+```
+Write key: configured
+```
+
+While the server runs in `observe` mode a missing key is recorded and still served, so
+`NOT configured` is a warning rather than an outage — until the server switches to
+`enforce`, at which point this machine stops being able to write.
 
 ## Automatic updates
 
@@ -266,6 +292,8 @@ Find the `EnvironmentVariables` section and uncomment/update the URLs you need:
     <string>http://your-ysweet-url.com</string>
     <key>PROCLAIM_BASE_URL</key>
     <string>http://your-proclaim-url:52195</string>
+    <key>PROCLAIM_WRITE_KEY</key>
+    <string>the-shared-write-key</string>
 </dict>
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,8 +99,14 @@ writer once each component announces its clientID (planned: via the status heart
   needs non-silent audio, not just a connection.
 - **Doc IDs are date-anchored** (`getDocId.ts`, and the Proclaim service anchors to the
   show's scheduled date), so a service's state lives in one doc per date.
-- **Editor vs viewer** is enforced server-side via Y-Sweet token scope, keyed off the
-  `#editor` request — there is currently no other auth.
+- **Editor vs viewer** is enforced server-side via Y-Sweet token scope. The `#editor` request
+  states an intent; whether it is honored depends on a shared per-device write key
+  (`writeAuth.ts`, [WRITE_KEYS.md](WRITE_KEYS.md)) — as does taking the microphone, and the
+  endpoints that spend money. Reading needs no key, and never will: viewers are the point.
+  An unauthorized editor request is *downgraded* to a read-only token rather than refused, so
+  a stale key shows the session read-only instead of a blank screen mid-service. The whole
+  thing defaults to `observe` mode, which records what it would have refused and refuses
+  nothing — check the mode before concluding that a key is being enforced.
 
 ## Testing seams
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@ Short, surfaced-not-comprehensive documentation. Coding agents can grep; humans 
 
 - [SMOKE_TEST.md](SMOKE_TEST.md) — the pre-service manual smoke-test checklist, and how PRs
   declare which sections they touch.
+- [WRITE_KEYS.md](WRITE_KEYS.md) — shared-key write authorization: what needs a key, the
+  observe→enforce rollout, how each device is given one, and how to rotate.
 - [OBSERVABILITY.md](OBSERVABILITY.md) — what to observe about the live-audio backend
   (status/liveness) and where to pull it from: PostHog events, in-process state, LiveKit, Yjs.
 - [live-audio-resilience.md](live-audio-resilience.md) — how the translation bridge survives

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -94,6 +94,10 @@ Skip entirely when `WRITE_KEYS` is unset (the server logs `write authorization i
 - [ ] Provision the editor device once with `#editor&key=THEKEY`: the key disappears from
       the address bar, and `#editor` survives.
 - [ ] Reload that device with a plain `#editor` URL (no key): still an editor.
+- [ ] `/status` reports "Key installed" and the last four characters of the right key.
+- [ ] On a device with no key (or a wrong one), an `#editor` URL prompts for a key, and
+      pasting a valid one grants edit access without a reload. Cancelling continues
+      read-only — and does *not* prompt again on the next reconnect.
 - [ ] Server logs show `key=<label> → ok` for `/api/ys-auth` from each real device —
       the editor browsers, the Proclaim Mac (`Write key: configured` in its own log), and
       the feeder. Anything logged as `key=none` is a device that `enforce` would lock out.

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -85,7 +85,28 @@ startup log line reports which):
 - [ ] Tap a translated line: audio plays. Tap again: cancels.
 - [ ] Auto-speak advances line to line.
 
-## 6. Teardown sanity
+## 6. Write keys
+
+Skip entirely when `WRITE_KEYS` is unset (the server logs `write authorization is off`).
+
+- [ ] Server startup logs show the expected mode and key labels:
+      `[write-auth] mode=observe keys=[proclaim, booth, …]`.
+- [ ] Provision the editor device once with `#editor&key=THEKEY`: the key disappears from
+      the address bar, and `#editor` survives.
+- [ ] Reload that device with a plain `#editor` URL (no key): still an editor.
+- [ ] Server logs show `key=<label> → ok` for `/api/ys-auth` from each real device —
+      the editor browsers, the Proclaim Mac (`Write key: configured` in its own log), and
+      the feeder. Anything logged as `key=none` is a device that `enforce` would lock out.
+- [ ] A viewer URL (no `#editor`, no key) still connects, and TTS still plays — viewers must
+      never need a key.
+
+**In `enforce` mode only** (skip while in `observe`):
+
+- [ ] An editor URL on an unprovisioned device shows the read-only banner and no edit
+      controls, rather than a blank or broken page.
+- [ ] Broadcast from an unprovisioned device fails with a visible error, not silence.
+
+## 7. Teardown sanity
 
 - [ ] Close all listener tabs; confirm the supervisor winds the translator bots down within
       ~2 minutes (60 s demand grace + a reconcile tick; watch for `[SessionManager] Supervisor

--- a/docs/WRITE_KEYS.md
+++ b/docs/WRITE_KEYS.md
@@ -58,12 +58,19 @@ booting into a state where every device — including the Proclaim service — i
 
    ```
    [write-auth] observe /api/ys-auth key=proclaim → ok
-   [write-auth] observe /api/livekit/token key=none → MISSING (allowed — observe mode)
+   [write-auth] observe /api/livekit/token key=none ip=192.168.1.40 → MISSING (allowed — observe mode)
+   [write-auth] observe /api/ys-auth key=unknown(3f2a9c11) ip=192.168.1.51 → INVALID (allowed — observe mode)
    ```
 
    Every line with `key=none` or `key=unknown` is a device that would have been locked out.
-   Chase those down first — the PostHog event carries `route`, `status` and `keyLabel`, so
-   "has the tablet been provisioned yet?" is a chart, not a grep.
+   Chase those down first. The audit says as much as it can about who asked: the caller's
+   address, a truncated user agent, and — for a key that was presented but not recognized —
+   a short digest of it. That digest is what separates "still on last month's key" from
+   "junk", and being stable it makes every un-migrated device one bucket to watch drain.
+
+   The same fields ride on the PostHog `write_auth_check` event, filed under the device
+   label when known, else `stale-key-<digest>`, else `no-key-<ip>` — so "has the tablet been
+   provisioned yet?" is a chart, not a grep.
 3. When nothing but the odd stray shows up missing, set `WRITE_AUTH_MODE=enforce` and restart.
 
 ## Giving a device its key
@@ -109,12 +116,50 @@ It lands in the LaunchAgent plist as `PROCLAIM_WRITE_KEY`. Reinstalling without
 
 ## Rotating
 
-Rotation is editing `WRITE_KEYS` and restarting the server. Because it is a *list*, old and
-new can overlap: add the new key, move devices over one at a time, then delete the old entry.
-Removing a device's key is how you revoke it.
+The server holds many keys at once; each device holds exactly one. That asymmetry is what
+makes rotation work — the overlap lives in `WRITE_KEYS`, and devices move across it one at a
+time.
 
-One caveat: a Y-Sweet token already issued stays valid until it expires — revoking a key
-stops the *next* token from being issued, not the current one.
+**Not during a service.** Every `WRITE_KEYS` edit needs a server restart, and a restart drops
+the live translator bridges and the broadcaster's room along with it. Rotate on a weekday.
+
+1. **One edit, one restart.** Add the new key *and* relabel the old one to say it's on its
+   way out:
+
+   ```sh
+   WRITE_KEYS=booth-old:OLDKEY,booth:NEWKEY,proclaim:…,feeder:…
+   ```
+
+   Labels are display-only — nothing compares them — so renaming an entry doesn't disturb
+   the device still using it. What it buys you is a name for the un-migrated: the booth
+   laptop keeps working and now announces itself in the logs as `key=booth-old`.
+
+2. **Move the devices** (see the previous section: `/status` is the one to use here — the
+   masked tail tells you whether a device has actually moved). Watch the logs:
+
+   ```
+   [write-auth] observe /api/ys-auth key=booth-old ip=192.168.1.40 → ok
+   ```
+
+3. **When `booth-old` stops appearing, delete it** and restart again. That silence is the
+   completion criterion — better than trying to remember which devices you got.
+
+Removing a device's key is also how you revoke it. Two caveats:
+
+- **A Y-Sweet token already issued stays valid until it expires.** Revoking a key stops the
+  *next* token from being issued, not the one in flight.
+- **A key is per-device only by convention.** Nothing stops two devices sharing one, and the
+  server can't tell that they do. If you rotate a key to lock out a lost tablet, that only
+  works if nothing else was ever given the same key. The server warns at boot when two
+  labels share a key value, which catches the accident but not the habit.
+
+### Keys the server can't reach
+
+The Proclaim Mac and the audio feeder are rotated by hand, on the machine — the installer's
+`--write-key=` and the feeder's settings pane. There is no remote path. For the feeder in
+particular this means a rotation is a trip to the booth, so give it a key you're content to
+leave in place, and confirm it in the server log (`key=feeder → ok`) rather than by looking
+at the machine.
 
 ## What this is and isn't
 

--- a/docs/WRITE_KEYS.md
+++ b/docs/WRITE_KEYS.md
@@ -23,7 +23,26 @@ device is given a key once and keeps it.
 
 The last row is the deliberate gap: listeners legitimately request TTS and translator bots,
 so those endpoints cannot require an editor's key. They are still unauthenticated and still
-cost money. Not built yet (TODO): ensure that `/api/tts` can only speak lines that are in the current notes, and there's a maximum number of live translator bots (`/api/livekit/translate`) at a time.
+cost money — and once `enforce` closes everything else, they are the *only* unmetered spend
+left, which is where anyone holding the URL will end up.
+
+Both now carry a crude per-caller rate limit ([rateLimit.ts](../rateLimit.ts)) as a stopgap:
+
+```sh
+TTS_RATE_LIMIT_PER_MIN=600         # default; 0 disables
+TRANSLATE_RATE_LIMIT_PER_MIN=1200  # default; 0 disables
+```
+
+The defaults sit far above what a real service generates, on purpose. A congregation
+arrives from a single public address, so a limit tight enough to be interesting is also
+tight enough to cut off the room; what these stop is a script in a loop, which is orders of
+magnitude away. The caller is identified by `X-Forwarded-For` where present, which is
+spoofable — an abuser can evade the cap, which leaves us no worse off than having none.
+
+Still to build (TODO): `/api/tts` should only speak lines that are actually in the current
+notes, and there should be a ceiling on how many live translator bots
+(`/api/livekit/translate`) can exist at once. Those are the real fixes; the rate limit just
+buys time.
 
 ## Configuring the server
 

--- a/docs/WRITE_KEYS.md
+++ b/docs/WRITE_KEYS.md
@@ -68,18 +68,32 @@ booting into a state where every device — including the Proclaim service — i
 
 ## Giving a device its key
 
-**Browser (booth laptop, tablet).** Open the app once with the key in the URL fragment:
+**Browser (booth laptop, tablet).** Three ways in, all landing in the same
+`localStorage` slot:
 
-```
-https://…/sourceText#editor&key=THEKEY
-```
+1. **It asks.** Open an `#editor` URL on a device the server doesn't recognize and the page
+   prompts for a key, stores what you paste, and retries. Once per page load, whatever the
+   answer — cancelling continues read-only rather than nagging on the next reconnect. This
+   fires in `observe` mode too, where nothing is refused, because that is when devices are
+   supposed to be getting their keys.
+2. **The status page.** `/status` shows whether this device has a key and the last four
+   characters of it, with a box to paste a new one and a button to clear it. This is the one
+   to use for rotation: the masked tail answers "has this tablet moved to the new key yet?"
+   without putting the secret on a screen.
+3. **A URL, for a device you're setting up in advance:**
 
-The key is stored in that browser's `localStorage` and stripped from the address bar
-immediately, so it doesn't linger on screen or in a bookmark. Every later visit — plain
-`#editor`, no key — is authorized. A `?key=THEKEY` query parameter works too, but prefer the
-fragment: it never reaches the server's access log.
+   ```
+   https://…/sourceText#editor&key=THEKEY
+   ```
 
-Clearing site data (or a different browser, or a private window) means provisioning again.
+   The key is stored and stripped from the address bar immediately, so it doesn't linger on
+   screen or in a bookmark — though a URL you *typed* still lands in the browser's own
+   history and omnibox suggestions, so prefer (1) or (2) on a shared machine. A `?key=THEKEY`
+   query parameter works too, but prefer the fragment: it never reaches the server's access
+   log.
+
+Every later visit — plain `#editor`, no key — is authorized. Clearing site data (or a
+different browser, or a private window) means provisioning again.
 
 **Proclaim service.** Pass it to the installer:
 

--- a/docs/WRITE_KEYS.md
+++ b/docs/WRITE_KEYS.md
@@ -23,7 +23,7 @@ device is given a key once and keeps it.
 
 The last row is the deliberate gap: listeners legitimately request TTS and translator bots,
 so those endpoints cannot require an editor's key. They are still unauthenticated and still
-cost money. Rate limiting, not a key, is the answer there, and it isn't built yet.
+cost money. Not built yet (TODO): ensure that `/api/tts` can only speak lines that are in the current notes, and there's a maximum number of live translator bots (`/api/livekit/translate`) at a time.
 
 ## Configuring the server
 

--- a/docs/WRITE_KEYS.md
+++ b/docs/WRITE_KEYS.md
@@ -1,0 +1,114 @@
+# Write keys
+
+Reading a session is open to anyone with the link. **Writing** — editing the notes, taking
+the microphone, spending money on models and TTS — is gated on a shared key.
+
+The unit being authorized is a **device**, not a person: the booth laptop, the tablet on the
+music stand, the Proclaim Mac, the audio feeder. There are no accounts and no logins. Each
+device is given a key once and keeps it.
+
+## What a key protects
+
+| Endpoint | Needs a key |
+|---|---|
+| `POST /api/ys-auth` with `isEditor: true` (a *writable* Y-Sweet token) | yes |
+| `POST /api/ys-auth` for a read-only token | no — anyone may watch |
+| `POST /api/livekit/token` with `role: organizer` (the microphone) | yes |
+| `POST /api/livekit/token` as a listener | no |
+| `POST /api/translateItem`, `/api/slideConversation/message`, `/api/slideConversation/note` | yes |
+| `POST /api/requestTranslatedBlocks` | yes |
+| `POST /api/slideLibrary` (upsert a reviewed translation) | yes |
+| `GET /api/slideLibrary`, `POST /api/slideLibrary/lookup` | no |
+| `POST /api/tts`, `POST /api/livekit/translate` | no — **viewers call these** |
+
+The last row is the deliberate gap: listeners legitimately request TTS and translator bots,
+so those endpoints cannot require an editor's key. They are still unauthenticated and still
+cost money. Rate limiting, not a key, is the answer there, and it isn't built yet.
+
+## Configuring the server
+
+Two environment variables:
+
+```sh
+# A comma-separated list. Each entry is `label:key`, or a bare `key`.
+# The label is only used in logs — it answers "which device is this?".
+WRITE_KEYS=proclaim:kZ8x…,booth:9fQ2…,tablet:Lm4v…,feeder:t7Rb…
+
+# off | observe | enforce   (default: observe)
+WRITE_AUTH_MODE=observe
+```
+
+Generate a key with `openssl rand -hex 24`.
+
+### The three modes
+
+- **`off`** — no checking, no logging. Also the automatic mode when `WRITE_KEYS` is empty, so
+  an install that doesn't use this feature is unaffected.
+- **`observe`** (default) — every privileged request is checked and recorded, then **allowed
+  regardless**. Nothing is refused. This is how a rollout starts.
+- **`enforce`** — unauthorized privileged requests are refused.
+
+Asking for `enforce` with no keys configured makes the server refuse to start, rather than
+booting into a state where every device — including the Proclaim service — is locked out.
+
+## Rolling it out
+
+1. Set `WRITE_KEYS` and leave the mode at `observe`. Distribute keys to the devices (below).
+2. Run a service. Then read the logs, or the `write_auth_check` event in PostHog:
+
+   ```
+   [write-auth] observe /api/ys-auth key=proclaim → ok
+   [write-auth] observe /api/livekit/token key=none → MISSING (allowed — observe mode)
+   ```
+
+   Every line with `key=none` or `key=unknown` is a device that would have been locked out.
+   Chase those down first — the PostHog event carries `route`, `status` and `keyLabel`, so
+   "has the tablet been provisioned yet?" is a chart, not a grep.
+3. When nothing but the odd stray shows up missing, set `WRITE_AUTH_MODE=enforce` and restart.
+
+## Giving a device its key
+
+**Browser (booth laptop, tablet).** Open the app once with the key in the URL fragment:
+
+```
+https://…/sourceText#editor&key=THEKEY
+```
+
+The key is stored in that browser's `localStorage` and stripped from the address bar
+immediately, so it doesn't linger on screen or in a bookmark. Every later visit — plain
+`#editor`, no key — is authorized. A `?key=THEKEY` query parameter works too, but prefer the
+fragment: it never reaches the server's access log.
+
+Clearing site data (or a different browser, or a private window) means provisioning again.
+
+**Proclaim service.** Pass it to the installer:
+
+```sh
+bash install_proclaim_service.sh --server-url=https://… --write-key=THEKEY
+```
+
+It lands in the LaunchAgent plist as `PROCLAIM_WRITE_KEY`. Reinstalling without
+`--write-key=` keeps the key already installed. The service logs `Write key: configured` (or
+`NOT configured`) at startup — never the key itself.
+
+**macOS audio feeder.** Settings → Server → *Write key*.
+
+## Rotating
+
+Rotation is editing `WRITE_KEYS` and restarting the server. Because it is a *list*, old and
+new can overlap: add the new key, move devices over one at a time, then delete the old entry.
+Removing a device's key is how you revoke it.
+
+One caveat: a Y-Sweet token already issued stays valid until it expires — revoking a key
+stops the *next* token from being issued, not the current one.
+
+## What this is and isn't
+
+It is a lock on the door: someone who finds the URL can't scribble on the notes or evict the
+speaker from the microphone mid-service.
+
+It is not per-user access control, and it doesn't pretend to be. Everyone with a key can do
+everything, keys are shared, keys live in browser storage and a plist, and anyone holding one
+can pass it on. There is no audit trail beyond the key's label. For the failure modes this is
+meant to prevent — a stranger with the link, a misconfigured device, an accidental edit from
+the wrong tab — that's the right size. For anything stronger, this is the wrong design.

--- a/install_proclaim_service.sh
+++ b/install_proclaim_service.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 # Install proclaim_service as a macOS LaunchAgent
 # Usage: bash install_proclaim_service.sh [--server-url=<url>] [--branch=<branch>]
-#                                         [--no-auto-update] [--uninstall]
+#                                         [--write-key=<key>] [--no-auto-update]
+#                                         [--uninstall]
+#
+# --write-key is the shared key this machine presents to the server's privileged
+# endpoints (see docs/WRITE_KEYS.md). It is NOT fetched from the server — /api/config is
+# public. Omitting it on a reinstall keeps whatever key is already installed.
 #
 # The LaunchAgent runs proclaim_service_launch.sh, which updates this checkout
 # from the release branch on every launch before starting the service. See
@@ -47,6 +52,19 @@ fetch_posthog_config() {
     POSTHOG_HOST=$(echo "$config" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('posthogHost',''))")
 }
 
+# Escape a value for use as a sed replacement with | as the delimiter.
+sed_escape() {
+    printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
+# The write key already installed, if any. Lets a reinstall (or an --server-url change)
+# keep the machine's key instead of silently dropping it.
+read_existing_write_key() {
+    [ -f "$PLIST_DEST" ] || return 1
+    /usr/libexec/PlistBuddy -c "Print :EnvironmentVariables:PROCLAIM_WRITE_KEY" \
+        "$PLIST_DEST" 2>/dev/null
+}
+
 generate_plist() {
     # Generate plist from template with variable substitution
     sed "s|{{SERVICE_SCRIPT}}|$SERVICE_SCRIPT|g" "$PLIST_TEMPLATE" | \
@@ -60,6 +78,7 @@ generate_plist() {
     sed "s|{{AUTO_UPDATE}}|$AUTO_UPDATE|g" | \
     sed "s|{{POSTHOG_KEY}}|$POSTHOG_KEY|g" | \
     sed "s|{{POSTHOG_HOST}}|$POSTHOG_HOST|g" | \
+    sed "s|{{WRITE_KEY}}|$(sed_escape "$WRITE_KEY")|g" | \
     sed "s|{{YSWEET_URL}}|$SERVER_URL|g"
 }
 
@@ -90,15 +109,24 @@ POSTHOG_HOST=""
 # `git push origin main:proclaim-stable`.
 UPDATE_BRANCH="proclaim-stable"
 AUTO_UPDATE="1"
+WRITE_KEY=""
+WRITE_KEY_GIVEN="0"
 
 for arg in "$@"; do
     case "$arg" in
         --uninstall) uninstall ;;
         --server-url=*) SERVER_URL="${arg#--server-url=}" ;;
         --branch=*) UPDATE_BRANCH="${arg#--branch=}" ;;
+        --write-key=*) WRITE_KEY="${arg#--write-key=}"; WRITE_KEY_GIVEN="1" ;;
         --no-auto-update) AUTO_UPDATE="0" ;;
     esac
 done
+
+# Carry the installed key forward when this run didn't supply one, so routine
+# reinstalls and server-url changes don't quietly de-authorize the machine.
+if [ "$WRITE_KEY_GIVEN" = "0" ]; then
+    WRITE_KEY="$(read_existing_write_key || true)"
+fi
 
 if [ -z "$SERVER_URL" ]; then
     log_error "--server-url is required"
@@ -168,6 +196,15 @@ log_info "  Repo:   $SCRIPT_DIR"
 log_info "  Logs:   $LOG_DIR"
 log_info "  uv:     $UV_PATH"
 log_info "  Server: $SERVER_URL"
+if [ -n "$WRITE_KEY" ]; then
+    if [ "$WRITE_KEY_GIVEN" = "1" ]; then
+        log_info "  Key:    installed"
+    else
+        log_info "  Key:    kept from the previous install"
+    fi
+else
+    log_warn "  Key:    none — pass --write-key=<key> once the server enforces write keys"
+fi
 if [ "$AUTO_UPDATE" = "1" ]; then
     log_info "  Update: on every launch, from origin/$UPDATE_BRANCH"
 else

--- a/macos-audio-feeder/Packaging/build-app.sh
+++ b/macos-audio-feeder/Packaging/build-app.sh
@@ -51,7 +51,7 @@ if [[ -z "$TEAM_ID" ]]; then
     -derivedDataPath "$BUILD_DIR" \
     ENABLE_HARDENED_RUNTIME=NO \
     build
-  echo "==> Built: $BUILD_DIR/Build/Products/Release/$APP_NAME.app"
+  echo "==> Built: \"$BUILD_DIR/Build/Products/Release/$APP_NAME.app\""
   echo "    Unsigned. Set TEAM_ID (and NOTARIZE_PROFILE) for a distributable build."
   exit 0
 fi

--- a/macos-audio-feeder/README.md
+++ b/macos-audio-feeder/README.md
@@ -75,6 +75,21 @@ open AudioFeeder.xcodeproj # then just hit Run
 Re-run `xcodegen generate` after changing `project.yml` (or after adding source files, since
 the file list is captured at generation time).
 
+## Write key
+
+Publishing takes the room's microphone — and because every broadcaster shares the
+`organizer-host` identity, it evicts whoever is currently speaking. The server therefore
+gates organizer tokens on a shared per-device key ([docs/WRITE_KEYS.md](../docs/WRITE_KEYS.md)).
+
+Paste this machine's key into **Settings → Server → Write key**. It rides on the
+`/api/livekit/token` request as `X-Write-Key`; nothing else about the request changes. While
+the server runs in `observe` mode a blank key still works, so the feeder keeps publishing
+until the server switches to `enforce`.
+
+The key is persisted in the app's plaintext JSON config alongside the other settings, not the
+Keychain — proportionate for a key that grants a room's microphone and is rotated by editing
+the server's `WRITE_KEYS`.
+
 ## Watching the logs
 
 The app has no console window and, when it's doing its job, no visible UI beyond a menu-bar

--- a/macos-audio-feeder/Sources/AudioFeederApp/AppController.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/AppController.swift
@@ -197,7 +197,7 @@ final class AppController: ObservableObject {
             channel \(self.config.channelIndex + 1, privacy: .public), room \(docID, privacy: .public)
             """)
 
-        let publisher = Publisher(serverURL: config.serverURL)
+        let publisher = Publisher(serverURL: config.serverURL, writeKey: config.writeKey)
         publisher.onStateChange = { [weak self] pubState in
             Task { @MainActor in self?.handlePublisherState(pubState) }
         }

--- a/macos-audio-feeder/Sources/AudioFeederApp/ConfigView.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/ConfigView.swift
@@ -22,11 +22,11 @@ struct ConfigView: View {
                                 set: { controller.config.docIDOverride = $0.isEmpty ? nil : $0 }))
                     Text("Will publish to room: \(controller.config.resolvedDocID())")
                         .font(.caption).foregroundStyle(.secondary)
-                    SecureField("Write key (from the server's WRITE_KEYS)",
+                    SecureField("Write key (must match the server)",
                                 text: Binding(
                                     get: { controller.config.writeKey ?? "" },
                                     set: { controller.config.writeKey = $0.isEmpty ? nil : $0 }))
-                    Text("Required to take the microphone once the server enforces keys.")
+                    Text("Required to take the microphone.")
                         .font(.caption).foregroundStyle(.secondary)
                 }
 

--- a/macos-audio-feeder/Sources/AudioFeederApp/ConfigView.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/ConfigView.swift
@@ -22,6 +22,12 @@ struct ConfigView: View {
                                 set: { controller.config.docIDOverride = $0.isEmpty ? nil : $0 }))
                     Text("Will publish to room: \(controller.config.resolvedDocID())")
                         .font(.caption).foregroundStyle(.secondary)
+                    SecureField("Write key (from the server's WRITE_KEYS)",
+                                text: Binding(
+                                    get: { controller.config.writeKey ?? "" },
+                                    set: { controller.config.writeKey = $0.isEmpty ? nil : $0 }))
+                    Text("Required to take the microphone once the server enforces keys.")
+                        .font(.caption).foregroundStyle(.secondary)
                 }
 
                 Section("Input") {

--- a/macos-audio-feeder/Sources/AudioFeederApp/Publisher.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/Publisher.swift
@@ -58,6 +58,7 @@ final class Publisher {
     var onStateChange: ((State) -> Void)?
 
     private let serverURL: String
+    private let writeKey: String?
     private var room: Room?
     private var connectTask: Task<Void, Never>?
 
@@ -70,8 +71,9 @@ final class Publisher {
     /// notably the `didDisconnectWithError(nil)` that our own `stop()` provokes.
     private var sessionID: Int = 0
 
-    init(serverURL: String) {
+    init(serverURL: String, writeKey: String? = nil) {
         self.serverURL = serverURL
+        self.writeKey = writeKey
     }
 
     /// Connect to `room` (the doc id) and publish. Idempotent while connected/connecting.
@@ -115,7 +117,8 @@ final class Publisher {
         var pending: Room?
         do {
             Log.publisher.notice("fetching token from \(self.serverURL, privacy: .public) for room \(docID, privacy: .public)")
-            let token = try await LiveKitTokenClient(serverURL: serverURL).fetchToken(room: docID)
+            let token = try await LiveKitTokenClient(serverURL: serverURL, writeKey: writeKey)
+                .fetchToken(room: docID)
             guard isCurrent(id) else { return }
             Log.publisher.notice("token OK; connecting to \(token.serverUrl, privacy: .public)")
 

--- a/macos-audio-feeder/Sources/AudioFeederCore/Config.swift
+++ b/macos-audio-feeder/Sources/AudioFeederCore/Config.swift
@@ -53,6 +53,14 @@ public struct FeederConfig: Codable, Equatable, Sendable {
     public var serverURL: String
     /// Optional explicit Y-Sweet/LiveKit doc id. When nil, defaults to `doc-YYYY-MM-DD` (local).
     public var docIDOverride: String?
+    /// Shared key authorizing this machine to take the microphone (server side: writeAuth.ts).
+    /// Publishing evicts whoever is currently broadcasting, so the server gates it on a key.
+    /// Optional: while the server runs in observe mode a keyless request is still served.
+    ///
+    /// Persisted in the same plaintext JSON as the rest of the config, not the Keychain —
+    /// adequate for a key that only grants the room's microphone, and rotated by editing
+    /// the server's WRITE_KEYS.
+    public var writeKey: String?
     /// CoreAudio device UID of the sound board (stable across hotplug, unlike device index).
     public var deviceUID: String?
     /// 0-based channel index to pull from the multichannel device.
@@ -62,12 +70,14 @@ public struct FeederConfig: Codable, Equatable, Sendable {
 
     public init(serverURL: String = "https://notelate.com",
                 docIDOverride: String? = nil,
+                writeKey: String? = nil,
                 deviceUID: String? = nil,
                 channelIndex: Int = 0,
                 schedule: Schedule = Schedule(),
                 manualOverride: ManualOverride = .off) {
         self.serverURL = serverURL
         self.docIDOverride = docIDOverride
+        self.writeKey = writeKey
         self.deviceUID = deviceUID
         self.channelIndex = channelIndex
         self.schedule = schedule

--- a/macos-audio-feeder/Sources/AudioFeederCore/LiveKitTokenClient.swift
+++ b/macos-audio-feeder/Sources/AudioFeederCore/LiveKitTokenClient.swift
@@ -29,11 +29,17 @@ public enum LiveKitTokenError: Error, CustomStringConvertible {
 public struct LiveKitTokenClient: Sendable {
     public static let organizerIdentity = "organizer-host"
 
+    /// Must match WRITE_KEY_HEADER in the server's writeAuth.ts.
+    public static let writeKeyHeader = "X-Write-Key"
+
     public var serverURL: String
+    /// Shared key authorizing an organizer (publishing) token. Omitted when nil/blank.
+    public var writeKey: String?
     private let session: URLSession
 
-    public init(serverURL: String, session: URLSession = .shared) {
+    public init(serverURL: String, writeKey: String? = nil, session: URLSession = .shared) {
         self.serverURL = serverURL
+        self.writeKey = writeKey
         self.session = session
     }
 
@@ -44,9 +50,11 @@ public struct LiveKitTokenClient: Sendable {
         ["room": room, "identity": identity, "role": role]
     }
 
-    public func fetchToken(room: String,
-                           identity: String = organizerIdentity,
-                           role: String = "organizer") async throws -> LiveKitToken {
+    /// Build the exact request `fetchToken` sends. Separated so tests can assert on the
+    /// headers and body without stubbing the network.
+    public func makeRequest(room: String,
+                            identity: String = organizerIdentity,
+                            role: String = "organizer") throws -> URLRequest {
         let base = serverURL.hasSuffix("/") ? String(serverURL.dropLast()) : serverURL
         guard let url = URL(string: "\(base)/api/livekit/token") else {
             throw LiveKitTokenError.malformedResponse
@@ -54,8 +62,18 @@ public struct LiveKitTokenClient: Sendable {
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let key = writeKey?.trimmingCharacters(in: .whitespacesAndNewlines), !key.isEmpty {
+            req.setValue(key, forHTTPHeaderField: Self.writeKeyHeader)
+        }
         req.httpBody = try JSONSerialization.data(
             withJSONObject: Self.requestBody(room: room, identity: identity, role: role))
+        return req
+    }
+
+    public func fetchToken(room: String,
+                           identity: String = organizerIdentity,
+                           role: String = "organizer") async throws -> LiveKitToken {
+        let req = try makeRequest(room: room, identity: identity, role: role)
 
         let (data, response) = try await session.data(for: req)
         if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {

--- a/macos-audio-feeder/Tests/AudioFeederCoreTests/LiveKitTokenClientTests.swift
+++ b/macos-audio-feeder/Tests/AudioFeederCoreTests/LiveKitTokenClientTests.swift
@@ -14,6 +14,36 @@ final class LiveKitTokenClientTests: XCTestCase {
         XCTAssertEqual(LiveKitTokenClient.organizerIdentity, "organizer-host")
     }
 
+    func testRequestCarriesTheWriteKeyWhenConfigured() throws {
+        let client = LiveKitTokenClient(serverURL: "https://example.com", writeKey: "SECRET123")
+        let req = try client.makeRequest(room: "doc-2025-06-30")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "X-Write-Key"), "SECRET123")
+    }
+
+    func testRequestOmitsTheWriteKeyHeaderWhenUnset() throws {
+        let unset = LiveKitTokenClient(serverURL: "https://example.com")
+        XCTAssertNil(try unset.makeRequest(room: "r").value(forHTTPHeaderField: "X-Write-Key"))
+
+        let blank = LiveKitTokenClient(serverURL: "https://example.com", writeKey: "   ")
+        XCTAssertNil(try blank.makeRequest(room: "r").value(forHTTPHeaderField: "X-Write-Key"))
+    }
+
+    func testWriteKeyDoesNotDisturbTheExistingRequestContract() throws {
+        let client = LiveKitTokenClient(serverURL: "https://example.com", writeKey: "SECRET123")
+        let req = try client.makeRequest(room: "doc-2025-06-30")
+
+        XCTAssertEqual(req.url?.absoluteString, "https://example.com/api/livekit/token")
+        XCTAssertEqual(req.httpMethod, "POST")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let body = try XCTUnwrap(req.httpBody)
+        let decoded = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: body) as? [String: String])
+        XCTAssertEqual(decoded["room"], "doc-2025-06-30")
+        XCTAssertEqual(decoded["identity"], "organizer-host")
+        XCTAssertEqual(decoded["role"], "organizer")
+    }
+
     func testTokenDecoding() throws {
         let json = Data(#"{"token":"jwt.abc","serverUrl":"wss://lk.example.com"}"#.utf8)
         let token = try JSONDecoder().decode(LiveKitToken.self, from: json)

--- a/org.kenarnold.proclaim-service.plist.template
+++ b/org.kenarnold.proclaim-service.plist.template
@@ -45,6 +45,12 @@
         <key>YSWEET_URL</key>
         <string>{{YSWEET_URL}}</string>
 
+        <!-- Shared key authorizing this machine's writes (full Y-Sweet tokens and
+             /api/translateItem). Installed by install_proclaim_service.sh --write-key=;
+             never fetched from the server, since /api/config is public. -->
+        <key>PROCLAIM_WRITE_KEY</key>
+        <string>{{WRITE_KEY}}</string>
+
         <!-- Set PROCLAIM_BASE_URL if on different machine -->
         <key>PROCLAIM_BASE_URL</key>
         <string>http://127.0.0.1:52195</string>

--- a/proclaim_service.py
+++ b/proclaim_service.py
@@ -39,6 +39,7 @@ from proclaim_feed import DEFAULT_PROCLAIM_BASE_URL, ProclaimFeed
 from slide_feed import SlideFeed
 from slide_replay import RecordingSlideFeed, ReplaySlideFeed, load_records
 from slide_sync_runtime import RuntimeTiming, SlideSyncRuntime
+from write_key import get_write_key, write_key_headers
 from slide_translator import SlideTranslator
 from yjs_publisher import YjsSlidePublisher
 
@@ -56,6 +57,10 @@ logging.getLogger('httpx').setLevel(logging.WARNING)
 PROCLAIM_BASE_URL = os.getenv('PROCLAIM_BASE_URL', DEFAULT_PROCLAIM_BASE_URL)
 YSWEET_URL = os.getenv('YSWEET_URL', '')
 assert YSWEET_URL, "YSWEET_URL must be set"
+# Shared key identifying this machine to the server's privileged endpoints (full Y-Sweet
+# tokens, /api/translateItem). Installed into the LaunchAgent plist by
+# install_proclaim_service.sh --write-key=. Optional while the server runs in observe mode.
+WRITE_KEY = get_write_key()
 POLL_INTERVAL = float(os.getenv('PROCLAIM_POLL_INTERVAL', '0.5'))  # seconds
 POLL_INTERVAL_OFF_AIR = float(os.getenv('PROCLAIM_POLL_INTERVAL_OFF_AIR', '10'))  # seconds
 # How often the feed re-reads the full on-air service order (all items + slides). Items whose
@@ -197,7 +202,7 @@ def make_status_announcer(
     return announce
 
 
-def make_translate_fn(ysweet_url: str, languages: List[str]):
+def make_translate_fn(ysweet_url: str, languages: List[str], write_key: Optional[str] = None):
     """Build the translation call the SlideTranslator injects: POST /api/translateItem.
 
     Returns the ``{language: [{text, status, provenance}, ...]}`` map, or None on failure
@@ -228,6 +233,7 @@ def make_translate_fn(ysweet_url: str, languages: List[str]):
                 response = await client.post(
                     f"{ysweet_url}/api/translateItem",
                     json=body,
+                    headers=write_key_headers(write_key),
                     timeout=3 * 60.0,
                 )
                 response.raise_for_status()
@@ -295,7 +301,9 @@ def build_runtime(
     )
     publisher = YjsSlidePublisher()
     translator = SlideTranslator(
-        translate_fn=make_translate_fn(YSWEET_URL, SLIDE_TRANSLATION_LANGUAGES),
+        translate_fn=make_translate_fn(
+            YSWEET_URL, SLIDE_TRANSLATION_LANGUAGES, write_key=WRITE_KEY
+        ),
         languages=SLIDE_TRANSLATION_LANGUAGES,
         scan_interval=TRANSLATION_SCAN_INTERVAL,
         report_exception=report_exception,
@@ -315,6 +323,7 @@ def build_runtime(
         feed, publisher, translator, YSWEET_URL,
         doc_id=doc_id, timing=timing, report_exception=report_exception,
         on_session_start=make_status_announcer(),
+        write_key=WRITE_KEY,
     )
 
 
@@ -366,6 +375,10 @@ async def main():
 
     logger.info(f"Proclaim URL: {PROCLAIM_BASE_URL}")
     logger.info(f"Poll interval: {POLL_INTERVAL}s (on air), {POLL_INTERVAL_OFF_AIR}s (off air)")
+    # Says whether a key is configured, never what it is. Worth a line: once the server
+    # enforces keys, "no write key configured" is the whole explanation for a service that
+    # connects but silently can't write.
+    logger.info(f"Write key: {'configured' if WRITE_KEY else 'NOT configured'}")
     version_info = service_version_info()
     logger.info(
         f"Version: {version_info['gitShaShort'] or 'unknown'} "

--- a/rateLimit.test.ts
+++ b/rateLimit.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RateLimiter, callerKey, limitFromEnv } from './rateLimit.ts';
+
+/** A clock the test drives by hand, so no window has to be waited out. */
+function fakeClock(start = 1_000_000) {
+  let now = start;
+  return { now: () => now, advance: (ms: number) => (now += ms) };
+}
+
+describe('callerKey', () => {
+  it('prefers the forwarded address, since req.ip behind a proxy is the proxy', () => {
+    // The failure this avoids: every listener collapsing into one bucket and the cap
+    // taking down a full service.
+    expect(
+      callerKey({ ip: '10.0.0.1', headers: { 'x-forwarded-for': '203.0.113.7' } }),
+    ).toBe('203.0.113.7');
+  });
+
+  it('takes the first hop of a forwarded chain', () => {
+    expect(
+      callerKey({ ip: '10.0.0.1', headers: { 'x-forwarded-for': '203.0.113.7, 10.0.0.5' } }),
+    ).toBe('203.0.113.7');
+  });
+
+  it('falls back to the socket address, then to a constant', () => {
+    expect(callerKey({ ip: '203.0.113.7', headers: {} })).toBe('203.0.113.7');
+    expect(callerKey({ headers: {} })).toBe('unknown');
+    expect(callerKey({ ip: '203.0.113.7', headers: { 'x-forwarded-for': '  ' } })).toBe(
+      '203.0.113.7',
+    );
+  });
+});
+
+describe('RateLimiter', () => {
+  it('allows exactly the limit, then refuses', () => {
+    const limiter = new RateLimiter({ limit: 3, route: '/api/tts' });
+    const results = [1, 2, 3, 4].map(() => limiter.check('caller').allowed);
+    expect(results).toEqual([true, true, true, false]);
+  });
+
+  it('counts each caller separately', () => {
+    const limiter = new RateLimiter({ limit: 1, route: '/api/tts' });
+    expect(limiter.check('a').allowed).toBe(true);
+    expect(limiter.check('b').allowed).toBe(true);
+    expect(limiter.check('a').allowed).toBe(false);
+  });
+
+  it('forgives once the window rolls over', () => {
+    const clock = fakeClock();
+    const limiter = new RateLimiter({
+      limit: 1,
+      windowMs: 60_000,
+      route: '/api/tts',
+      now: clock.now,
+    });
+
+    expect(limiter.check('caller').allowed).toBe(true);
+    expect(limiter.check('caller').allowed).toBe(false);
+
+    clock.advance(60_000);
+    expect(limiter.check('caller').allowed).toBe(true);
+  });
+
+  it('says how long to wait', () => {
+    const clock = fakeClock();
+    const limiter = new RateLimiter({
+      limit: 1,
+      windowMs: 60_000,
+      route: '/api/tts',
+      now: clock.now,
+    });
+
+    limiter.check('caller');
+    clock.advance(15_000);
+    expect(limiter.check('caller').retryAfterSeconds).toBe(45);
+  });
+
+  it('reports once per window, not once per refused request', () => {
+    // A script in a loop should cost one log line a minute, not thousands.
+    const onLimited = vi.fn();
+    const limiter = new RateLimiter({ limit: 1, route: '/api/tts', onLimited });
+
+    for (let i = 0; i < 50; i++) limiter.check('caller');
+
+    expect(onLimited).toHaveBeenCalledTimes(1);
+    expect(onLimited).toHaveBeenCalledWith({ caller: 'caller', route: '/api/tts', count: 2 });
+  });
+
+  it('is disabled by a limit of zero, and lets everything through', () => {
+    const limiter = new RateLimiter({ limit: 0, route: '/api/tts' });
+    expect(limiter.enabled).toBe(false);
+    for (let i = 0; i < 100; i++) expect(limiter.check('caller').allowed).toBe(true);
+  });
+
+  it('does not accumulate windows forever', () => {
+    const clock = fakeClock();
+    const limiter = new RateLimiter({
+      limit: 10,
+      windowMs: 60_000,
+      route: '/api/tts',
+      now: clock.now,
+    });
+
+    for (let i = 0; i < 600; i++) limiter.check(`caller-${i}`);
+    clock.advance(60_000);
+    for (let i = 600; i < 1200; i++) limiter.check(`caller-${i}`);
+
+    // The sweep runs every 500 requests, so the expired first batch is gone rather than
+    // held forever by a server that runs for months.
+    const windows = limiter as unknown as { windows: Map<string, unknown> };
+    expect(windows.windows.size).toBeLessThan(1200);
+  });
+});
+
+describe('limitFromEnv', () => {
+  it('keeps the default when unset or unparseable', () => {
+    expect(limitFromEnv(undefined, 600)).toBe(600);
+    expect(limitFromEnv('', 600)).toBe(600);
+    expect(limitFromEnv('  ', 600)).toBe(600);
+    expect(limitFromEnv('lots', 600)).toBe(600);
+    expect(limitFromEnv('-5', 600)).toBe(600);
+  });
+
+  it('takes an explicit value, including zero to disable', () => {
+    expect(limitFromEnv('100', 600)).toBe(100);
+    expect(limitFromEnv('0', 600)).toBe(0);
+  });
+});

--- a/rateLimit.ts
+++ b/rateLimit.ts
@@ -1,0 +1,136 @@
+/**
+ * A crude per-caller request cap for the two endpoints a write key can't protect.
+ *
+ * `/api/tts` and `/api/livekit/translate` are called by *listeners* — legitimately, and
+ * often — so they cannot require an editor's key (see docs/WRITE_KEYS.md). That makes
+ * them the whole of the unmetered spend once `WRITE_AUTH_MODE=enforce` closes everything
+ * else, and the first place anyone holding the URL will land.
+ *
+ * This is a stopgap, not the answer. The answer is in that doc's TODO: TTS should only
+ * speak lines that are actually in the notes, and there should be a ceiling on live
+ * translator bots. This just makes a script cost something before it costs money.
+ *
+ * Deliberately generous, and deliberately dependency-free so it is easy to revert.
+ *
+ * ## Two things to know before tuning it
+ *
+ * **A congregation shares one address.** Everyone on the church wifi arrives from a single
+ * public IP, so a limit tight enough to be interesting is also tight enough to cut off the
+ * room. The defaults are set well above what a full service generates — a listener pings
+ * `/api/livekit/translate` every 10s, and auto-speak fetches a line at a time — and the
+ * failure they are guarding against is a script in a loop, which is orders of magnitude
+ * away, not a factor of two.
+ *
+ * **The caller key is spoofable.** It prefers `X-Forwarded-For` over `req.ip`, because
+ * behind a reverse proxy `req.ip` is the *proxy* — which would collapse every listener
+ * into one bucket and take the service down at the first busy Sunday. A forged header
+ * lets an abuser evade the cap, which leaves us no worse off than having no cap at all.
+ * Never use this for anything but rate limiting.
+ */
+import type { RequestHandler } from 'express';
+
+export interface RateLimitedRequest {
+  ip?: string;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+/**
+ * Who to count this request against. See the header note above: this identifies a caller
+ * for accounting only, and must never be treated as trustworthy.
+ */
+export function callerKey(req: RateLimitedRequest): string {
+  const header = req.headers['x-forwarded-for'];
+  const forwarded = Array.isArray(header) ? header[0] : header;
+  const first = forwarded?.split(',')[0]?.trim();
+  return first || req.ip || 'unknown';
+}
+
+export interface RateLimitOptions {
+  /** Requests allowed per window. 0 or less disables the limiter entirely. */
+  limit: number;
+  windowMs?: number;
+  /** Route name, for the log line. */
+  route: string;
+  /** Called the first time a caller trips the limit within a window. */
+  onLimited?: (info: { caller: string; route: string; count: number }) => void;
+  now?: () => number;
+}
+
+interface Window {
+  count: number;
+  startedAt: number;
+}
+
+/** Sweep expired windows every so many requests, so the map can't grow forever. */
+const SWEEP_EVERY = 500;
+
+export class RateLimiter {
+  private readonly windows = new Map<string, Window>();
+  private readonly limit: number;
+  private readonly windowMs: number;
+  private readonly route: string;
+  private readonly onLimited: (info: { caller: string; route: string; count: number }) => void;
+  private readonly now: () => number;
+  private sinceSweep = 0;
+
+  constructor(options: RateLimitOptions) {
+    this.limit = options.limit;
+    this.windowMs = options.windowMs ?? 60_000;
+    this.route = options.route;
+    this.onLimited = options.onLimited ?? (() => {});
+    this.now = options.now ?? Date.now;
+  }
+
+  get enabled(): boolean {
+    return this.limit > 0;
+  }
+
+  /** Record a request. Returns whether it may proceed, and when to retry if not. */
+  check(caller: string): { allowed: boolean; retryAfterSeconds: number } {
+    if (!this.enabled) return { allowed: true, retryAfterSeconds: 0 };
+
+    const now = this.now();
+    if (++this.sinceSweep >= SWEEP_EVERY) {
+      this.sinceSweep = 0;
+      for (const [key, window] of this.windows) {
+        if (now - window.startedAt >= this.windowMs) this.windows.delete(key);
+      }
+    }
+
+    const existing = this.windows.get(caller);
+    const window =
+      existing && now - existing.startedAt < this.windowMs
+        ? existing
+        : { count: 0, startedAt: now };
+    window.count += 1;
+    this.windows.set(caller, window);
+
+    if (window.count <= this.limit) return { allowed: true, retryAfterSeconds: 0 };
+    // Only the request that crosses the line reports, not every one after it — a script
+    // in a loop should cost one log line per window, not thousands.
+    if (window.count === this.limit + 1) {
+      this.onLimited({ caller, route: this.route, count: window.count });
+    }
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(1, Math.ceil((window.startedAt + this.windowMs - now) / 1000)),
+    };
+  }
+}
+
+export function makeRateLimit(options: RateLimitOptions): RequestHandler {
+  const limiter = new RateLimiter(options);
+  return (req, res, next) => {
+    const { allowed, retryAfterSeconds } = limiter.check(callerKey(req));
+    if (allowed) return next();
+    res.setHeader('Retry-After', String(retryAfterSeconds));
+    res.status(429).json({ ok: false, error: 'Too many requests; slow down.' });
+  };
+}
+
+/** Read a per-minute limit from the environment. Unset keeps the default; 0 disables. */
+export function limitFromEnv(raw: string | undefined, fallback: number): number {
+  const value = Number((raw ?? '').trim());
+  if (!(raw ?? '').trim() || !Number.isFinite(value) || value < 0) return fallback;
+  return Math.floor(value);
+}

--- a/server.ts
+++ b/server.ts
@@ -34,6 +34,7 @@ import TranslationSessionManager from './live-audio/translation-session-manager.
 import { parseSilenceThresholdDbfs } from './live-audio/translation-bridge.ts';
 import { WriteAuth, auditDistinctId, formatAudit, resolveWriteAuthConfig } from './writeAuth.ts';
 import { makeOrganizerGate, makeYsAuthHandler } from './writeAuthRoutes.ts';
+import { limitFromEnv, makeRateLimit } from './rateLimit.ts';
 
 // Get API keys from environment variables, crash if not set
 function getEnvOrCrash(name: string): string {
@@ -209,6 +210,45 @@ function requireWriteKey(route: string): express.RequestHandler {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Rate limits for the two endpoints a write key can't protect (see rateLimit.ts).
+//
+// Listeners call these legitimately and often, so they can't require a key — which makes
+// them the whole of the unmetered spend once enforcement closes everything else. The
+// defaults sit far above a real service (a listener pings /translate every 10s; auto-speak
+// fetches one line at a time) because a congregation shares one public address and the
+// thing being stopped is a script in a loop, not a busy Sunday. Set either to 0 to disable.
+// ---------------------------------------------------------------------------
+const TTS_RATE_LIMIT_PER_MIN = limitFromEnv(process.env.TTS_RATE_LIMIT_PER_MIN, 600);
+const TRANSLATE_RATE_LIMIT_PER_MIN = limitFromEnv(
+  process.env.TRANSLATE_RATE_LIMIT_PER_MIN,
+  1200,
+);
+
+function makeCostLimiter(route: string, limit: number): express.RequestHandler {
+  console.log(
+    `[rate-limit] ${route}: ${limit > 0 ? `${limit}/min per caller` : 'disabled'}`,
+  );
+  return makeRateLimit({
+    route,
+    limit,
+    onLimited: ({ caller, count }) => {
+      console.warn(`[rate-limit] ${route} capped ${caller} at ${count} requests in a minute`);
+      phClient.capture({
+        distinctId: caller,
+        event: 'rate_limited',
+        properties: { route, count, limit },
+      });
+    },
+  });
+}
+
+const ttsRateLimit = makeCostLimiter('/api/tts', TTS_RATE_LIMIT_PER_MIN);
+const translateRateLimit = makeCostLimiter(
+  '/api/livekit/translate',
+  TRANSLATE_RATE_LIMIT_PER_MIN,
+);
+
 const app = express();
 app.use(express.static("dist"));
 app.use(express.json());
@@ -343,7 +383,7 @@ app.post('/api/livekit/token', makeOrganizerGate(writeAuth), async (req, res) =>
 
 // Request (or reuse) a translator bot for a language in a room. The bot spins
 // up a Gemini Live session and publishes translated audio as `translator-<code>`.
-app.post('/api/livekit/translate', async (req, res) => {
+app.post('/api/livekit/translate', translateRateLimit, async (req, res) => {
   try {
     if (!getLiveKitConfig()) return res.status(503).json({ error: 'LiveKit not configured' });
 
@@ -764,7 +804,7 @@ const VOICE_CONFIG: Record<string, { voiceId: string; languageCode: string; mode
   },
 };
 
-app.post('/api/tts', async (req, res) => {
+app.post('/api/tts', ttsRateLimit, async (req, res) => {
   const { text, language } = req.body;
 
   if (!text || !language) {

--- a/server.ts
+++ b/server.ts
@@ -232,13 +232,21 @@ app.get('/api/config', (_req, res) => {
 app.post('/api/ys-auth', async (req, res) => {
   const docId = req.body?.docId ?? null;
   const wantsEditor = req.body?.isEditor ?? false;
-  const authorized = wantsEditor ? writeAuth.check(req, '/api/ys-auth').allowed : true;
-  const authorization = wantsEditor && authorized ? 'full' : 'read-only';
+  // Only editor requests are evaluated, and so only they are audited: a viewer needs no
+  // key, and checking one anyway would put an audit record on every page load of every
+  // screen in the session.
+  const check = wantsEditor ? writeAuth.check(req, '/api/ys-auth') : null;
+  const authorization = check?.allowed ? 'full' : 'read-only';
   console.log(`Auth request: doc=${docId} isEditor=${wantsEditor} granted=${authorization}`);
   const clientToken = await documentManager.getOrCreateDocAndToken(docId, {
     authorization
   })
   res.setHeader('X-Granted-Authorization', authorization);
+  // Why the key was or wasn't accepted, which is not the same question as what was
+  // granted. In observe mode nothing is refused, so `granted` is always `full` and this
+  // header is the only way a device can discover it is holding a stale key — during the
+  // observe window, which is exactly when that is still cheap to fix.
+  if (check) res.setHeader('X-Write-Key-Status', check.result.status);
   res.send(clientToken)
 })
 

--- a/server.ts
+++ b/server.ts
@@ -33,6 +33,7 @@ import { SimulateScenarioKind } from '@livekit/rtc-node';
 import TranslationSessionManager from './live-audio/translation-session-manager.ts';
 import { parseSilenceThresholdDbfs } from './live-audio/translation-bridge.ts';
 import { WriteAuth, auditDistinctId, formatAudit, resolveWriteAuthConfig } from './writeAuth.ts';
+import { makeOrganizerGate, makeYsAuthHandler } from './writeAuthRoutes.ts';
 
 // Get API keys from environment variables, crash if not set
 function getEnvOrCrash(name: string): string {
@@ -224,37 +225,19 @@ app.get('/api/config', (_req, res) => {
   });
 });
 
-// Y-Sweet
-//
-// Read-only tokens are unconditional — anyone may watch a session. A *full* token is
-// the app's real write boundary (the browser talks to Y-Sweet directly with it), so
-// asking for one is what requires a key.
-//
-// An unauthorized editor request is downgraded to read-only rather than refused: a
-// device with a stale key then shows the session as a viewer instead of a blank page,
-// which is the failure anyone would rather have mid-service. The granted level comes
-// back in a header so the UI can say so plainly instead of offering edit controls that
-// silently do nothing.
-app.post('/api/ys-auth', async (req, res) => {
-  const docId = req.body?.docId ?? null;
-  const wantsEditor = req.body?.isEditor ?? false;
-  // Only editor requests are evaluated, and so only they are audited: a viewer needs no
-  // key, and checking one anyway would put an audit record on every page load of every
-  // screen in the session.
-  const check = wantsEditor ? writeAuth.check(req, '/api/ys-auth') : null;
-  const authorization = check?.allowed ? 'full' : 'read-only';
-  console.log(`Auth request: doc=${docId} isEditor=${wantsEditor} granted=${authorization}`);
-  const clientToken = await documentManager.getOrCreateDocAndToken(docId, {
-    authorization
-  })
-  res.setHeader('X-Granted-Authorization', authorization);
-  // Why the key was or wasn't accepted, which is not the same question as what was
-  // granted. In observe mode nothing is refused, so `granted` is always `full` and this
-  // header is the only way a device can discover it is holding a stale key — during the
-  // observe window, which is exactly when that is still cheap to fix.
-  if (check) res.setHeader('X-Write-Key-Status', check.result.status);
-  res.send(clientToken)
-})
+// Y-Sweet token issuance. The decision lives in writeAuthRoutes.ts so it can be tested
+// without standing up Y-Sweet, LiveKit and PostHog.
+app.post(
+  '/api/ys-auth',
+  makeYsAuthHandler({
+    writeAuth,
+    // The SDK takes `docId?`, and treats a falsy one as "make me a new doc" — so an
+    // absent id has always meant the same thing here whether it arrived as null or not.
+    issueToken: (docId, authorization) =>
+      documentManager.getOrCreateDocAndToken(docId ?? undefined, { authorization }),
+    log: (message) => console.log(message),
+  }),
+);
 
 
 // ---------------------------------------------------------------------------
@@ -304,7 +287,7 @@ const SILENCE_THRESHOLD_DBFS = parseSilenceThresholdDbfs(process.env.LIVE_AUDIO_
 
 // Issue a LiveKit access token. role 'organizer' => can publish (the speaker);
 // anything else => subscribe-only attendee (a listener).
-app.post('/api/livekit/token', async (req, res) => {
+app.post('/api/livekit/token', makeOrganizerGate(writeAuth), async (req, res) => {
   try {
     const lk = getLiveKitConfig();
     if (!lk) return res.status(503).json({ error: 'LiveKit not configured' });
@@ -321,12 +304,9 @@ app.post('/api/livekit/token', async (req, res) => {
       return res.status(400).json({ error: 'Missing room or identity' });
     }
 
+    // Organizer requests were already gated by makeOrganizerGate above; anything that
+    // reaches here either presented a valid key or didn't ask for the microphone.
     const isOrganizer = role === 'organizer';
-    // An organizer token is the microphone. Its holder can speak into the room and —
-    // because every broadcaster joins under the same `organizer-host` identity, which
-    // LiveKit resolves by evicting the incumbent — can silently cut off whoever is
-    // currently speaking. Listeners ask for no such thing and need no key.
-    if (isOrganizer && !writeAuth.gate(req, res, '/api/livekit/token')) return;
 
     const at = new AccessToken(lk.apiKey, lk.apiSecret, {
       identity,

--- a/server.ts
+++ b/server.ts
@@ -32,6 +32,7 @@ import { AccessToken } from 'livekit-server-sdk';
 import { SimulateScenarioKind } from '@livekit/rtc-node';
 import TranslationSessionManager from './live-audio/translation-session-manager.ts';
 import { parseSilenceThresholdDbfs } from './live-audio/translation-bridge.ts';
+import { WriteAuth, formatAudit, resolveWriteAuthConfig } from './writeAuth.ts';
 
 // Get API keys from environment variables, crash if not set
 function getEnvOrCrash(name: string): string {
@@ -156,6 +157,51 @@ function currentDayDocId(): string {
   return `doc-${ymd}`;
 }
 
+// ---------------------------------------------------------------------------
+// Write authorization (shared keys, not user logins — see writeAuth.ts).
+//
+// Reading is open to anyone: viewers get read-only Y-Sweet tokens, TTS and listener
+// LiveKit tokens with no key at all. What a key protects is the ability to *write* —
+// full doc tokens, the broadcaster's microphone, and the endpoints that spend money on
+// models and TTS.
+//
+// Defaults to `observe`: every privileged request is checked and recorded, and then
+// allowed regardless. That makes it safe to ship keys to the clients first and read
+// the logs for a week before flipping WRITE_AUTH_MODE=enforce.
+// ---------------------------------------------------------------------------
+const writeAuthConfig = resolveWriteAuthConfig(process.env);
+for (const notice of writeAuthConfig.notices) console.log(notice);
+
+const writeAuth = new WriteAuth(writeAuthConfig, (audit) => {
+  // Log every outcome, and mirror it to PostHog so the observe week can be read as a
+  // chart ("is the Proclaim service presenting a key yet?") rather than by grepping.
+  const line = formatAudit(audit);
+  if (audit.status === 'ok') console.log(line);
+  else console.warn(line);
+  phClient.capture({
+    distinctId: audit.label ?? 'unknown-device',
+    event: 'write_auth_check',
+    properties: {
+      route: audit.route,
+      status: audit.status,
+      keyLabel: audit.label,
+      mode: audit.mode,
+      refused: audit.refused,
+    },
+  });
+});
+
+/**
+ * Gate a route that is *always* privileged. Routes where only some requests are
+ * privileged (asking for an editor token, or for the broadcaster's microphone) call
+ * `writeAuth.check`/`gate` inline instead, so an ordinary viewer request stays open.
+ */
+function requireWriteKey(route: string): express.RequestHandler {
+  return (req, res, next) => {
+    if (writeAuth.gate(req, res, route)) next();
+  };
+}
+
 const app = express();
 app.use(express.static("dist"));
 app.use(express.json());
@@ -173,16 +219,26 @@ app.get('/api/config', (_req, res) => {
 });
 
 // Y-Sweet
+//
+// Read-only tokens are unconditional — anyone may watch a session. A *full* token is
+// the app's real write boundary (the browser talks to Y-Sweet directly with it), so
+// asking for one is what requires a key.
+//
+// An unauthorized editor request is downgraded to read-only rather than refused: a
+// device with a stale key then shows the session as a viewer instead of a blank page,
+// which is the failure anyone would rather have mid-service. The granted level comes
+// back in a header so the UI can say so plainly instead of offering edit controls that
+// silently do nothing.
 app.post('/api/ys-auth', async (req, res) => {
-  console.log('Auth request:', req.body);
   const docId = req.body?.docId ?? null;
-  const isEditor = req.body?.isEditor ?? false;
-  const authorization = isEditor ? 'full' : 'read-only';
-  // In a production app, this is where you'd authenticate the user
-  // and check that they are authorized to access the doc.
+  const wantsEditor = req.body?.isEditor ?? false;
+  const authorized = wantsEditor ? writeAuth.check(req, '/api/ys-auth').allowed : true;
+  const authorization = wantsEditor && authorized ? 'full' : 'read-only';
+  console.log(`Auth request: doc=${docId} isEditor=${wantsEditor} granted=${authorization}`);
   const clientToken = await documentManager.getOrCreateDocAndToken(docId, {
     authorization
   })
+  res.setHeader('X-Granted-Authorization', authorization);
   res.send(clientToken)
 })
 
@@ -252,6 +308,12 @@ app.post('/api/livekit/token', async (req, res) => {
     }
 
     const isOrganizer = role === 'organizer';
+    // An organizer token is the microphone. Its holder can speak into the room and —
+    // because every broadcaster joins under the same `organizer-host` identity, which
+    // LiveKit resolves by evicting the incumbent — can silently cut off whoever is
+    // currently speaking. Listeners ask for no such thing and need no key.
+    if (isOrganizer && !writeAuth.gate(req, res, '/api/livekit/token')) return;
+
     const at = new AccessToken(lk.apiKey, lk.apiSecret, {
       identity,
       name: identity,
@@ -401,7 +463,7 @@ app.post('/api/livekit/translate/simulate', async (req, res) => {
 });
 
 
-app.post('/api/requestTranslatedBlocks', async (req, res) => {
+app.post('/api/requestTranslatedBlocks', requireWriteKey('/api/requestTranslatedBlocks'), async (req, res) => {
   console.log('Request translated blocks:', req.body);
   const translationTodos = (req.body?.translationTodos as [TranslationTodo]) ?? [];
   const language = req.body?.language;
@@ -437,7 +499,8 @@ app.post('/api/slideLibrary/lookup', (req, res) => {
 });
 
 // Upsert a reviewed translation. Body: { language, sourceText, text, provenance? }.
-app.post('/api/slideLibrary', async (req, res) => {
+// Writes to the persistent library on disk, so unlike the lookups above it needs a key.
+app.post('/api/slideLibrary', requireWriteKey('/api/slideLibrary'), async (req, res) => {
   const { language, sourceText, text, provenance } = req.body ?? {};
   if (!language || typeof sourceText !== 'string' || typeof text !== 'string') {
     return res.status(400).json({ ok: false, error: 'Missing language, sourceText, or text' });
@@ -451,7 +514,7 @@ app.post('/api/slideLibrary', async (req, res) => {
 // { slides: string[], languages: string[], reference?: string }. `reference` is a free-text
 // dump (possibly multilingual, arbitrarily segmented) the model uses where it covers a
 // target language and ignores otherwise. Returns { translations: { [language]: PerSlideTranslation[] } }.
-app.post('/api/translateItem', async (req, res) => {
+app.post('/api/translateItem', requireWriteKey('/api/translateItem'), async (req, res) => {
   const slides = (req.body?.slides as string[]) ?? [];
   const requestedLanguages = (req.body?.languages as string[]) ?? [];
   const reference = (req.body?.reference as string | undefined)?.trim();
@@ -568,7 +631,7 @@ app.post('/api/translateItem', async (req, res) => {
 // text and/or revise translations via set_translations; revised entries are returned for the
 // browser to write into the slideTranslations Y.Map. Conversation progress (status, agent
 // reasoning, tool calls) streams live via the slideConversations Y.Map.
-app.post('/api/slideConversation/message', async (req, res) => {
+app.post('/api/slideConversation/message', requireWriteKey('/api/slideConversation/message'), async (req, res) => {
   const itemId = (req.body?.itemId as string | undefined)?.trim();
   const text = (req.body?.text as string | undefined)?.trim();
   const docId = (req.body?.docId as string | undefined)?.trim();
@@ -636,7 +699,7 @@ app.post('/api/slideConversation/message', async (req, res) => {
 
 // Record a reviewer's manual edit as a note in the conversation, so the next follow-up has
 // that context. No agent run — the edit itself is written to Yjs/library by the browser.
-app.post('/api/slideConversation/note', async (req, res) => {
+app.post('/api/slideConversation/note', requireWriteKey('/api/slideConversation/note'), async (req, res) => {
   const itemId = (req.body?.itemId as string | undefined)?.trim();
   const text = (req.body?.text as string | undefined)?.trim();
   const docId = (req.body?.docId as string | undefined)?.trim();

--- a/server.ts
+++ b/server.ts
@@ -32,7 +32,7 @@ import { AccessToken } from 'livekit-server-sdk';
 import { SimulateScenarioKind } from '@livekit/rtc-node';
 import TranslationSessionManager from './live-audio/translation-session-manager.ts';
 import { parseSilenceThresholdDbfs } from './live-audio/translation-bridge.ts';
-import { WriteAuth, formatAudit, resolveWriteAuthConfig } from './writeAuth.ts';
+import { WriteAuth, auditDistinctId, formatAudit, resolveWriteAuthConfig } from './writeAuth.ts';
 
 // Get API keys from environment variables, crash if not set
 function getEnvOrCrash(name: string): string {
@@ -179,7 +179,7 @@ const writeAuth = new WriteAuth(writeAuthConfig, (audit) => {
   if (audit.status === 'ok') console.log(line);
   else console.warn(line);
   phClient.capture({
-    distinctId: audit.label ?? 'unknown-device',
+    distinctId: auditDistinctId(audit),
     event: 'write_auth_check',
     properties: {
       route: audit.route,
@@ -187,6 +187,12 @@ const writeAuth = new WriteAuth(writeAuthConfig, (audit) => {
       keyLabel: audit.label,
       mode: audit.mode,
       refused: audit.refused,
+      // Attribution for the misses. Without these, every unauthorized request in the
+      // observe window collapses into one anonymous total, which cannot answer the only
+      // question that window exists to ask: *which* device still needs a key.
+      ip: audit.client.ip,
+      userAgent: audit.client.userAgent,
+      keyFingerprint: audit.client.keyFingerprint,
     },
   });
 });

--- a/slide_sync_runtime.py
+++ b/slide_sync_runtime.py
@@ -26,6 +26,7 @@ from pycrdt.websocket.websocket import HttpxWebsocket
 
 from slide_feed import SessionInfo, SlideFeed, SnapshotBus
 from slide_translator import SlideTranslator
+from write_key import write_key_headers
 from yjs_publisher import YjsSlidePublisher
 
 logger = logging.getLogger(__name__)
@@ -55,11 +56,16 @@ class SlideSyncRuntime:
         timing: Optional[RuntimeTiming] = None,
         report_exception: Optional[Callable[[Exception], None]] = None,
         on_session_start: Optional[Callable[[Doc], None]] = None,
+        write_key: Optional[str] = None,
     ):
         self.feed = feed
         self.publisher = publisher
         self.translator = translator
         self.ysweet_url = ysweet_url
+        # Shared key identifying this device to the server when asking for a *full*
+        # (writable) Y-Sweet token. Optional: while the server runs in observe mode a
+        # keyless request is recorded and still served.
+        self.write_key = write_key
         self.timing = timing or RuntimeTiming()
         self._report_exception = report_exception or (lambda _e: None)
         # Called with the freshly connected Doc at the start of every session — the seam the
@@ -156,6 +162,7 @@ class SlideSyncRuntime:
             response = await client.post(
                 f"{self.ysweet_url}/api/ys-auth",
                 json={"docId": self.doc_id, "isEditor": True},
+                headers=write_key_headers(self.write_key),
                 timeout=self.timing.ysweet_token_timeout,
             )
             response.raise_for_status()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import { SlideReviewContainer } from "./SlideReviewContainer";
 import { SlideTranslationViewerContainer } from "./SlideTranslationViewer";
 import { StatusViewContainer } from "./StatusView";
 import { getDocId } from "./getDocId";
-import { apiFetch } from "./writeKey";
+import { apiFetch, promptForWriteKeyOnce } from "./writeKey";
 
 // Lazy-loaded so the heavy LiveKit client SDK is only fetched when a live-audio
 // pane (listen-{language} / broadcast) is actually rendered, keeping it out of
@@ -477,29 +477,49 @@ const App = () => {
 
   const [, setIsEditor] = useAtom(isEditorAtom);
   const [, setEditorDenied] = useAtom(editorDeniedAtom);
+  const s = useStrings();
   React.useEffect(() => {
     setIsEditor(isEditor);
   }, [isEditor, setIsEditor]);
   const authEndpoint: AuthEndpoint = async () => {
-    const response = await apiFetch("/api/ys-auth", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ docId, isEditor }),
-    });
-    // The server decides what we actually get: asking to edit without a valid write key
-    // is answered with a read-only token rather than an error, so the session still
-    // displays. Record what was granted so the UI can stop offering edit controls.
-    const granted = response.headers.get("X-Granted-Authorization");
-    if (isEditor && granted === "read-only") {
+    const requestToken = async () => {
+      const response = await apiFetch("/api/ys-auth", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ docId, isEditor }),
+      });
+      return {
+        // The server decides what we actually get: asking to edit without a valid write
+        // key is answered with a read-only token rather than an error, so the session
+        // still displays.
+        granted: response.headers.get("X-Granted-Authorization"),
+        // Why the key was or wasn't accepted — absent for a viewer request, which is
+        // never evaluated.
+        keyStatus: response.headers.get("X-Write-Key-Status"),
+        clientToken: (await response.json()) as ClientToken,
+      };
+    };
+
+    let result = await requestToken();
+    // Provisioning: this device asked to edit and the server didn't recognize its key,
+    // so ask for one and try again. Keyed on the key's status rather than on what was
+    // granted, so it also fires in observe mode — where nothing is refused, and which is
+    // precisely the window in which devices are supposed to be getting their keys.
+    if (isEditor && result.keyStatus && result.keyStatus !== "ok") {
+      if (promptForWriteKeyOnce(s.enterWriteKey)) result = await requestToken();
+    }
+    // Record what we ended up with, so every isEditor-gated control degrades to the
+    // viewer experience rather than offering edits that silently do nothing.
+    if (isEditor && result.granted === "read-only") {
       console.warn(
         "[write-auth] editor access was not granted for this device; continuing read-only",
       );
       setIsEditor(false);
       setEditorDenied(true);
     }
-    return (await response.json()) as ClientToken;
+    return result.clientToken;
   };
 
   // Parse URL path to determine which page to render

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import React, { useState } from "react";
 import "./App.css";
 
 import { useAtom } from "jotai";
-import { fontSizeAtom, isEditorAtom, languages } from "./configAtoms";
+import { editorDeniedAtom, fontSizeAtom, isEditorAtom, languages } from "./configAtoms";
 import { useStrings, resolveLocale, LANGUAGE_BCP47 } from "./useLocale";
 import {
   LISTEN_LANGUAGE_CODES,
@@ -26,6 +26,7 @@ import { SlideReviewContainer } from "./SlideReviewContainer";
 import { SlideTranslationViewerContainer } from "./SlideTranslationViewer";
 import { StatusViewContainer } from "./StatusView";
 import { getDocId } from "./getDocId";
+import { apiFetch } from "./writeKey";
 
 // Lazy-loaded so the heavy LiveKit client SDK is only fetched when a live-audio
 // pane (listen-{language} / broadcast) is actually rendered, keeping it out of
@@ -441,6 +442,31 @@ function LayoutPage({ layout: initialLayout }: { layout: string }) {
   );
 }
 
+/**
+ * Shown when a device asked for `#editor` but the server would only issue a read-only
+ * token — i.e. this device has no valid write key. Fixed rather than in flow so it can't
+ * reshuffle a projected layout, and dismissible because the session still works fine
+ * read-only and nobody needs a banner over the words during a service.
+ */
+function EditorDeniedBanner() {
+  const s = useStrings();
+  const [denied] = useAtom(editorDeniedAtom);
+  const [dismissed, setDismissed] = useState(false);
+  if (!denied || dismissed) return null;
+  return (
+    <div className="fixed top-2 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 px-4 py-2 rounded-lg shadow-lg bg-amber-100 text-amber-900 dark:bg-amber-900 dark:text-amber-100 text-sm max-w-[90vw]">
+      <span>{s.editorAccessDenied}</span>
+      <button
+        type="button"
+        className="text-xs underline whitespace-nowrap"
+        onClick={() => setDismissed(true)}
+      >
+        {s.dismiss}
+      </button>
+    </div>
+  );
+}
+
 const App = () => {
   // We're an editor only if location hash includes #editor
   const isEditor = window.location.hash.includes("editor");
@@ -450,17 +476,29 @@ const App = () => {
   const docId = getDocId();
 
   const [, setIsEditor] = useAtom(isEditorAtom);
+  const [, setEditorDenied] = useAtom(editorDeniedAtom);
   React.useEffect(() => {
     setIsEditor(isEditor);
   }, [isEditor, setIsEditor]);
   const authEndpoint: AuthEndpoint = async () => {
-    const response = await fetch("/api/ys-auth", {
+    const response = await apiFetch("/api/ys-auth", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ docId, isEditor }),
     });
+    // The server decides what we actually get: asking to edit without a valid write key
+    // is answered with a read-only token rather than an error, so the session still
+    // displays. Record what was granted so the UI can stop offering edit controls.
+    const granted = response.headers.get("X-Granted-Authorization");
+    if (isEditor && granted === "read-only") {
+      console.warn(
+        "[write-auth] editor access was not granted for this device; continuing read-only",
+      );
+      setIsEditor(false);
+      setEditorDenied(true);
+    }
     return (await response.json()) as ClientToken;
   };
 
@@ -480,6 +518,7 @@ const App = () => {
 
   return (
     <YDocProvider docId={docId} authEndpoint={authEndpoint}>
+      <EditorDeniedBanner />
       {pageComponent}
     </YDocProvider>
   );

--- a/src/BroadcastControl.tsx
+++ b/src/BroadcastControl.tsx
@@ -17,6 +17,7 @@ import { isEditorAtom } from "./configAtoms";
 import { useStrings } from "./useLocale";
 import { LiveTranscript } from "./LiveTranscript";
 import { getDocId } from "./getDocId";
+import { apiFetch } from "./writeKey";
 
 // The default/primary translator bridge transcribes the speaker's own audio and
 // writes it to the shared Yjs doc under this code, so the broadcaster can read
@@ -161,7 +162,7 @@ export function BroadcastControl() {
     setError(null);
     setConnecting(true);
     try {
-      const tk = (await fetch("/api/livekit/token", {
+      const tk = (await apiFetch("/api/livekit/token", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/src/ListenViewer.tsx
+++ b/src/ListenViewer.tsx
@@ -23,6 +23,7 @@ import { LANGUAGE_BCP47, useStrings } from "./useLocale";
 import { LISTEN_ORIGINAL_CODE } from "./listenLanguages";
 import { LiveTranscript } from "./LiveTranscript";
 import { getDocId } from "./getDocId";
+import { apiFetch } from "./writeKey";
 
 const ORGANIZER_PREFIX = "organizer-";
 const TRANSLATOR_PREFIX = "translator-";
@@ -106,7 +107,7 @@ function ListenAudio({
       const now = Date.now();
       if (now - lastEnsureRef.current < ENSURE_TRANSLATOR_INTERVAL_MS) return;
       lastEnsureRef.current = now;
-      void fetch("/api/livekit/translate", {
+      void apiFetch("/api/livekit/translate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ sessionId: docId, targetLanguage: translatorLanguage }),
@@ -219,7 +220,7 @@ export function ListenViewer({ language }: { language: string }) {
         // to run.
         let translatorIdentity: string | null = null;
         if (translatorLanguage) {
-          const tr = (await fetch("/api/livekit/translate", {
+          const tr = (await apiFetch("/api/livekit/translate", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ sessionId: docId, targetLanguage: translatorLanguage }),
@@ -235,7 +236,7 @@ export function ListenViewer({ language }: { language: string }) {
         // presence, so our bridge survives as long as we're in the room — no
         // refcounts, no unload beacon. Sent only when we actually want a bot, so
         // "demand" stays a true statement about what someone is listening to.
-        const tk = (await fetch("/api/livekit/token", {
+        const tk = (await apiFetch("/api/livekit/token", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({

--- a/src/StatusView.test.tsx
+++ b/src/StatusView.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { StatusView } from './StatusView';
 
 describe('StatusView', () => {
@@ -60,5 +61,81 @@ describe('StatusView', () => {
       />,
     );
     expect(screen.getByText(/\(2\)/)).toBeInTheDocument();
+  });
+});
+
+describe('StatusView write key', () => {
+  it('stays out of the way when the page has no way to change the key', () => {
+    render(<StatusView docId="doc-2026-07-13" statusEntries={{}} />);
+    expect(screen.queryByText(/write key/i)).not.toBeInTheDocument();
+  });
+
+  it('says plainly when the device has no key', () => {
+    render(
+      <StatusView docId="doc-2026-07-13" statusEntries={{}} onWriteKeyChange={() => {}} />,
+    );
+    expect(screen.getByText('No key on this device')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+  });
+
+  it('shows only the tail of an installed key, never the key', () => {
+    render(
+      <StatusView
+        docId="doc-2026-07-13"
+        statusEntries={{}}
+        writeKey="kZ8xQ2vLm4vt7Rb9ab12"
+        onWriteKeyChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('Key installed')).toBeInTheDocument();
+    expect(screen.getByText('…ab12')).toBeInTheDocument();
+    expect(screen.queryByText('kZ8xQ2vLm4vt7Rb9ab12')).not.toBeInTheDocument();
+  });
+
+  it('stores a pasted key, trimmed', async () => {
+    const onWriteKeyChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <StatusView
+        docId="doc-2026-07-13"
+        statusEntries={{}}
+        onWriteKeyChange={onWriteKeyChange}
+      />,
+    );
+
+    await user.type(screen.getByLabelText('Paste a write key'), '  NEWKEY  ');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onWriteKeyChange).toHaveBeenCalledWith('NEWKEY');
+  });
+
+  it('refuses to store an empty key', () => {
+    const onWriteKeyChange = vi.fn();
+    render(
+      <StatusView
+        docId="doc-2026-07-13"
+        statusEntries={{}}
+        onWriteKeyChange={onWriteKeyChange}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(onWriteKeyChange).not.toHaveBeenCalled();
+  });
+
+  it('clears the key with null, so a lost device can be de-provisioned on the spot', async () => {
+    const onWriteKeyChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <StatusView
+        docId="doc-2026-07-13"
+        statusEntries={{}}
+        writeKey="kZ8xQ2vLm4vt7Rb9ab12"
+        onWriteKeyChange={onWriteKeyChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+    expect(onWriteKeyChange).toHaveBeenCalledWith(null);
   });
 });

--- a/src/StatusView.tsx
+++ b/src/StatusView.tsx
@@ -1,8 +1,9 @@
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { useMap, useYDoc } from '@y-sweet/react';
 import { useStrings } from './useLocale';
 import { getDocId } from './getDocId';
 import { TranscriptHealth } from './TranscriptHealth';
+import { getWriteKey, maskWriteKey, setWriteKey } from './writeKey';
 
 /**
  * Session status / admin page.
@@ -48,6 +49,89 @@ function readProclaimServiceStatus(entries: Record<string, unknown>): ProclaimSe
   };
 }
 
+const SECTION_CLASS = 'bg-white/80 dark:bg-gray-800/80 rounded shadow p-4 flex flex-col gap-3';
+const SECTION_TITLE_CLASS = 'font-semibold text-lg';
+const PLACEHOLDER_CLASS = 'text-sm text-gray-500 dark:text-gray-400';
+
+/**
+ * This device's write key: whether it has one, and a way to change it that doesn't
+ * involve typing `#editor&key=…` into a tablet's address bar.
+ *
+ * The masked tail is the point of the display. During a rotation the question is never
+ * "is there a key" but "is this device on the new one yet", and four characters answer
+ * that without putting the secret on a screen that may well be projected.
+ */
+function WriteKeySection({
+  writeKey,
+  onWriteKeyChange,
+}: {
+  writeKey: string | null;
+  onWriteKeyChange: (key: string | null) => void;
+}) {
+  const s = useStrings();
+  const [typed, setTyped] = useState('');
+  const pending = typed.trim();
+
+  return (
+    <section className={SECTION_CLASS}>
+      <h2 className={SECTION_TITLE_CLASS}>{s.statusWriteKeyTitle}</h2>
+      <p className={PLACEHOLDER_CLASS}>{s.statusWriteKeyDescription}</p>
+      <div className="flex items-center gap-2 text-sm">
+        <span
+          className={`inline-block w-2.5 h-2.5 rounded-full ${
+            writeKey ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'
+          }`}
+        />
+        {writeKey ? (
+          <>
+            <span>{s.statusWriteKeyInstalled}</span>
+            <code className="text-xs text-gray-500 dark:text-gray-400">
+              {maskWriteKey(writeKey)}
+            </code>
+          </>
+        ) : (
+          <span>{s.statusWriteKeyMissing}</span>
+        )}
+      </div>
+      <form
+        className="flex flex-wrap items-center gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!pending) return;
+          onWriteKeyChange(pending);
+          setTyped('');
+        }}
+      >
+        <input
+          type="password"
+          value={typed}
+          onChange={(event) => setTyped(event.target.value)}
+          placeholder={s.statusWriteKeyPlaceholder}
+          autoComplete="off"
+          aria-label={s.statusWriteKeyPlaceholder}
+          className="flex-1 min-w-40 px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm"
+        />
+        <button
+          type="submit"
+          disabled={!pending}
+          className="px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-40 disabled:hover:bg-blue-500 text-sm"
+        >
+          {s.statusWriteKeySave}
+        </button>
+        {writeKey && (
+          <button
+            type="button"
+            onClick={() => onWriteKeyChange(null)}
+            className="px-3 py-1 rounded border border-gray-300 dark:border-gray-600 text-sm"
+          >
+            {s.statusWriteKeyClear}
+          </button>
+        )}
+      </form>
+    </section>
+  );
+}
+
 export interface StatusViewProps {
   /** The session's doc id (drives the export link). */
   docId: string;
@@ -61,18 +145,30 @@ export interface StatusViewProps {
    * observers). Kept as a slot so the pure component stays testable without Yjs.
    */
   liveTranscripts?: ReactNode;
+  /** This device's stored write key, or null when it has none. */
+  writeKey?: string | null;
+  /**
+   * Store a key typed here, or clear it with null. Omitting this hides the write-key
+   * section entirely, which is what keeps the section out of tests that don't care.
+   */
+  onWriteKeyChange?: (key: string | null) => void;
 }
 
-export function StatusView({ docId, statusEntries, liveTranscripts }: StatusViewProps) {
+export function StatusView({
+  docId,
+  statusEntries,
+  liveTranscripts,
+  writeKey = null,
+  onWriteKeyChange,
+}: StatusViewProps) {
   const s = useStrings();
   const exportHref = `/api/session/export?doc=${encodeURIComponent(docId)}`;
   const reportingCount = Object.keys(statusEntries).length;
   const proclaim = readProclaimServiceStatus(statusEntries);
 
-  const sectionClass =
-    'bg-white/80 dark:bg-gray-800/80 rounded shadow p-4 flex flex-col gap-3';
-  const sectionTitleClass = 'font-semibold text-lg';
-  const placeholderClass = 'text-sm text-gray-500 dark:text-gray-400';
+  const sectionClass = SECTION_CLASS;
+  const sectionTitleClass = SECTION_TITLE_CLASS;
+  const placeholderClass = PLACEHOLDER_CLASS;
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-100 to-gray-300 dark:from-gray-950 dark:to-gray-900 text-black dark:text-gray-200 overflow-auto">
@@ -137,6 +233,11 @@ export function StatusView({ docId, statusEntries, liveTranscripts }: StatusView
           )}
         </section>
 
+        {/* This device's write key — provisioning and rotation, off the viewer screens. */}
+        {onWriteKeyChange && (
+          <WriteKeySection writeKey={writeKey} onWriteKeyChange={onWriteKeyChange} />
+        )}
+
         {/* Preflight canary — placeholder until #72. */}
         <section className={sectionClass}>
           <h2 className={sectionTitleClass}>{s.statusCanaryTitle}</h2>
@@ -175,11 +276,18 @@ export function StatusViewContainer() {
   statusMap.forEach((value, key) => {
     statusEntries[key] = value;
   });
+  // The stored key isn't reactive, so mirror it into state to re-render on a change.
+  const [writeKey, setWriteKeyState] = useState<string | null>(() => getWriteKey());
   return (
     <StatusView
       docId={getDocId()}
       statusEntries={statusEntries}
       liveTranscripts={<TranscriptHealth />}
+      writeKey={writeKey}
+      onWriteKeyChange={(key) => {
+        setWriteKey(key);
+        setWriteKeyState(key);
+      }}
     />
   );
 }

--- a/src/configAtoms.ts
+++ b/src/configAtoms.ts
@@ -1,7 +1,19 @@
 import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 
+/**
+ * Whether this device may edit. Set optimistically from the `#editor` hash, then
+ * corrected to false if the server declines to issue a full token (no valid write key),
+ * so every `isEditor`-gated control degrades to the viewer experience on its own.
+ */
 export const isEditorAtom = atom(false);
+
+/**
+ * True when this device *asked* to edit and was refused. Distinct from `!isEditor`,
+ * which is also the ordinary state of a plain viewer: only this warrants telling
+ * someone their device needs a key.
+ */
+export const editorDeniedAtom = atom(false);
 export const fontSizeAtom = atomWithStorage('fontSize', 20);
 export const languages = ["French", "Haitian Creole", "Spanish"] as const;
 export const languageAtom = atom<string>("French");

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,12 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { PostHogProvider } from 'posthog-js/react'
+import { initWriteKey } from './writeKey.ts'
+
+// Claim any write key from the URL before the app renders: App's first act is to ask
+// /api/ys-auth for a token, and that request needs the key already in hand. This also
+// scrubs the key out of the address bar (see writeKey.ts).
+initWriteKey()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/slideTranslationApi.ts
+++ b/src/slideTranslationApi.ts
@@ -11,6 +11,7 @@ import type { PerSlideTranslation } from './slideItemTranslation.ts';
 import type { BibleToolCall } from '../bible.ts';
 import type { Content } from '@google/genai';
 import { getDocId } from './getDocId.ts';
+import { apiFetch } from './writeKey.ts';
 
 export type { BibleToolCall };
 export type { Content };
@@ -98,7 +99,7 @@ export function parseSlidesInput(text: string): string[] {
 }
 
 async function postJson<T>(url: string, body: unknown): Promise<T> {
-  const response = await fetch(url, {
+  const response = await apiFetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -111,7 +112,7 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
 
 /** Fetch all reviewed library entries. */
 export async function fetchLibrary(): Promise<SlideLibraryRecord[]> {
-  const response = await fetch('/api/slideLibrary');
+  const response = await apiFetch('/api/slideLibrary');
   if (!response.ok) throw new Error(`/api/slideLibrary failed: ${response.status}`);
   const data = (await response.json()) as { entries: SlideLibraryRecord[] };
   return data.entries;

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -79,6 +79,10 @@ export interface AppStrings {
   goHome: string;
   downloadSession: string;
 
+  // Write authorization (shared device keys)
+  editorAccessDenied: string;
+  dismiss: string;
+
   // Status / admin page (skeleton for #72)
   statusTitle: string;
   statusHealthTitle: string;
@@ -179,6 +183,8 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     next: 'Next',
     untitledPresentation: 'Untitled Presentation',
     goHome: 'Go home',
+    editorAccessDenied: 'This device is not set up to edit. Showing the session read-only.',
+    dismiss: 'Dismiss',
     downloadSession: 'Download session',
     statusTitle: 'Session status',
     statusHealthTitle: 'Component health',
@@ -273,6 +279,8 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     next: 'Suivant',
     untitledPresentation: 'Pr\u00e9sentation sans titre',
     goHome: 'Accueil',
+    editorAccessDenied: "Cet appareil n'est pas autorisé à modifier. Session affichée en lecture seule.",
+    dismiss: 'Fermer',
     downloadSession: 'Télécharger la session',
     statusTitle: 'État de la session',
     statusHealthTitle: 'État des composants',
@@ -367,6 +375,8 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     next: 'Siguiente',
     untitledPresentation: 'Presentaci\u00f3n sin t\u00edtulo',
     goHome: 'Ir al inicio',
+    editorAccessDenied: 'Este dispositivo no está autorizado para editar. Sesión en solo lectura.',
+    dismiss: 'Cerrar',
     downloadSession: 'Descargar sesión',
     statusTitle: 'Estado de la sesión',
     statusHealthTitle: 'Estado de los componentes',
@@ -461,6 +471,8 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     next: 'Apr\u00e8',
     untitledPresentation: 'Prezantasyon San Tit',
     goHome: 'Retounen lakay',
+    editorAccessDenied: 'Aparèy sa a pa otorize pou modifye. N ap montre sesyon an an lekti sèlman.',
+    dismiss: 'Fèmen',
     downloadSession: 'Telechaje sesyon an',
     statusTitle: 'Estati sesyon an',
     statusHealthTitle: 'Estati konpozan yo',

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -82,6 +82,14 @@ export interface AppStrings {
   // Write authorization (shared device keys)
   editorAccessDenied: string;
   dismiss: string;
+  enterWriteKey: string;
+  statusWriteKeyTitle: string;
+  statusWriteKeyDescription: string;
+  statusWriteKeyInstalled: string;
+  statusWriteKeyMissing: string;
+  statusWriteKeyPlaceholder: string;
+  statusWriteKeySave: string;
+  statusWriteKeyClear: string;
 
   // Status / admin page (skeleton for #72)
   statusTitle: string;
@@ -185,6 +193,16 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     goHome: 'Go home',
     editorAccessDenied: 'This device is not set up to edit. Showing the session read-only.',
     dismiss: 'Dismiss',
+    enterWriteKey:
+      'This device needs a write key to edit. Paste it here, or cancel to continue read-only.',
+    statusWriteKeyTitle: "This device's write key",
+    statusWriteKeyDescription:
+      'Authorizes editing, the microphone, and translation from this device. Keys are per device, not per person.',
+    statusWriteKeyInstalled: 'Key installed',
+    statusWriteKeyMissing: 'No key on this device',
+    statusWriteKeyPlaceholder: 'Paste a write key',
+    statusWriteKeySave: 'Save',
+    statusWriteKeyClear: 'Clear',
     downloadSession: 'Download session',
     statusTitle: 'Session status',
     statusHealthTitle: 'Component health',
@@ -281,6 +299,16 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     goHome: 'Accueil',
     editorAccessDenied: "Cet appareil n'est pas autorisé à modifier. Session affichée en lecture seule.",
     dismiss: 'Fermer',
+    enterWriteKey:
+      "Cet appareil a besoin d'une clé d'écriture pour modifier. Collez-la ici, ou annulez pour rester en lecture seule.",
+    statusWriteKeyTitle: "Clé d'écriture de cet appareil",
+    statusWriteKeyDescription:
+      "Autorise la modification, le microphone et la traduction depuis cet appareil. Une clé par appareil, pas par personne.",
+    statusWriteKeyInstalled: 'Clé installée',
+    statusWriteKeyMissing: 'Aucune clé sur cet appareil',
+    statusWriteKeyPlaceholder: "Collez une clé d'écriture",
+    statusWriteKeySave: 'Enregistrer',
+    statusWriteKeyClear: 'Effacer',
     downloadSession: 'Télécharger la session',
     statusTitle: 'État de la session',
     statusHealthTitle: 'État des composants',
@@ -377,6 +405,16 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     goHome: 'Ir al inicio',
     editorAccessDenied: 'Este dispositivo no está autorizado para editar. Sesión en solo lectura.',
     dismiss: 'Cerrar',
+    enterWriteKey:
+      'Este dispositivo necesita una clave de escritura para editar. Péguela aquí o cancele para continuar en solo lectura.',
+    statusWriteKeyTitle: 'Clave de escritura de este dispositivo',
+    statusWriteKeyDescription:
+      'Autoriza la edición, el micrófono y la traducción desde este dispositivo. Una clave por dispositivo, no por persona.',
+    statusWriteKeyInstalled: 'Clave instalada',
+    statusWriteKeyMissing: 'Sin clave en este dispositivo',
+    statusWriteKeyPlaceholder: 'Pegue una clave de escritura',
+    statusWriteKeySave: 'Guardar',
+    statusWriteKeyClear: 'Borrar',
     downloadSession: 'Descargar sesión',
     statusTitle: 'Estado de la sesión',
     statusHealthTitle: 'Estado de los componentes',
@@ -473,6 +511,16 @@ export const strings: Record<SupportedLocale, AppStrings> = {
     goHome: 'Retounen lakay',
     editorAccessDenied: 'Aparèy sa a pa otorize pou modifye. N ap montre sesyon an an lekti sèlman.',
     dismiss: 'Fèmen',
+    enterWriteKey:
+      'Aparèy sa a bezwen yon kle ekriti pou l ka modifye. Kole l isit la, oswa anile pou w rete an lekti sèlman.',
+    statusWriteKeyTitle: 'Kle ekriti aparèy sa a',
+    statusWriteKeyDescription:
+      'Li otorize modifikasyon, mikwofòn nan, ak tradiksyon depi aparèy sa a. Yon kle pou chak aparèy, pa pou chak moun.',
+    statusWriteKeyInstalled: 'Kle enstale',
+    statusWriteKeyMissing: 'Pa gen kle sou aparèy sa a',
+    statusWriteKeyPlaceholder: 'Kole yon kle ekriti',
+    statusWriteKeySave: 'Anrejistre',
+    statusWriteKeyClear: 'Efase',
     downloadSession: 'Telechaje sesyon an',
     statusTitle: 'Estati sesyon an',
     statusHealthTitle: 'Estati konpozan yo',

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -23,6 +23,38 @@ if (!Element.prototype.scrollTo) {
   Element.prototype.scrollTo = vi.fn();
 }
 
+// jsdom exposes `window.localStorage` as an accessor that returns undefined, so the
+// `in globalThis` guard style used elsewhere in this file doesn't detect it — the
+// property exists, its value doesn't. Anything reading storage (the write key, and
+// `atomWithStorage` behind fontSizeAtom) therefore sees nothing at all under test.
+// Override it outright with a Map-backed stand-in.
+{
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      // `?? null` would turn a stored empty string into a miss; Storage keeps it.
+      getItem: (key: string) => {
+        const value = store.get(key);
+        return value === undefined ? null : value;
+      },
+      setItem: (key: string, value: string) => {
+        store.set(key, String(value));
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+      clear: () => {
+        store.clear();
+      },
+      key: (index: number) => [...store.keys()][index] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+  });
+}
+
 // jsdom doesn't implement ResizeObserver. The text auto-fit hook (useFitText)
 // observes its container; without this stub construction throws. jsdom also has
 // no layout, so clientHeight/clientWidth are 0 and the hook skips the fit — the

--- a/src/translationUtils.ts
+++ b/src/translationUtils.ts
@@ -1,4 +1,6 @@
 
+import { apiFetch } from './writeKey.ts';
+
 export function findContiguousBlocks(arr: unknown[]) {
     const blocks = [];
     let start = -1;
@@ -188,7 +190,7 @@ export async function fetchAndCacheTranslations(
     const translationTodos = buildBlockTranslationRequests(language, blocks, translationCache);
 
     if (translationTodos.length > 0) {
-        const response = await fetch('/api/requestTranslatedBlocks', {
+        const response = await apiFetch('/api/requestTranslatedBlocks', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ translationTodos, language }),

--- a/src/useTTS.ts
+++ b/src/useTTS.ts
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { Howl } from 'howler';
+import { apiFetch } from './writeKey.ts';
 
 /**
  * Fetches audio for a given text and language from the TTS API.
@@ -14,7 +15,7 @@ async function fetchAudio(text: string, language: string): Promise<string> {
     strippedText += '.';
   }
 
-  const response = await fetch('/api/tts', {
+  const response = await apiFetch('/api/tts', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ text: strippedText, language }),

--- a/src/writeKey.test.ts
+++ b/src/writeKey.test.ts
@@ -5,6 +5,8 @@ import {
   getWriteKey,
   hasWriteKey,
   initWriteKey,
+  maskWriteKey,
+  promptForWriteKeyOnce,
   resetWriteKeyCache,
   setWriteKey,
 } from './writeKey.ts';
@@ -166,5 +168,62 @@ describe('apiFetch', () => {
 
     const init = spy.mock.calls[0][1] as RequestInit | undefined;
     expect(new Headers(init?.headers).get(WRITE_KEY_HEADER)).toBeNull();
+  });
+});
+
+describe('maskWriteKey', () => {
+  it('shows only the tail, enough to tell two keys apart during a rotation', () => {
+    expect(maskWriteKey('kZ8xQ2vLm4vt7Rb9ab12')).toBe('…ab12');
+  });
+
+  it('gives away nothing about a key too short to mask', () => {
+    expect(maskWriteKey('abcd')).toBe('…');
+  });
+});
+
+describe('promptForWriteKeyOnce', () => {
+  it('stores what was typed and asks the caller to retry', () => {
+    const prompt = vi.spyOn(window, 'prompt').mockReturnValue('  NEWKEY  ');
+
+    expect(promptForWriteKeyOnce('needs a key')).toBe(true);
+    expect(prompt).toHaveBeenCalledWith('needs a key');
+    expect(getWriteKey()).toBe('NEWKEY');
+  });
+
+  it('asks only once per page load', () => {
+    // The guard that matters: y-sweet re-invokes its auth endpoint on every reconnect
+    // cycle that exhausts the retry budget, so without this a flaky booth wifi would
+    // throw a blocking modal onto the editor tablet over and over mid-service.
+    const prompt = vi.spyOn(window, 'prompt').mockReturnValue('NEWKEY');
+
+    expect(promptForWriteKeyOnce('needs a key')).toBe(true);
+    expect(promptForWriteKeyOnce('needs a key')).toBe(false);
+    expect(promptForWriteKeyOnce('needs a key')).toBe(false);
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not ask again after the operator cancels', () => {
+    const prompt = vi.spyOn(window, 'prompt').mockReturnValue(null);
+
+    expect(promptForWriteKeyOnce('needs a key')).toBe(false);
+    expect(promptForWriteKeyOnce('needs a key')).toBe(false);
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(getWriteKey()).toBeNull();
+  });
+
+  it('leaves an existing key alone when the operator submits nothing', () => {
+    setWriteKey('OLDKEY');
+    vi.spyOn(window, 'prompt').mockReturnValue('   ');
+
+    expect(promptForWriteKeyOnce('needs a key')).toBe(false);
+    expect(getWriteKey()).toBe('OLDKEY');
+  });
+
+  it('survives a context where prompt() is unavailable', () => {
+    vi.spyOn(window, 'prompt').mockImplementation(() => {
+      throw new Error('blocked in a sandboxed iframe');
+    });
+
+    expect(promptForWriteKeyOnce('needs a key')).toBe(false);
   });
 });

--- a/src/writeKey.test.ts
+++ b/src/writeKey.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  WRITE_KEY_HEADER,
+  apiFetch,
+  getWriteKey,
+  hasWriteKey,
+  initWriteKey,
+  resetWriteKeyCache,
+  setWriteKey,
+} from './writeKey.ts';
+
+/** Point jsdom at a URL, the way a device would be provisioned. */
+function visit(url: string) {
+  window.history.replaceState(null, '', url);
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  resetWriteKeyCache();
+  visit('/notes');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('initWriteKey', () => {
+  it('captures a key from the fragment and scrubs it from the address bar', () => {
+    visit('/notes#editor&key=SECRET123');
+
+    expect(initWriteKey()).toBe('SECRET123');
+    expect(getWriteKey()).toBe('SECRET123');
+    expect(window.location.href).not.toContain('SECRET123');
+  });
+
+  it('leaves the rest of the fragment alone, including the bare #editor flag', () => {
+    visit('/notes#editor&key=SECRET123');
+    initWriteKey();
+    // App.tsx routes on hash.includes("editor"), so this must survive verbatim.
+    expect(window.location.hash).toBe('#editor');
+  });
+
+  it('captures a key from the query string too, preserving other params', () => {
+    visit('/notes?doc=doc-2026-08-02&key=SECRET123#editor');
+
+    expect(initWriteKey()).toBe('SECRET123');
+    expect(window.location.search).toBe('?doc=doc-2026-08-02');
+    expect(window.location.hash).toBe('#editor');
+  });
+
+  it('prefers the fragment when a key appears in both places', () => {
+    visit('/notes?key=FROM_QUERY#key=FROM_HASH');
+    expect(initWriteKey()).toBe('FROM_HASH');
+  });
+
+  it('url-decodes the key', () => {
+    visit('/notes#key=a%2Fb%2Bc');
+    expect(initWriteKey()).toBe('a/b+c');
+  });
+
+  it('persists across a reload', () => {
+    visit('/notes#editor&key=SECRET123');
+    initWriteKey();
+
+    resetWriteKeyCache();
+    visit('/notes#editor');
+
+    expect(initWriteKey()).toBe('SECRET123');
+    expect(hasWriteKey()).toBe(true);
+  });
+
+  it('keeps the stored key when the URL has none', () => {
+    setWriteKey('STORED');
+    resetWriteKeyCache();
+    visit('/notes#editor');
+
+    expect(initWriteKey()).toBe('STORED');
+  });
+
+  it('replaces the stored key when a new one arrives', () => {
+    setWriteKey('OLD');
+    visit('/notes#key=NEW');
+
+    expect(initWriteKey()).toBe('NEW');
+    expect(getWriteKey()).toBe('NEW');
+  });
+
+  it('returns null when no key has ever been seen', () => {
+    expect(initWriteKey()).toBeNull();
+    expect(hasWriteKey()).toBe(false);
+  });
+
+  it('ignores an empty key param', () => {
+    visit('/notes#editor&key=');
+    expect(initWriteKey()).toBeNull();
+  });
+
+  it('still works for the tab when localStorage throws', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    visit('/notes#key=SECRET123');
+
+    expect(initWriteKey()).toBe('SECRET123');
+    expect(getWriteKey()).toBe('SECRET123');
+  });
+});
+
+describe('setWriteKey', () => {
+  it('stores a hand-typed key', () => {
+    setWriteKey('  TYPED  ');
+    resetWriteKeyCache();
+    expect(getWriteKey()).toBe('TYPED');
+  });
+
+  it('clears the device key with null or blank', () => {
+    setWriteKey('TYPED');
+    setWriteKey(null);
+    expect(getWriteKey()).toBeNull();
+
+    setWriteKey('TYPED');
+    setWriteKey('   ');
+    expect(getWriteKey()).toBeNull();
+  });
+});
+
+describe('apiFetch', () => {
+  const mockFetch = () => {
+    const spy = vi.fn().mockResolvedValue(new Response('{}'));
+    vi.stubGlobal('fetch', spy);
+    return spy;
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('attaches the key when the device has one', async () => {
+    setWriteKey('SECRET123');
+    const spy = mockFetch();
+
+    await apiFetch('/api/translateItem', { method: 'POST' });
+
+    const init = spy.mock.calls[0][1] as RequestInit;
+    expect(new Headers(init.headers).get(WRITE_KEY_HEADER)).toBe('SECRET123');
+  });
+
+  it('preserves headers the caller already set', async () => {
+    setWriteKey('SECRET123');
+    const spy = mockFetch();
+
+    await apiFetch('/api/translateItem', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const headers = new Headers((spy.mock.calls[0][1] as RequestInit).headers);
+    expect(headers.get('Content-Type')).toBe('application/json');
+    expect(headers.get(WRITE_KEY_HEADER)).toBe('SECRET123');
+  });
+
+  it('sends nothing extra when the device has no key', async () => {
+    const spy = mockFetch();
+
+    await apiFetch('/api/tts', { method: 'POST' });
+
+    const init = spy.mock.calls[0][1] as RequestInit | undefined;
+    expect(new Headers(init?.headers).get(WRITE_KEY_HEADER)).toBeNull();
+  });
+});

--- a/src/writeKey.ts
+++ b/src/writeKey.ts
@@ -1,0 +1,141 @@
+/**
+ * The browser half of shared-key write authorization (server side: ../writeAuth.ts).
+ *
+ * The unit being authorized is a *device*, not a person: the booth laptop, the tablet on
+ * the music stand. So the key arrives once in a URL, is stored in localStorage, and is
+ * then attached to every API request that device makes from then on — no login, no
+ * session, nothing to re-enter next Sunday.
+ *
+ * Provisioning a device means opening a URL with the key in it:
+ *
+ *   https://…/notes#editor&key=THEKEY      ← preferred: a fragment never leaves the browser
+ *   https://…/notes?key=THEKEY#editor      ← also accepted, but reaches the server's logs
+ *
+ * Either form is removed from the address bar immediately after being stored, so the key
+ * doesn't linger on screen, in a bookmark, or in a screenshot of the projector laptop.
+ */
+
+/** Must match WRITE_KEY_HEADER in ../writeAuth.ts (not imported: that module is Node-only). */
+export const WRITE_KEY_HEADER = 'X-Write-Key';
+
+const STORAGE_KEY = 'live-notes:writeKey';
+
+/**
+ * Fallback for when localStorage is unavailable (Safari private browsing, a locked-down
+ * kiosk profile). The key then lasts only as long as the tab, which still beats failing.
+ */
+let memoryKey: string | null = null;
+
+function readStored(): string | null {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeStored(key: string | null): void {
+  try {
+    if (key === null) window.localStorage.removeItem(STORAGE_KEY);
+    else window.localStorage.setItem(STORAGE_KEY, key);
+  } catch {
+    // Ignored: memoryKey already holds the value for this tab.
+  }
+}
+
+/** Pull `key=…` out of a `a=1&b=2` style string, if present and non-empty. */
+function readKeyParam(raw: string): string | null {
+  for (const part of raw.split('&')) {
+    const match = /^key=(.*)$/i.exec(part);
+    if (!match) continue;
+    let value: string;
+    try {
+      value = decodeURIComponent(match[1].replace(/\+/g, ' '));
+    } catch {
+      value = match[1];
+    }
+    if (value.trim()) return value.trim();
+  }
+  return null;
+}
+
+/**
+ * Remove `key=…` while leaving every other part untouched — including valueless flags
+ * like the `#editor` this app routes on, which a URLSearchParams round-trip would
+ * rewrite to `editor=`.
+ */
+function stripKeyParam(raw: string): string {
+  return raw
+    .split('&')
+    .filter((part) => !/^key=/i.test(part))
+    .join('&');
+}
+
+/**
+ * Capture a key from the current URL, store it, and scrub it from the address bar.
+ * Idempotent, and safe to call when there is no key in the URL: an already-stored key
+ * is kept. Returns the key now in effect, if any.
+ */
+export function initWriteKey(): string | null {
+  const search = window.location.search.replace(/^\?/, '');
+  const hash = window.location.hash.replace(/^#/, '');
+  // The fragment wins: it is the form that never reaches a server log.
+  const fromUrl = readKeyParam(hash) ?? readKeyParam(search);
+
+  if (fromUrl) {
+    memoryKey = fromUrl;
+    writeStored(fromUrl);
+
+    const strippedSearch = stripKeyParam(search);
+    const strippedHash = stripKeyParam(hash);
+    const url =
+      window.location.pathname +
+      (strippedSearch ? `?${strippedSearch}` : '') +
+      (strippedHash ? `#${strippedHash}` : '');
+    try {
+      window.history.replaceState(window.history.state, '', url);
+    } catch {
+      // Non-fatal: the key is stored either way, it just stays visible in the bar.
+    }
+    return fromUrl;
+  }
+
+  memoryKey = readStored();
+  return memoryKey;
+}
+
+/** The key this device holds, or null. */
+export function getWriteKey(): string | null {
+  if (memoryKey) return memoryKey;
+  memoryKey = readStored();
+  return memoryKey;
+}
+
+export function hasWriteKey(): boolean {
+  return getWriteKey() !== null;
+}
+
+/** Store a key typed in by hand, or clear this device's key with `null`. */
+export function setWriteKey(key: string | null): void {
+  const normalized = key?.trim() ? key.trim() : null;
+  memoryKey = normalized;
+  writeStored(normalized);
+}
+
+/** Reset the module's cache. Tests only. */
+export function resetWriteKeyCache(): void {
+  memoryKey = null;
+}
+
+/**
+ * `fetch`, plus this device's write key when it has one. Use it for every `/api/` call:
+ * requests that don't need a key are unaffected by carrying one, and routing them all
+ * through here means a newly privileged endpoint doesn't need a new call site audited.
+ */
+export function apiFetch(input: RequestInfo | URL, init: RequestInit = {}): Promise<Response> {
+  const key = getWriteKey();
+  if (!key) return fetch(input, init);
+  const headers = new Headers(init.headers);
+  headers.set(WRITE_KEY_HEADER, key);
+  return fetch(input, { ...init, headers });
+}

--- a/src/writeKey.ts
+++ b/src/writeKey.ts
@@ -122,9 +122,53 @@ export function setWriteKey(key: string | null): void {
   writeStored(normalized);
 }
 
-/** Reset the module's cache. Tests only. */
+/**
+ * Show the last few characters of a key, for answering "which key is this device on?"
+ * during a rotation without putting the secret on a projector. Four characters of a
+ * 48-character random key identifies it among the handful in `WRITE_KEYS` and is
+ * useless to anyone who doesn't already have the list.
+ */
+export function maskWriteKey(key: string): string {
+  const trimmed = key.trim();
+  if (trimmed.length <= 4) return '…';
+  return `…${trimmed.slice(-4)}`;
+}
+
+/**
+ * True once this page load has asked for a key. The guard is the whole reason this
+ * lives here rather than at the call site: y-sweet re-invokes its auth endpoint on
+ * every reconnect cycle that exhausts the retry budget, so an unguarded prompt would
+ * throw a blocking modal onto the editor tablet every time the wifi hiccups mid-service
+ * — a far worse failure than the missing key it is trying to fix.
+ */
+let hasPrompted = false;
+
+/**
+ * Ask for this device's key and store what is typed. Once per page load, whatever the
+ * answer: someone who cancels has said no, and asking again on the next reconnect would
+ * be nagging. Returns true only when a new key was stored, i.e. when it is worth the
+ * caller retrying the request that provoked this.
+ */
+export function promptForWriteKeyOnce(message: string): boolean {
+  if (hasPrompted) return false;
+  hasPrompted = true;
+  let typed: string | null;
+  try {
+    typed = window.prompt(message);
+  } catch {
+    // prompt() is unavailable (sandboxed iframe, some kiosk profiles). The device can
+    // still be provisioned by URL or from the status page.
+    return false;
+  }
+  if (!typed?.trim()) return false;
+  setWriteKey(typed.trim());
+  return true;
+}
+
+/** Reset the module's caches, as if this were a fresh page load. Tests only. */
 export function resetWriteKeyCache(): void {
   memoryKey = null;
+  hasPrompted = false;
 }
 
 /**

--- a/template-.env
+++ b/template-.env
@@ -2,6 +2,17 @@ YSWEET_CONNECTION_STRING=...
 GEMINI_API_KEY=...
 ELEVENLABS_API_KEY=...
 
+# Write authorization: shared per-device keys, not user logins (docs/WRITE_KEYS.md).
+# Reading stays open to anyone; these gate editing, the microphone, and the endpoints that
+# spend money. Comma-separated, each entry `label:key` or a bare `key`; the label only ever
+# shows up in logs. Generate with `openssl rand -hex 24`.
+# WRITE_KEYS=proclaim:...,booth:...,tablet:...,feeder:...
+
+# off | observe | enforce (default: observe; forced to off when WRITE_KEYS is empty).
+# `observe` checks and logs every privileged request but allows it anyway — ship keys to the
+# devices, watch the logs for `key=none`, and only then switch to `enforce`.
+# WRITE_AUTH_MODE=observe
+
 # TTS Rate Limiting (optional, default: 2 concurrent requests)
 # TTS_MAX_CONCURRENT=2
 

--- a/template-.env
+++ b/template-.env
@@ -13,6 +13,13 @@ ELEVENLABS_API_KEY=...
 # devices, watch the logs for `key=none`, and only then switch to `enforce`.
 # WRITE_AUTH_MODE=observe
 
+# Per-caller request caps for the two endpoints a write key can't protect, because
+# listeners legitimately call them (docs/WRITE_KEYS.md). Set far above a real service: a
+# congregation shares one public address, so these are sized to stop a script, not a busy
+# Sunday. 0 disables.
+# TTS_RATE_LIMIT_PER_MIN=600
+# TRANSLATE_RATE_LIMIT_PER_MIN=1200
+
 # TTS Rate Limiting (optional, default: 2 concurrent requests)
 # TTS_MAX_CONCURRENT=2
 

--- a/tests/test_write_key.py
+++ b/tests/test_write_key.py
@@ -1,0 +1,112 @@
+"""Tests for the service's shared write key: reading it, and presenting it on the two
+privileged calls this service makes (a full Y-Sweet token, and /api/translateItem)."""
+
+from unittest import mock
+
+import pytest
+
+import proclaim_service
+from slide_sync_runtime import SlideSyncRuntime
+from slide_translator import SlideTranslator
+from write_key import WRITE_KEY_HEADER, get_write_key, write_key_headers
+from yjs_publisher import YjsSlidePublisher
+
+from helpers import fast_timing
+
+
+class TestWriteKeyHelpers:
+    def test_headers_present_the_key(self):
+        assert write_key_headers("SECRET123") == {WRITE_KEY_HEADER: "SECRET123"}
+
+    def test_headers_are_empty_without_a_key(self):
+        assert write_key_headers(None) == {}
+        assert write_key_headers("") == {}
+        assert write_key_headers("   ") == {}
+
+    def test_headers_trim_whitespace(self):
+        assert write_key_headers("  SECRET123\n") == {WRITE_KEY_HEADER: "SECRET123"}
+
+    def test_get_write_key_reads_the_env_var(self):
+        assert get_write_key({"PROCLAIM_WRITE_KEY": "SECRET123"}) == "SECRET123"
+        assert get_write_key({"PROCLAIM_WRITE_KEY": "  SECRET123  "}) == "SECRET123"
+
+    def test_get_write_key_is_none_when_unset_or_blank(self):
+        assert get_write_key({}) is None
+        assert get_write_key({"PROCLAIM_WRITE_KEY": ""}) is None
+        assert get_write_key({"PROCLAIM_WRITE_KEY": "   "}) is None
+
+
+def make_runtime(write_key):
+    return SlideSyncRuntime(
+        mock.Mock(),
+        YjsSlidePublisher(),
+        SlideTranslator(mock.AsyncMock(return_value=None), ["French"], 0.001),
+        "http://localhost:8000",
+        doc_id="doc-test",
+        timing=fast_timing(),
+        write_key=write_key,
+    )
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+def patched_httpx_post(module, payload):
+    """Patch httpx.AsyncClient in `module` and hand back the post mock to assert on."""
+    post = mock.AsyncMock(return_value=FakeResponse(payload))
+    client = mock.MagicMock()
+    client.__aenter__ = mock.AsyncMock(return_value=mock.Mock(post=post))
+    client.__aexit__ = mock.AsyncMock(return_value=False)
+    return mock.patch.object(module.httpx, "AsyncClient", return_value=client), post
+
+
+@pytest.mark.anyio
+class TestYSweetTokenRequest:
+    async def test_sends_the_write_key_when_configured(self):
+        import slide_sync_runtime
+
+        patcher, post = patched_httpx_post(slide_sync_runtime, {"url": "ws://test"})
+        with patcher:
+            await make_runtime("SECRET123").get_ysweet_token()
+
+        assert post.call_args.kwargs["headers"] == {WRITE_KEY_HEADER: "SECRET123"}
+        # The doc/editor contract is unchanged by the key.
+        assert post.call_args.kwargs["json"] == {"docId": "doc-test", "isEditor": True}
+
+    async def test_sends_no_key_header_when_unconfigured(self):
+        import slide_sync_runtime
+
+        patcher, post = patched_httpx_post(slide_sync_runtime, {"url": "ws://test"})
+        with patcher:
+            await make_runtime(None).get_ysweet_token()
+
+        assert post.call_args.kwargs["headers"] == {}
+
+
+@pytest.mark.anyio
+class TestTranslateItemRequest:
+    async def test_sends_the_write_key_when_configured(self):
+        patcher, post = patched_httpx_post(proclaim_service, {"translations": {}})
+        translate = proclaim_service.make_translate_fn(
+            "http://localhost:8000", ["French"], write_key="SECRET123"
+        )
+        with patcher:
+            await translate(["a slide"], "Psalm 23", "item-1", None, "doc-test")
+
+        assert post.call_args.kwargs["headers"] == {WRITE_KEY_HEADER: "SECRET123"}
+
+    async def test_sends_no_key_header_when_unconfigured(self):
+        patcher, post = patched_httpx_post(proclaim_service, {"translations": {}})
+        translate = proclaim_service.make_translate_fn("http://localhost:8000", ["French"])
+        with patcher:
+            await translate(["a slide"], "Psalm 23", "item-1", None, "doc-test")
+
+        assert post.call_args.kwargs["headers"] == {}

--- a/writeAuth.test.ts
+++ b/writeAuth.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  WriteAuth,
+  extractPresentedKey,
+  formatAudit,
+  parseWriteAuthMode,
+  parseWriteKeys,
+  resolveWriteAuthConfig,
+  type WriteAuthAudit,
+} from './writeAuth.ts';
+
+const req = (headers: Record<string, string | string[] | undefined>) => ({ headers });
+
+describe('parseWriteKeys', () => {
+  it('returns nothing for unset or empty input', () => {
+    expect(parseWriteKeys(undefined)).toEqual([]);
+    expect(parseWriteKeys('')).toEqual([]);
+    expect(parseWriteKeys('   ')).toEqual([]);
+  });
+
+  it('parses labelled entries', () => {
+    expect(parseWriteKeys('proclaim:abc123,tablet:def456')).toEqual([
+      { label: 'proclaim', key: 'abc123' },
+      { label: 'tablet', key: 'def456' },
+    ]);
+  });
+
+  it('gives bare keys a positional label', () => {
+    expect(parseWriteKeys('abc123,def456')).toEqual([
+      { label: 'key1', key: 'abc123' },
+      { label: 'key2', key: 'def456' },
+    ]);
+  });
+
+  it('tolerates whitespace and trailing commas', () => {
+    expect(parseWriteKeys(' proclaim : abc123 , , tablet:def456 ,')).toEqual([
+      { label: 'proclaim', key: 'abc123' },
+      { label: 'tablet', key: 'def456' },
+    ]);
+  });
+
+  it('drops entries with an empty key so nothing ever matches the empty string', () => {
+    expect(parseWriteKeys('label:,:,good:abc123')).toEqual([
+      { label: 'good', key: 'abc123' },
+    ]);
+  });
+
+  it('keeps colons that appear inside the key itself', () => {
+    expect(parseWriteKeys('proclaim:abc:123')).toEqual([
+      { label: 'proclaim', key: 'abc:123' },
+    ]);
+  });
+});
+
+describe('parseWriteAuthMode', () => {
+  it('defaults to observe when unset', () => {
+    expect(parseWriteAuthMode(undefined)).toBe('observe');
+    expect(parseWriteAuthMode('')).toBe('observe');
+  });
+
+  it('accepts the three modes, case-insensitively', () => {
+    expect(parseWriteAuthMode('off')).toBe('off');
+    expect(parseWriteAuthMode('Observe')).toBe('observe');
+    expect(parseWriteAuthMode(' ENFORCE ')).toBe('enforce');
+  });
+
+  it('throws on a typo rather than silently allowing everything', () => {
+    expect(() => parseWriteAuthMode('enfoce')).toThrow(/off\|observe\|enforce/);
+  });
+});
+
+describe('resolveWriteAuthConfig', () => {
+  it('turns itself off when no keys are configured', () => {
+    const config = resolveWriteAuthConfig({});
+    expect(config.mode).toBe('off');
+    expect(config.notices.join('\n')).toMatch(/no WRITE_KEYS configured/);
+  });
+
+  it('defaults to observe once keys exist', () => {
+    const config = resolveWriteAuthConfig({ WRITE_KEYS: 'proclaim:0123456789abcdef' });
+    expect(config.mode).toBe('observe');
+    expect(config.keys).toHaveLength(1);
+    expect(config.notices.join('\n')).toMatch(/RECORDED BUT ALLOWED/);
+  });
+
+  it('refuses to start in enforce mode with no keys', () => {
+    expect(() => resolveWriteAuthConfig({ WRITE_AUTH_MODE: 'enforce' })).toThrow(
+      /requires at least one key/,
+    );
+  });
+
+  it('warns about implausibly short keys but still starts', () => {
+    const config = resolveWriteAuthConfig({ WRITE_KEYS: 'tablet:hunter2' });
+    expect(config.mode).toBe('observe');
+    expect(config.notices.join('\n')).toMatch(/short key\(s\) \[tablet\]/);
+  });
+});
+
+describe('extractPresentedKey', () => {
+  it('reads the X-Write-Key header', () => {
+    expect(extractPresentedKey(req({ 'x-write-key': 'abc123' }))).toBe('abc123');
+  });
+
+  it('reads an Authorization: Bearer header', () => {
+    expect(extractPresentedKey(req({ authorization: 'Bearer abc123' }))).toBe('abc123');
+    expect(extractPresentedKey(req({ authorization: 'bearer abc123' }))).toBe('abc123');
+  });
+
+  it('prefers X-Write-Key when both are present', () => {
+    expect(
+      extractPresentedKey(req({ 'x-write-key': 'abc123', authorization: 'Bearer other' })),
+    ).toBe('abc123');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(extractPresentedKey(req({ 'x-write-key': '  abc123  ' }))).toBe('abc123');
+  });
+
+  it('returns null when absent, blank, or a non-Bearer scheme', () => {
+    expect(extractPresentedKey(req({}))).toBeNull();
+    expect(extractPresentedKey(req({ 'x-write-key': '   ' }))).toBeNull();
+    expect(extractPresentedKey(req({ authorization: 'Basic abc123' }))).toBeNull();
+  });
+
+  it('uses the first value when a header is repeated', () => {
+    expect(extractPresentedKey(req({ 'x-write-key': ['abc123', 'def456'] }))).toBe('abc123');
+  });
+});
+
+describe('WriteAuth.evaluate', () => {
+  const auth = new WriteAuth(
+    resolveWriteAuthConfig({ WRITE_KEYS: 'proclaim:0123456789abcdef,tablet:fedcba9876543210' }),
+  );
+
+  it('matches a configured key and reports its label', () => {
+    expect(auth.evaluate(req({ 'x-write-key': '0123456789abcdef' }))).toEqual({
+      status: 'ok',
+      label: 'proclaim',
+    });
+    expect(auth.evaluate(req({ 'x-write-key': 'fedcba9876543210' }))).toEqual({
+      status: 'ok',
+      label: 'tablet',
+    });
+  });
+
+  it('reports a missing key separately from a wrong one', () => {
+    expect(auth.evaluate(req({}))).toEqual({ status: 'missing', label: null });
+    expect(auth.evaluate(req({ 'x-write-key': 'nope' }))).toEqual({
+      status: 'invalid',
+      label: null,
+    });
+  });
+
+  it('does not match a prefix, a suffix, or a different case', () => {
+    expect(auth.evaluate(req({ 'x-write-key': '0123456789abcde' })).status).toBe('invalid');
+    expect(auth.evaluate(req({ 'x-write-key': '0123456789abcdefg' })).status).toBe('invalid');
+    expect(auth.evaluate(req({ 'x-write-key': '0123456789ABCDEF' })).status).toBe('invalid');
+  });
+});
+
+describe('WriteAuth.check', () => {
+  const keys = { WRITE_KEYS: 'proclaim:0123456789abcdef' };
+
+  it('allows everything and audits nothing when off', () => {
+    const onAudit = vi.fn();
+    const auth = new WriteAuth(resolveWriteAuthConfig({}), onAudit);
+    expect(auth.check(req({}), '/api/translateItem').allowed).toBe(true);
+    expect(onAudit).not.toHaveBeenCalled();
+  });
+
+  it('allows an unauthorized request in observe mode, but records what enforce would do', () => {
+    const audits: WriteAuthAudit[] = [];
+    const auth = new WriteAuth(resolveWriteAuthConfig(keys), (a) => audits.push(a));
+
+    expect(auth.check(req({}), '/api/translateItem').allowed).toBe(true);
+
+    expect(audits).toEqual([
+      {
+        mode: 'observe',
+        route: '/api/translateItem',
+        status: 'missing',
+        label: null,
+        refused: false,
+      },
+    ]);
+  });
+
+  it('refuses an unauthorized request in enforce mode', () => {
+    const audits: WriteAuthAudit[] = [];
+    const auth = new WriteAuth(
+      resolveWriteAuthConfig({ ...keys, WRITE_AUTH_MODE: 'enforce' }),
+      (a) => audits.push(a),
+    );
+
+    expect(auth.check(req({}), '/api/ys-auth').allowed).toBe(false);
+    expect(auth.check(req({ 'x-write-key': 'wrong' }), '/api/ys-auth').allowed).toBe(false);
+    expect(auth.check(req({ 'x-write-key': '0123456789abcdef' }), '/api/ys-auth').allowed).toBe(
+      true,
+    );
+
+    expect(audits.map((a) => [a.status, a.refused])).toEqual([
+      ['missing', true],
+      ['invalid', true],
+      ['ok', false],
+    ]);
+  });
+});
+
+describe('WriteAuth.gate', () => {
+  const enforcing = () =>
+    new WriteAuth(
+      resolveWriteAuthConfig({
+        WRITE_KEYS: 'proclaim:0123456789abcdef',
+        WRITE_AUTH_MODE: 'enforce',
+      }),
+    );
+
+  const fakeRes = () => {
+    const json = vi.fn();
+    return { json, status: vi.fn(() => ({ json })) };
+  };
+
+  it('sends a 401 and stops the request when refused', () => {
+    const res = fakeRes();
+    expect(enforcing().gate(req({}), res, '/api/translateItem')).toBe(false);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, error: expect.stringContaining('write key') }),
+    );
+  });
+
+  it('leaves the response untouched when authorized', () => {
+    const res = fakeRes();
+    expect(
+      enforcing().gate(req({ 'x-write-key': '0123456789abcdef' }), res, '/api/translateItem'),
+    ).toBe(true);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});
+
+describe('formatAudit', () => {
+  const base = { mode: 'observe' as const, route: '/api/ys-auth' };
+
+  it('names the device on success', () => {
+    expect(formatAudit({ ...base, status: 'ok', label: 'proclaim', refused: false })).toBe(
+      '[write-auth] observe /api/ys-auth key=proclaim → ok',
+    );
+  });
+
+  it('spells out that observe mode let an unauthorized request through', () => {
+    expect(formatAudit({ ...base, status: 'missing', label: null, refused: false })).toBe(
+      '[write-auth] observe /api/ys-auth key=none → MISSING (allowed — observe mode)',
+    );
+  });
+
+  it('marks a refusal', () => {
+    expect(
+      formatAudit({ ...base, mode: 'enforce', status: 'invalid', label: null, refused: true }),
+    ).toBe('[write-auth] enforce /api/ys-auth key=unknown → INVALID (refused)');
+  });
+});

--- a/writeAuth.test.ts
+++ b/writeAuth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   WriteAuth,
+  auditDistinctId,
   extractPresentedKey,
   formatAudit,
   parseWriteAuthMode,
@@ -9,7 +10,13 @@ import {
   type WriteAuthAudit,
 } from './writeAuth.ts';
 
-const req = (headers: Record<string, string | string[] | undefined>) => ({ headers });
+const req = (headers: Record<string, string | string[] | undefined>, ip?: string) => ({
+  headers,
+  ip,
+});
+
+/** What `client` looks like for a request that told us nothing about itself. */
+const anonymous = { ip: null, userAgent: null, keyFingerprint: null };
 
 describe('parseWriteKeys', () => {
   it('returns nothing for unset or empty input', () => {
@@ -93,6 +100,21 @@ describe('resolveWriteAuthConfig', () => {
     const config = resolveWriteAuthConfig({ WRITE_KEYS: 'tablet:hunter2' });
     expect(config.mode).toBe('observe');
     expect(config.notices.join('\n')).toMatch(/short key\(s\) \[tablet\]/);
+  });
+
+  it('warns when two labels share a key, since only the first will ever be logged', () => {
+    const config = resolveWriteAuthConfig({
+      WRITE_KEYS: 'booth:0123456789abcdef,tablet:0123456789abcdef',
+    });
+    expect(config.keys).toHaveLength(2);
+    expect(config.notices.join('\n')).toMatch(/tablet shares booth's key/);
+  });
+
+  it('says nothing when every key is distinct', () => {
+    const config = resolveWriteAuthConfig({
+      WRITE_KEYS: 'booth:0123456789abcdef,tablet:fedcba9876543210',
+    });
+    expect(config.notices.join('\n')).not.toMatch(/shares/);
   });
 });
 
@@ -181,6 +203,7 @@ describe('WriteAuth.check', () => {
         status: 'missing',
         label: null,
         refused: false,
+        client: anonymous,
       },
     ]);
   });
@@ -203,6 +226,83 @@ describe('WriteAuth.check', () => {
       ['invalid', true],
       ['ok', false],
     ]);
+  });
+});
+
+describe('WriteAuth.check attribution', () => {
+  const keys = { WRITE_KEYS: 'proclaim:0123456789abcdef' };
+
+  const auditFor = (request: ReturnType<typeof req>, env = keys) => {
+    const audits: WriteAuthAudit[] = [];
+    new WriteAuth(resolveWriteAuthConfig(env), (a) => audits.push(a)).check(request, '/api/tts');
+    return audits[0];
+  };
+
+  it('records where a keyless request came from', () => {
+    const audit = auditFor(req({ 'user-agent': 'AudioFeeder/1.0' }, '192.168.1.40'));
+    expect(audit.client.ip).toBe('192.168.1.40');
+    expect(audit.client.userAgent).toBe('AudioFeeder/1.0');
+    expect(audit.client.keyFingerprint).toBeNull();
+  });
+
+  it('truncates a long user agent rather than logging a whole browser string', () => {
+    const audit = auditFor(req({ 'user-agent': 'x'.repeat(300) }));
+    expect(audit.client.userAgent).toHaveLength(60);
+  });
+
+  it('fingerprints an unrecognized key, stably and without revealing it', () => {
+    const first = auditFor(req({ 'x-write-key': 'LAST-MONTHS-BOOTH-KEY' }));
+    const second = auditFor(req({ 'x-write-key': 'LAST-MONTHS-BOOTH-KEY' }));
+
+    expect(first.status).toBe('invalid');
+    expect(first.client.keyFingerprint).toMatch(/^[0-9a-f]{8}$/);
+    // Stable, so "every device still on the old key" is one bucket you can watch drain.
+    expect(second.client.keyFingerprint).toBe(first.client.keyFingerprint);
+    expect(first.client.keyFingerprint).not.toContain('BOOTH');
+  });
+
+  it('never fingerprints a key that worked', () => {
+    const audit = auditFor(req({ 'x-write-key': '0123456789abcdef' }));
+    expect(audit.status).toBe('ok');
+    expect(audit.client.keyFingerprint).toBeNull();
+  });
+});
+
+describe('auditDistinctId', () => {
+  const base = { mode: 'observe' as const, route: '/api/ys-auth', refused: false };
+
+  it('files an authorized request under the device label', () => {
+    expect(
+      auditDistinctId({ ...base, status: 'ok', label: 'proclaim', client: anonymous }),
+    ).toBe('proclaim');
+  });
+
+  it('groups everyone still holding the same stale key together', () => {
+    expect(
+      auditDistinctId({
+        ...base,
+        status: 'invalid',
+        label: null,
+        client: { ...anonymous, keyFingerprint: '3f2a9c11' },
+      }),
+    ).toBe('stale-key-3f2a9c11');
+  });
+
+  it('falls back to the address when there is no key at all to group by', () => {
+    expect(
+      auditDistinctId({
+        ...base,
+        status: 'missing',
+        label: null,
+        client: { ...anonymous, ip: '192.168.1.40' },
+      }),
+    ).toBe('no-key-192.168.1.40');
+  });
+
+  it('has one last fallback when a request says nothing about itself', () => {
+    expect(
+      auditDistinctId({ ...base, status: 'missing', label: null, client: anonymous }),
+    ).toBe('unknown-device');
   });
 });
 
@@ -239,7 +339,7 @@ describe('WriteAuth.gate', () => {
 });
 
 describe('formatAudit', () => {
-  const base = { mode: 'observe' as const, route: '/api/ys-auth' };
+  const base = { mode: 'observe' as const, route: '/api/ys-auth', client: anonymous };
 
   it('names the device on success', () => {
     expect(formatAudit({ ...base, status: 'ok', label: 'proclaim', refused: false })).toBe(
@@ -253,9 +353,30 @@ describe('formatAudit', () => {
     );
   });
 
-  it('marks a refusal', () => {
+  it('marks a refusal, and fingerprints the key that was refused', () => {
     expect(
-      formatAudit({ ...base, mode: 'enforce', status: 'invalid', label: null, refused: true }),
-    ).toBe('[write-auth] enforce /api/ys-auth key=unknown → INVALID (refused)');
+      formatAudit({
+        ...base,
+        mode: 'enforce',
+        status: 'invalid',
+        label: null,
+        refused: true,
+        client: { ...anonymous, keyFingerprint: '3f2a9c11' },
+      }),
+    ).toBe('[write-auth] enforce /api/ys-auth key=unknown(3f2a9c11) → INVALID (refused)');
+  });
+
+  it('says where a miss came from, so it can be chased down', () => {
+    expect(
+      formatAudit({
+        ...base,
+        status: 'missing',
+        label: null,
+        refused: false,
+        client: { ...anonymous, ip: '192.168.1.40' },
+      }),
+    ).toBe(
+      '[write-auth] observe /api/ys-auth key=none ip=192.168.1.40 → MISSING (allowed — observe mode)',
+    );
   });
 });

--- a/writeAuth.ts
+++ b/writeAuth.ts
@@ -43,17 +43,43 @@ export interface WriteAuthResult {
   label: string | null;
 }
 
+/**
+ * Whatever can be said about who asked, for a request that presented no usable key.
+ *
+ * Not identity — there is none to be had here. This exists because the observe window's
+ * whole job is answering "which device is still missing a key", and a record saying only
+ * that *something* was unauthorized cannot answer it.
+ */
+export interface WriteAuthClient {
+  ip: string | null;
+  /** Truncated: enough to tell a Mac service from an iPad, not a tracking record. */
+  userAgent: string | null;
+  /**
+   * Short digest of a presented-but-unrecognized key. Set only for `invalid` — an `ok`
+   * request has a label, and a `missing` one presented nothing to digest. This is what
+   * distinguishes "still holding last month's booth key" from "random junk", which
+   * during a rotation is the entire question.
+   */
+  keyFingerprint: string | null;
+}
+
 /** The audit record emitted for every privileged request, in every non-`off` mode. */
 export interface WriteAuthAudit extends WriteAuthResult {
   mode: WriteAuthMode;
   route: string;
   /** True when the request was actually refused (enforce mode + a bad key). */
   refused: boolean;
+  client: WriteAuthClient;
 }
 
-/** Just enough of an express Request to read headers from. */
+/**
+ * Just enough of an express Request to read headers from. `ip` is express's, which
+ * behind a reverse proxy is the proxy's address unless `trust proxy` is configured —
+ * treat it as a hint for chasing down a device, never as an access control input.
+ */
 export interface HeaderBearingRequest {
   headers: Record<string, string | string[] | undefined>;
+  ip?: string;
 }
 
 /** Header clients use to present their key. `Authorization: Bearer <key>` also works. */
@@ -139,6 +165,24 @@ export function resolveWriteAuthConfig(env: {
         `use at least ${MIN_REASONABLE_KEY_LENGTH} random characters`,
     );
   }
+
+  // Two labels sharing a key value is a plausible slip while hand-editing WRITE_KEYS
+  // during a rotation, and a quiet one: matching returns the *first* label, so the
+  // second device's traffic is filed under the first device's name. The label is the
+  // only audit trail there is, so it silently lying is worth a line at boot.
+  const firstLabelForKey = new Map<string, string>();
+  const collisions: string[] = [];
+  for (const entry of keys) {
+    const first = firstLabelForKey.get(entry.key);
+    if (first) collisions.push(`${entry.label} shares ${first}'s key`);
+    else firstLabelForKey.set(entry.key, entry.label);
+  }
+  if (collisions.length > 0) {
+    notices.push(
+      `[write-auth] WARNING: ${collisions.join('; ')} — audits report only the first ` +
+        `label, so those devices are indistinguishable in the logs`,
+    );
+  }
   notices.push(
     `[write-auth] mode=${requestedMode} keys=[${keys.map((e) => e.label).join(', ')}]`,
   );
@@ -160,6 +204,43 @@ function keysMatch(presented: string, configured: string): boolean {
   const a = createHash('sha256').update(presented, 'utf8').digest();
   const b = createHash('sha256').update(configured, 'utf8').digest();
   return timingSafeEqual(a, b);
+}
+
+/**
+ * A short, stable digest of a key. Short on purpose: it is a label for "the key that was
+ * presented", not a credential, and it must be safe to put in a log and a chart.
+ */
+export function fingerprintKey(key: string): string {
+  return createHash('sha256').update(key, 'utf8').digest('hex').slice(0, 8);
+}
+
+/** Truncated so a log line stays one line and the record stays a hint, not a profile. */
+const MAX_LOGGED_USER_AGENT = 60;
+
+function describeClient(
+  req: HeaderBearingRequest,
+  presented: string | null,
+  status: WriteAuthStatus,
+): WriteAuthClient {
+  const uaHeader = req.headers['user-agent'];
+  const ua = Array.isArray(uaHeader) ? uaHeader[0] : uaHeader;
+  return {
+    ip: req.ip ?? null,
+    userAgent: ua ? ua.slice(0, MAX_LOGGED_USER_AGENT) : null,
+    keyFingerprint: status === 'invalid' && presented ? fingerprintKey(presented) : null,
+  };
+}
+
+/**
+ * Who to file an audit record under. `ok` is the device's label, which is the whole
+ * reason labels exist. The other two are the interesting cases: an unrecognized key
+ * groups by the key itself, so every device still holding last month's key lands in one
+ * bucket you can watch drain; a request with no key at all has nothing but its address.
+ */
+export function auditDistinctId(audit: WriteAuthAudit): string {
+  if (audit.status === 'ok') return audit.label ?? 'unknown-device';
+  if (audit.client.keyFingerprint) return `stale-key-${audit.client.keyFingerprint}`;
+  return audit.client.ip ? `no-key-${audit.client.ip}` : 'unknown-device';
 }
 
 /** Pull the presented key from `X-Write-Key`, or from `Authorization: Bearer <key>`. */
@@ -207,9 +288,16 @@ export class WriteAuth {
     if (this.mode === 'off') {
       return { result: { status: 'ok', label: null }, allowed: true };
     }
+    const presented = extractPresentedKey(req);
     const result = this.evaluate(req);
     const allowed = this.mode !== 'enforce' || result.status === 'ok';
-    this.onAudit({ ...result, mode: this.mode, route, refused: !allowed });
+    this.onAudit({
+      ...result,
+      mode: this.mode,
+      route,
+      refused: !allowed,
+      client: describeClient(req, presented, result.status),
+    });
     return { result, allowed };
   }
 
@@ -234,12 +322,18 @@ export class WriteAuth {
 
 /** Render an audit record as a single greppable log line. */
 export function formatAudit(audit: WriteAuthAudit): string {
-  const key = audit.status === 'ok' ? audit.label : audit.status === 'missing' ? 'none' : 'unknown';
+  const key =
+    audit.status === 'ok'
+      ? audit.label
+      : audit.status === 'missing'
+        ? 'none'
+        : `unknown(${audit.client.keyFingerprint ?? '?'})`;
+  const from = audit.client.ip ? ` ip=${audit.client.ip}` : '';
   const outcome =
     audit.status === 'ok'
       ? 'ok'
       : audit.refused
         ? `${audit.status.toUpperCase()} (refused)`
         : `${audit.status.toUpperCase()} (allowed — observe mode)`;
-  return `[write-auth] ${audit.mode} ${audit.route} key=${key} → ${outcome}`;
+  return `[write-auth] ${audit.mode} ${audit.route} key=${key}${from} → ${outcome}`;
 }

--- a/writeAuth.ts
+++ b/writeAuth.ts
@@ -1,0 +1,245 @@
+/**
+ * Shared-key ("pre-shared key") authorization for the app's privileged endpoints.
+ *
+ * This app is driven by *devices* — the Proclaim Mac, the audio feeder, a couple of
+ * editor browsers/tablets — not by named users, so authorization is a short list of
+ * shared keys rather than logins. Readers need no key at all: viewer traffic
+ * (read-only Y-Sweet tokens, TTS, listener LiveKit tokens) stays deliberately open.
+ *
+ * Rollout has three modes, chosen by `WRITE_AUTH_MODE`:
+ *
+ *   off      No checking, no logging. Local dev, and the automatic mode when no keys
+ *            are configured at all.
+ *   observe  Check and record the outcome, but always allow (the default). This is how
+ *            a key rollout starts: clients ship the key, and a week of logs shows that
+ *            every real device presents a valid one *before* anything can be locked out.
+ *   enforce  Unauthorized privileged requests are refused.
+ *
+ * Keys come from `WRITE_KEYS`, a comma-separated list whose entries are either `key`
+ * or `label:key`. The label is only ever used in logs and telemetry — it answers
+ * "which device is this?", so a rotation can be watched per device rather than as one
+ * anonymous total. Rotating is editing that list and restarting: keys stay valid until
+ * removed, so old and new can overlap while devices are updated one at a time.
+ *
+ * Deliberately dependency-free (no express, no PostHog) so it is trivially testable;
+ * the express glue and the telemetry sink are injected by server.ts.
+ */
+import { createHash, timingSafeEqual } from 'crypto';
+
+export type WriteAuthMode = 'off' | 'observe' | 'enforce';
+
+/** One configured key. `label` is for logging only and is never compared. */
+export interface WriteKeyEntry {
+  label: string;
+  key: string;
+}
+
+/** Why a privileged request was (or would have been) allowed or refused. */
+export type WriteAuthStatus = 'ok' | 'missing' | 'invalid';
+
+export interface WriteAuthResult {
+  status: WriteAuthStatus;
+  /** Label of the matched key, or null when nothing matched. */
+  label: string | null;
+}
+
+/** The audit record emitted for every privileged request, in every non-`off` mode. */
+export interface WriteAuthAudit extends WriteAuthResult {
+  mode: WriteAuthMode;
+  route: string;
+  /** True when the request was actually refused (enforce mode + a bad key). */
+  refused: boolean;
+}
+
+/** Just enough of an express Request to read headers from. */
+export interface HeaderBearingRequest {
+  headers: Record<string, string | string[] | undefined>;
+}
+
+/** Header clients use to present their key. `Authorization: Bearer <key>` also works. */
+export const WRITE_KEY_HEADER = 'x-write-key';
+
+/**
+ * Keys shorter than this are almost certainly a placeholder rather than a real secret.
+ * Warned about at boot, never rejected — refusing to start over a short key would be a
+ * worse failure than running with one.
+ */
+const MIN_REASONABLE_KEY_LENGTH = 16;
+
+/**
+ * Parse `WRITE_KEYS`. Entries are `label:key` or a bare `key`; blanks and entries with
+ * an empty key are dropped, so a trailing comma or a stray `label:` can't silently
+ * install a key that matches the empty string.
+ */
+export function parseWriteKeys(raw: string | undefined): WriteKeyEntry[] {
+  if (!raw) return [];
+  const entries: WriteKeyEntry[] = [];
+  for (const chunk of raw.split(',')) {
+    const trimmed = chunk.trim();
+    if (!trimmed) continue;
+    const separator = trimmed.indexOf(':');
+    const label = separator === -1 ? '' : trimmed.slice(0, separator).trim();
+    const key = separator === -1 ? trimmed : trimmed.slice(separator + 1).trim();
+    if (!key) continue;
+    entries.push({ label: label || `key${entries.length + 1}`, key });
+  }
+  return entries;
+}
+
+export function parseWriteAuthMode(raw: string | undefined): WriteAuthMode {
+  const value = (raw ?? '').trim().toLowerCase();
+  if (!value) return 'observe';
+  if (value === 'off' || value === 'observe' || value === 'enforce') return value;
+  // A typo here (`enfoce`) must never silently degrade to "allow everything", so this
+  // is fatal rather than a warning. Leaving the variable unset is the safe default.
+  throw new Error(
+    `WRITE_AUTH_MODE must be one of off|observe|enforce (got '${raw}')`,
+  );
+}
+
+export interface WriteAuthConfig {
+  mode: WriteAuthMode;
+  keys: WriteKeyEntry[];
+  /** Boot-time lines for the operator: effective mode, key labels, any warnings. */
+  notices: string[];
+}
+
+/**
+ * Resolve the effective configuration from the environment.
+ *
+ * Two safety rules live here. Configuring no keys drops to `off` rather than logging a
+ * miss for every request forever — an install that doesn't use this feature shouldn't
+ * pay for it. Asking for `enforce` with no keys throws, because it would lock out every
+ * device including the Proclaim service; that is a misconfiguration worth failing at
+ * boot for, when it is one env var away from being fixed, rather than mid-service.
+ */
+export function resolveWriteAuthConfig(env: {
+  WRITE_KEYS?: string;
+  WRITE_AUTH_MODE?: string;
+}): WriteAuthConfig {
+  const requestedMode = parseWriteAuthMode(env.WRITE_AUTH_MODE);
+  const keys = parseWriteKeys(env.WRITE_KEYS);
+  const notices: string[] = [];
+
+  if (keys.length === 0) {
+    if (requestedMode === 'enforce') {
+      throw new Error(
+        'WRITE_AUTH_MODE=enforce requires at least one key in WRITE_KEYS; ' +
+          'starting would refuse every editor, the Proclaim service and the audio feeder.',
+      );
+    }
+    notices.push('[write-auth] no WRITE_KEYS configured — write authorization is off');
+    return { mode: 'off', keys, notices };
+  }
+
+  const short = keys.filter((entry) => entry.key.length < MIN_REASONABLE_KEY_LENGTH);
+  if (short.length > 0) {
+    notices.push(
+      `[write-auth] WARNING: short key(s) [${short.map((e) => e.label).join(', ')}] — ` +
+        `use at least ${MIN_REASONABLE_KEY_LENGTH} random characters`,
+    );
+  }
+  notices.push(
+    `[write-auth] mode=${requestedMode} keys=[${keys.map((e) => e.label).join(', ')}]`,
+  );
+  if (requestedMode === 'observe') {
+    notices.push(
+      '[write-auth] observe mode: unauthorized writes are RECORDED BUT ALLOWED. ' +
+        'Set WRITE_AUTH_MODE=enforce once the logs show every device presenting a key.',
+    );
+  }
+  return { mode: requestedMode, keys, notices };
+}
+
+/**
+ * Constant-time key comparison. Compares SHA-256 digests rather than the raw strings so
+ * that both sides are always the same length — `timingSafeEqual` throws on a length
+ * mismatch, and returning early on one would leak the key's length.
+ */
+function keysMatch(presented: string, configured: string): boolean {
+  const a = createHash('sha256').update(presented, 'utf8').digest();
+  const b = createHash('sha256').update(configured, 'utf8').digest();
+  return timingSafeEqual(a, b);
+}
+
+/** Pull the presented key from `X-Write-Key`, or from `Authorization: Bearer <key>`. */
+export function extractPresentedKey(req: HeaderBearingRequest): string | null {
+  const header = req.headers[WRITE_KEY_HEADER];
+  const direct = Array.isArray(header) ? header[0] : header;
+  if (direct && direct.trim()) return direct.trim();
+
+  const authHeader = req.headers['authorization'];
+  const auth = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+  if (auth) {
+    const match = /^Bearer\s+(.+)$/i.exec(auth.trim());
+    if (match && match[1].trim()) return match[1].trim();
+  }
+  return null;
+}
+
+export class WriteAuth {
+  readonly mode: WriteAuthMode;
+  private readonly keys: WriteKeyEntry[];
+  private readonly onAudit: (audit: WriteAuthAudit) => void;
+
+  constructor(config: WriteAuthConfig, onAudit: (audit: WriteAuthAudit) => void = () => {}) {
+    this.mode = config.mode;
+    this.keys = config.keys;
+    this.onAudit = onAudit;
+  }
+
+  /** Does this request carry a valid key? No logging, no side effects. */
+  evaluate(req: HeaderBearingRequest): WriteAuthResult {
+    const presented = extractPresentedKey(req);
+    if (!presented) return { status: 'missing', label: null };
+    for (const entry of this.keys) {
+      if (keysMatch(presented, entry.key)) return { status: 'ok', label: entry.label };
+    }
+    return { status: 'invalid', label: null };
+  }
+
+  /**
+   * Evaluate a privileged request, record the outcome, and report whether it may
+   * proceed. In `observe` mode `allowed` is always true — that is the whole point of
+   * the mode — but the audit record still says what `enforce` would have done.
+   */
+  check(req: HeaderBearingRequest, route: string): { result: WriteAuthResult; allowed: boolean } {
+    if (this.mode === 'off') {
+      return { result: { status: 'ok', label: null }, allowed: true };
+    }
+    const result = this.evaluate(req);
+    const allowed = this.mode !== 'enforce' || result.status === 'ok';
+    this.onAudit({ ...result, mode: this.mode, route, refused: !allowed });
+    return { result, allowed };
+  }
+
+  /**
+   * `check()`, plus a 401 when the request is refused. Returns true if the caller
+   * should continue handling the request.
+   */
+  gate(
+    req: HeaderBearingRequest,
+    res: { status(code: number): { json(body: unknown): unknown } },
+    route: string,
+  ): boolean {
+    const { allowed } = this.check(req, route);
+    if (allowed) return true;
+    res.status(401).json({
+      ok: false,
+      error: 'This request needs a valid write key. See docs/WRITE_KEYS.md.',
+    });
+    return false;
+  }
+}
+
+/** Render an audit record as a single greppable log line. */
+export function formatAudit(audit: WriteAuthAudit): string {
+  const key = audit.status === 'ok' ? audit.label : audit.status === 'missing' ? 'none' : 'unknown';
+  const outcome =
+    audit.status === 'ok'
+      ? 'ok'
+      : audit.refused
+        ? `${audit.status.toUpperCase()} (refused)`
+        : `${audit.status.toUpperCase()} (allowed — observe mode)`;
+  return `[write-auth] ${audit.mode} ${audit.route} key=${key} → ${outcome}`;
+}

--- a/writeAuthRoutes.test.ts
+++ b/writeAuthRoutes.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Wiring tests for write authorization: a real express app, real routing, the real
+ * WriteAuth, driven over a real socket.
+ *
+ * The unit tests in writeAuth.test.ts prove the policy. These prove the two things the
+ * policy is *for*, which no amount of unit testing the helper can establish: that an
+ * editor without a key is quietly downgraded rather than refused, and that a stranger
+ * cannot take the microphone.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { WriteAuth, resolveWriteAuthConfig } from './writeAuth.ts';
+import { makeOrganizerGate, makeYsAuthHandler } from './writeAuthRoutes.ts';
+
+const GOOD_KEY = '0123456789abcdef0123';
+const STALE_KEY = 'last-months-booth-key';
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map((server) => new Promise((resolve) => server.close(resolve))),
+  );
+});
+
+/** Start `app` on an ephemeral port and return its base URL. */
+async function serve(app: express.Express): Promise<string> {
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, '127.0.0.1', () => resolve(s));
+  });
+  servers.push(server);
+  return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+function authFor(mode: 'observe' | 'enforce'): WriteAuth {
+  return new WriteAuth(
+    resolveWriteAuthConfig({ WRITE_KEYS: `booth:${GOOD_KEY}`, WRITE_AUTH_MODE: mode }),
+  );
+}
+
+/** The real /api/ys-auth route, with only Y-Sweet itself faked out. */
+async function ysAuthApp(mode: 'observe' | 'enforce') {
+  const app = express();
+  app.use(express.json());
+  app.post(
+    '/api/ys-auth',
+    makeYsAuthHandler({
+      writeAuth: authFor(mode),
+      // Stand in for Y-Sweet, but echo the level back so a test can prove the token was
+      // actually minted at the level the headers claim.
+      issueToken: (docId, authorization) => Promise.resolve({ docId, authorization }),
+    }),
+  );
+  return serve(app);
+}
+
+async function askForToken(base: string, body: unknown, key?: string) {
+  const response = await fetch(`${base}/api/ys-auth`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(key ? { 'X-Write-Key': key } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  return {
+    status: response.status,
+    granted: response.headers.get('X-Granted-Authorization'),
+    keyStatus: response.headers.get('X-Write-Key-Status'),
+    body: (await response.json()) as { authorization?: string },
+  };
+}
+
+describe('/api/ys-auth', () => {
+  it('gives an editor with a valid key a full token', async () => {
+    const base = await ysAuthApp('enforce');
+    const result = await askForToken(base, { docId: 'doc-1', isEditor: true }, GOOD_KEY);
+
+    expect(result.status).toBe(200);
+    expect(result.granted).toBe('full');
+    expect(result.keyStatus).toBe('ok');
+    expect(result.body.authorization).toBe('full');
+  });
+
+  it('downgrades an unrecognized editor instead of refusing them', async () => {
+    // The whole point of the downgrade: a device with a stale key shows the session
+    // read-only mid-service rather than a blank page.
+    const base = await ysAuthApp('enforce');
+    const result = await askForToken(base, { docId: 'doc-1', isEditor: true }, STALE_KEY);
+
+    expect(result.status).toBe(200);
+    expect(result.granted).toBe('read-only');
+    expect(result.keyStatus).toBe('invalid');
+    expect(result.body.authorization).toBe('read-only');
+  });
+
+  it('downgrades an editor presenting no key at all', async () => {
+    const base = await ysAuthApp('enforce');
+    const result = await askForToken(base, { docId: 'doc-1', isEditor: true });
+
+    expect(result.granted).toBe('read-only');
+    expect(result.keyStatus).toBe('missing');
+  });
+
+  it('lets a viewer in with no key, and never evaluates one', async () => {
+    const base = await ysAuthApp('enforce');
+    const result = await askForToken(base, { docId: 'doc-1', isEditor: false });
+
+    expect(result.status).toBe(200);
+    expect(result.granted).toBe('read-only');
+    // Absent, not 'ok': a viewer request is not checked, so there is nothing to report.
+    expect(result.keyStatus).toBeNull();
+  });
+
+  it('still grants full access in observe mode, but says the key was not recognized', async () => {
+    // This is the header that makes provisioning possible during the rollout: nothing is
+    // refused, so `granted` alone can never reveal that a device is on a stale key.
+    const base = await ysAuthApp('observe');
+    const result = await askForToken(base, { docId: 'doc-1', isEditor: true }, STALE_KEY);
+
+    expect(result.granted).toBe('full');
+    expect(result.keyStatus).toBe('invalid');
+  });
+});
+
+/** The real organizer gate, in front of a handler that just reports it was reached. */
+async function livekitApp(mode: 'observe' | 'enforce') {
+  const app = express();
+  app.use(express.json());
+  app.post('/api/livekit/token', makeOrganizerGate(authFor(mode)), (req, res) => {
+    res.json({ issued: true, role: req.body?.role ?? 'attendee' });
+  });
+  return serve(app);
+}
+
+async function askForMicrophone(base: string, body: unknown, key?: string) {
+  const response = await fetch(`${base}/api/livekit/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(key ? { 'X-Write-Key': key } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  return { status: response.status, body: (await response.json()) as { issued?: boolean } };
+}
+
+describe('/api/livekit/token organizer gate', () => {
+  it('refuses the microphone to a request with no key', async () => {
+    const base = await livekitApp('enforce');
+    const result = await askForMicrophone(base, { room: 'doc-1', role: 'organizer' });
+
+    expect(result.status).toBe(401);
+    expect(result.body.issued).toBeUndefined();
+  });
+
+  it('refuses the microphone to a stale key', async () => {
+    const base = await livekitApp('enforce');
+    const result = await askForMicrophone(
+      base,
+      { room: 'doc-1', role: 'organizer' },
+      STALE_KEY,
+    );
+    expect(result.status).toBe(401);
+  });
+
+  it('hands the microphone to a valid key', async () => {
+    const base = await livekitApp('enforce');
+    const result = await askForMicrophone(
+      base,
+      { room: 'doc-1', role: 'organizer' },
+      GOOD_KEY,
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body.issued).toBe(true);
+  });
+
+  it('lets listeners through untouched — viewers must never need a key', async () => {
+    const base = await livekitApp('enforce');
+
+    for (const body of [
+      { room: 'doc-1', role: 'attendee' },
+      { room: 'doc-1' }, // role omitted entirely
+    ]) {
+      const result = await askForMicrophone(base, body);
+      expect(result.status).toBe(200);
+      expect(result.body.issued).toBe(true);
+    }
+  });
+
+  it('hands over the microphone in observe mode even unauthorized, as designed', async () => {
+    const base = await livekitApp('observe');
+    const result = await askForMicrophone(base, { room: 'doc-1', role: 'organizer' });
+
+    expect(result.status).toBe(200);
+    expect(result.body.issued).toBe(true);
+  });
+});

--- a/writeAuthRoutes.ts
+++ b/writeAuthRoutes.ts
@@ -1,0 +1,79 @@
+/**
+ * Express glue for write authorization: the two routes where a key changes *what* a
+ * request gets, rather than simply whether it succeeds.
+ *
+ * They live here rather than inline in server.ts because that module cannot be imported
+ * by a test — it reads half a dozen required env vars and stands up Y-Sweet, LiveKit and
+ * PostHog at import time. These two behaviors are the ones that would ruin a service if
+ * they regressed (an editor silently losing the ability to edit; a stranger taking the
+ * microphone), so they need to be drivable against a bare express app.
+ */
+import type { RequestHandler } from 'express';
+import type { WriteAuth } from './writeAuth.ts';
+
+export type GrantedAuthorization = 'full' | 'read-only';
+
+/** What the caller actually got. Read by src/App.tsx. */
+export const GRANTED_AUTHORIZATION_HEADER = 'X-Granted-Authorization';
+/** Why the key was or wasn't accepted — a different question. Read by src/App.tsx. */
+export const WRITE_KEY_STATUS_HEADER = 'X-Write-Key-Status';
+
+export interface YsAuthDeps {
+  writeAuth: WriteAuth;
+  /** Mint a Y-Sweet client token at the given authorization level. */
+  issueToken: (docId: string | null, authorization: GrantedAuthorization) => Promise<unknown>;
+  log?: (message: string) => void;
+}
+
+/**
+ * Y-Sweet token issuance.
+ *
+ * Read-only tokens are unconditional — anyone may watch a session. A *full* token is the
+ * app's real write boundary (the browser talks to Y-Sweet directly with it), so asking
+ * for one is what requires a key.
+ *
+ * An unauthorized editor request is downgraded to read-only rather than refused: a device
+ * with a stale key then shows the session as a viewer instead of a blank page, which is
+ * the failure anyone would rather have mid-service.
+ */
+export function makeYsAuthHandler({
+  writeAuth,
+  issueToken,
+  log = () => {},
+}: YsAuthDeps): RequestHandler {
+  return async (req, res) => {
+    const docId = (req.body?.docId as string | undefined) ?? null;
+    const wantsEditor = req.body?.isEditor ?? false;
+    // Only editor requests are evaluated, and so only they are audited: a viewer needs no
+    // key, and checking one anyway would put an audit record on every page load of every
+    // screen in the session.
+    const check = wantsEditor ? writeAuth.check(req, '/api/ys-auth') : null;
+    const authorization: GrantedAuthorization = check?.allowed ? 'full' : 'read-only';
+    log(`Auth request: doc=${docId} isEditor=${wantsEditor} granted=${authorization}`);
+    const clientToken = await issueToken(docId, authorization);
+    res.setHeader(GRANTED_AUTHORIZATION_HEADER, authorization);
+    // In observe mode nothing is refused, so `granted` is always `full` and this header
+    // is the only way a device can discover it is holding a stale key — during the
+    // observe window, which is exactly when that is still cheap to fix.
+    if (check) res.setHeader(WRITE_KEY_STATUS_HEADER, check.result.status);
+    res.send(clientToken);
+  };
+}
+
+/**
+ * Gate the broadcaster's microphone, and only the microphone.
+ *
+ * An organizer token is the microphone. Its holder can speak into the room and — because
+ * every broadcaster joins under the same `organizer-host` identity, which LiveKit
+ * resolves by evicting the incumbent — can silently cut off whoever is currently
+ * speaking. Listeners ask for no such thing and need no key.
+ */
+export function makeOrganizerGate(
+  writeAuth: WriteAuth,
+  route = '/api/livekit/token',
+): RequestHandler {
+  return (req, res, next) => {
+    if ((req.body?.role as string | undefined) !== 'organizer') return next();
+    if (writeAuth.gate(req, res, route)) next();
+  };
+}

--- a/write_key.py
+++ b/write_key.py
@@ -1,0 +1,35 @@
+"""Presenting this service's shared write key to the live-notes server.
+
+The server authorizes *devices* rather than users (see ``writeAuth.ts``): a short list of
+shared keys, one of which belongs to this Proclaim machine. The key is read from
+``PROCLAIM_WRITE_KEY`` — set by the installer into the LaunchAgent plist — and attached to
+the two privileged calls this service makes: asking for a full Y-Sweet token, and asking
+the server to translate an item.
+
+Deliberately tolerant of an unset key: during the rollout the server runs in ``observe``
+mode, where a missing key is recorded and allowed, and a service that refused to start
+without one would be a worse outage than the problem it guards against.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional
+
+#: Must match WRITE_KEY_HEADER in writeAuth.ts.
+WRITE_KEY_HEADER = "X-Write-Key"
+
+ENV_VAR = "PROCLAIM_WRITE_KEY"
+
+
+def get_write_key(env: Optional[Dict[str, str]] = None) -> Optional[str]:
+    """The configured write key, or None when unset/blank."""
+    raw = (env if env is not None else os.environ).get(ENV_VAR, "")
+    return raw.strip() or None
+
+
+def write_key_headers(write_key: Optional[str]) -> Dict[str, str]:
+    """Headers presenting ``write_key``, or an empty dict when there is none."""
+    if not write_key or not write_key.strip():
+        return {}
+    return {WRITE_KEY_HEADER: write_key.strip()}


### PR DESCRIPTION
Reading a session stays open to anyone. **Writing** — editing the notes, taking the microphone, and the endpoints that spend money on models and TTS — is now gated on a shared per-device key. Devices, not users: no accounts, no logins; each device (booth laptop, tablet, Proclaim Mac, audio feeder) is given a key once and keeps it.

**Blast radius: §1, §3, §4, §5, and a new §6 (write keys).** Everything is wired up but nothing is enforced by default, so the practical radius this week is "clients now send a header."

## Why

Two holes motivated this, both one `curl` away:

- **`POST /api/ys-auth`** handed a *full* Y-Sweet token to anyone posting `isEditor: true` — one URL fragment away in the browser. That token is the app's real write boundary, since the browser talks to Y-Sweet directly with it.
- **`POST /api/livekit/token`** granted publish rights to anyone asking for `role: organizer`. Because every broadcaster shares the `organizer-host` identity and LiveKit evicts on duplicate identity, a stranger doesn't just join — they cut off the speaker mid-service.

Plus a softer tier that spends money for anyone who finds the host: `/api/translateItem`, `/api/slideConversation/*`, `/api/requestTranslatedBlocks`, and `POST /api/slideLibrary` (which writes to disk).

## This week: wired on the clients, not enforced on the server

`WRITE_AUTH_MODE` has three settings, defaulting to **`observe`**: every privileged request is checked, logged, and mirrored to PostHog as `write_auth_check`, then **allowed regardless**.

```
[write-auth] observe /api/ys-auth key=proclaim → ok
[write-auth] observe /api/livekit/token key=none → MISSING (allowed — observe mode)
```

So the clients can ship now, and a week of logs answers "does every real device present a valid key?" before anything can be locked out. Flipping to `enforce` is then one env var and a restart.

Two safety rules: configuring no keys disables the feature entirely (an install that doesn't use it pays nothing), and asking for `enforce` with no keys **refuses to boot** rather than starting up having locked out every device including Proclaim.

## Graceful degradation under enforce

An unauthorized editor request is **downgraded to a read-only token, not refused** — a device with a stale key shows the session read-only instead of a blank page mid-service. The granted level comes back in an `X-Granted-Authorization` header; the UI then clears `isEditorAtom` (so every existing `isEditor`-gated control degrades on its own) and shows a dismissible banner. The microphone still gets a plain 401, where `BroadcastControl` already has a visible error state.

## Keys and rotation

`WRITE_KEYS=proclaim:kZ8x…,booth:9fQ2…,tablet:Lm4v…` — a list, so rotation overlaps: add the new key, move devices one at a time, remove the old entry. Labels appear only in logs, so "has the tablet been provisioned?" is a chart rather than a grep. Comparison is constant-time over SHA-256 digests, so neither the key nor its length leaks through timing.

## How each device gets its key

| Device | Provisioning |
|---|---|
| Browser | Open once with `#editor&key=THEKEY`; stored in `localStorage`, stripped from the address bar immediately. `?key=` also works but the fragment never reaches an access log. |
| Proclaim service | `install_proclaim_service.sh --write-key=THEKEY` → `PROCLAIM_WRITE_KEY` in the plist. Reinstalling without the flag keeps the installed key. Never fetched from `/api/config`, which is public. |
| Audio feeder | Settings → Server → Write key. |

All three send `X-Write-Key`; `Authorization: Bearer` is also accepted.

## Deliberately not covered

`/api/tts` and `/api/livekit/translate` are called by **viewers** by design, so they cannot require an editor's key. They stay unauthenticated and still cost money — rate limiting is the answer there and isn't built yet. Same for `/api/session/export`, which will still export any doc id. Written down in `docs/WRITE_KEYS.md` rather than left implicit, along with what this design is and isn't (shared keys, no per-user control, no audit trail beyond a label).

## Testing

- `writeAuth.test.ts` — 30 tests: key-list parsing, mode resolution and the boot guards, header extraction, constant-time matching (no prefix/suffix/case matches), observe-vs-enforce decisions, the 401 shape, log formatting.
- `src/writeKey.test.ts` — 16 tests: capture from fragment and query, `#editor` surviving the strip, persistence across reload, `localStorage` failure fallback, header injection.
- `tests/test_write_key.py` — 9 tests: header helpers, and both privileged Python calls asserting the header with and without a key (plus that the doc/editor contract is unchanged).
- Full suites green: 354 vitest, 93 pytest, `tsc -b` and `eslint` clean.
- Verified the express wiring end-to-end against a real express app in both modes — confirmed observe allows all three key states while auditing them, enforce 401s the bad ones, viewers are never gated, and the editor downgrade returns `read-only` rather than an error.

**Not verified:** the Swift feeder changes don't compile here (no Swift toolchain in this environment). `LiveKitTokenClient` was refactored to expose `makeRequest`, and three tests were added asserting the header is present when configured, absent when blank, and that the existing room/identity/role body is untouched — but they need a `swift test` run on a Mac.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xv7dvyiUwZMp2FLvYXfCjt)_