### PR TITLE
Make the audio feeder say what it will do: weekday state, publish mode, and the map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This is a **live translation application** for presentations/talks. It provides 
 - **Frontend**: React + TypeScript + Vite + Tailwind CSS
 - **Backend**: Express server
 - **Live speech translation**: LiveKit rooms + Gemini Live ([live-audio/](live-audio/)) — a broadcaster publishes mic audio; per-language translator bots stream it through Gemini Live and publish translated audio + live transcripts
+- **macOS Audio Feeder** ([macos-audio-feeder/](macos-audio-feeder/)): a **native Swift/SwiftUI menu-bar app** — the only non-web, non-Python component in the repo. It takes one channel off the sound board and publishes it to the LiveKit room on a schedule, as an unattended alternative to the browser broadcast page. Built and tested with `swift test` / Xcode, **not** `npm test`
 
 **Start with [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** for the component map (what runs where, who writes what into the shared Yjs doc). [docs/README.md](docs/README.md) is the docs index; [docs/SMOKE_TEST.md](docs/SMOKE_TEST.md) is the manual pre-service smoke checklist — PR descriptions should declare which of its sections they touch.
 
@@ -92,6 +93,30 @@ npm start
 - Always run `npm install` before building or testing, especially in fresh environments. The build will fail with module resolution errors if dependencies aren't installed.
 - When running tests via tools/agents, use `--no-color` flag to disable ANSI color codes in output.
 - The root `tsconfig.json` is a solution-style config (`files: []` + `references`), so plain `tsc --noEmit -p .` silently checks nothing. Use `npm run typecheck` (or `tsc -b`) to actually type-check.
+
+### Swift (macOS Audio Feeder)
+
+[macos-audio-feeder/](macos-audio-feeder/) is a native macOS menu-bar app. **Nothing in the
+npm or uv toolchain touches it** — searching only `*.ts`/`*.tsx`/`*.py` will miss it entirely.
+
+```bash
+cd macos-audio-feeder
+swift test                 # AudioFeederCore: pure logic, fast, no Xcode needed
+xcodegen generate          # regenerate AudioFeeder.xcodeproj (source list is captured here,
+                           # so re-run after ADDING or REMOVING files)
+xcodebuild -project AudioFeeder.xcodeproj -scheme AudioFeederApp build
+```
+
+The split is deliberate: `AudioFeederCore` holds pure, dependency-free logic (schedule
+decisions, config, level metering, channel extraction, the LiveKit token contract) so it is
+covered by `swift test`; `AudioFeederApp` holds everything needing CoreAudio/LiveKit/SwiftUI.
+**Put new decision logic in the Core and test it there** — the app half has no test target.
+The `.xcodeproj` is generated from `project.yml` and not checked in; that YAML is the
+reviewable source of truth.
+
+Read [macos-audio-feeder/NOTEBOOK.md](macos-audio-feeder/NOTEBOOK.md) before touching
+packaging, entitlements, or connect/retry logic — it records failures that cost a service
+(the App Sandbox blocking WebRTC's UDP sockets, silent disconnects) and the rules they earned.
 
 ### Python (Proclaim service)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,10 +10,10 @@ derived data) drives the testing/replay strategy.
  sound booth / stage                      server (docker compose)              external SaaS
 ┌────────────────────┐                  ┌──────────────────────────┐
 │ Broadcaster        │── mic (WebRTC) ─▶│ LiveKit room             │
-│ (BroadcastControl, │                  │   ▲            │         │
-│  future macOS      │                  │   │ translated │ source  │
-│  ingest service)   │                  │   │ audio      ▼ audio   │
-└────────────────────┘                  │ translation-bridge ──────┼──▶ Gemini Live
+│ (BroadcastControl  │                  │   ▲            │         │
+│  in a browser, OR  │                  │   │ translated │ source  │
+│  the macOS Audio   │                  │   │ audio      ▼ audio   │
+│  Feeder app)       │                  │ translation-bridge ──────┼──▶ Gemini Live
 ┌────────────────────┐                  │  (per language, spawned  │    (translate speech)
 │ Proclaim Mac       │                  │   on listener demand by  │
 │ proclaim_service.py│─┐                │   translation-session-   │
@@ -49,6 +49,18 @@ derived data) drives the testing/replay strategy.
   That threshold is the feature's only switch: unset, it is −Infinity, every frame reads as
   voice, and nothing can suspend. It affects only what a bridge does while nobody speaks —
   *which* bridges exist is decided independently (see the supervisor below).
+- **macOS Audio Feeder** (`macos-audio-feeder/`): a native menu-bar app (Swift/SwiftUI) that
+  takes one channel off the sound board and publishes it to the LiveKit room on a schedule, so
+  a service doesn't depend on someone opening the browser broadcast page. It joins as the
+  *same* identity that page uses (`organizer-host`), and LiveKit permits one participant per
+  identity, so **the app and the browser page are mutually exclusive** — whichever connects
+  last evicts the other (handled deliberately: `DisconnectPolicy`). Split into
+  `AudioFeederCore` (pure logic — schedule, config, levels, channel extraction, token
+  contract; `swift test`, no Xcode) and `AudioFeederApp` (CoreAudio capture, LiveKit publish,
+  UI; built by an XcodeGen-generated project). Publishing spends the room's microphone, so it
+  carries a write key like everything else. Its own `README.md` covers operation and
+  `NOTEBOOK.md` records why it looks the way it does — read the notebook before changing
+  packaging, entitlements, or the connect/retry logic.
 - **proclaim_service.py**: polls Proclaim's local HTTP API (~1 s) and reads its SQLite DB,
   pushes presentations + slide status into Yjs. Internally decoupled into a **slide feed**
   (`ProclaimFeed`, the source) and **consumers** (a Yjs publisher + a translation worker),

--- a/macos-audio-feeder/NOTEBOOK.md
+++ b/macos-audio-feeder/NOTEBOOK.md
@@ -57,6 +57,13 @@ second, drifting opinion about the schedule.
 Anything the operator has to read at the booth gets a shape or a glyph, and anything that
 decides whether we go on air gets a sentence.
 
+**The same sentence went into the menu-bar popover**, which had the identical gap one level
+up: it said what the feeder was doing *now* ("Idle") and never whether anything would change
+that. An install with the schedule switched off sits at "Idle" indefinitely and looks exactly
+like one that is five minutes from going live. It turns orange only when the schedule is both
+inert *and* in charge — under a manual override the schedule isn't governing, and the override
+has its own controls two lines below.
+
 > **Not verified on a machine.** No Swift toolchain in the environment this was written in —
 > no build, no `swift test`, no run. The logic changes are pure and unit-tested *as written*;
 > the SwiftUI is plain, version-agnostic API (`buttonStyle(.plain)`, `background`, `overlay`,

--- a/macos-audio-feeder/NOTEBOOK.md
+++ b/macos-audio-feeder/NOTEBOOK.md
@@ -97,11 +97,41 @@ value is indistinguishable from a label holding a value — nothing said "you ca
 `.textFieldStyle(.roundedBorder)` on the `Form`. Same disease as the weekday chips, third
 instance in one screen: **state and affordance both have to be drawn, not implied.**
 
-**Verified.** `swift test` (45 tests) and `xcodebuild build` both clean on macOS 26 / Swift
-6.3.3, and the settings window was driven by hand: chips toggle visibly, the summary tracks.
-The popover's new mode picker is compiled and tested but **not yet clicked** — nobody launched
-the app to work it, because launching a second feeder takes the room's microphone from
-whoever has it. Work it once before the next service.
+### The picker's first click found a real one: publishing from inside a view update
+
+Clicking **Schedule** logged *"Publishing changes from within view updates is not allowed,
+this will cause undefined behavior."*
+
+`AppController.config` is `@Published` with a `didSet` that runs `evaluate()` **synchronously**,
+and `evaluate()` writes other `@Published` properties (`status`, `devices`, `standDown`). So
+any binding write to `config` mutates observable state; if that write happens inside SwiftUI's
+update pass, this is exactly the warning. A `Picker` writes its selection *during* that pass —
+a `Button`'s action closure does not, which is the only reason the three buttons this replaced
+never tripped it. **The defect was latent for every text field, toggle and stepper in the
+settings window**; the picker just made it fire.
+
+Fixed in two places, because two different mutations were in play:
+
+- `configChanged()` now defers `evaluate()` one runloop turn (`scheduleEvaluate()`, coalesced
+  with a pending flag). This covers every control that writes `config` — and incidentally
+  fixes the "full synchronous CoreAudio enumeration on every keystroke" noted under
+  2026-07-27, since a burst of edits now collapses into one evaluation.
+- The mode binding hops before calling `followSchedule()`/`startNow()`/`stopNow()`, since
+  those also write `standDown` directly, before any `config` mutation.
+
+**Worth keeping in view:** `Task { @MainActor in }` here is a *correctness* requirement, not
+style. Anything that mutates controller state from a `Binding` setter needs the same hop.
+
+**Verified.** `swift test` (45 tests) and `xcodebuild build` clean on macOS 26 / Swift 6.3.3;
+settings window driven by hand (chips toggle visibly, summary tracks). The popover **could not
+be driven from a script** — three attempts to open it via System Events (`click` and `AXPress`
+on the status item) reported success and opened nothing, because `NSStatusItem` + `NSPopover`
+wants a real mouse event. So the runtime warning's *absence* after this fix is reasoned, not
+observed: re-click the segments in Xcode to confirm. An honest note, per the rule above about
+first runs.
+
+**Unrelated observation from that launch, recorded because it may matter:** the app logged
+`5 input device(s)` on a MacBook Pro with no external audio hardware attached.
 
 ---
 

--- a/macos-audio-feeder/NOTEBOOK.md
+++ b/macos-audio-feeder/NOTEBOOK.md
@@ -38,7 +38,7 @@ was there in the config the whole time; the UI just never committed to showing i
 
   | Configuration | Chip row shows | Summary says |
   |---|---|---|
-  | `enabled == false` | a full week of chips | Schedule off — the feeder runs only when you press Start now. |
+  | `enabled == false` | a full week of chips | Schedule off — nothing will start the feeder on its own. |
   | `days.isEmpty` | nothing selected | No days selected — the schedule will never start the feeder. |
   | `startMinute == stopMinute` | a full week of chips | Start and stop are the same time — the schedule will never start the feeder. |
 
@@ -60,15 +60,48 @@ decides whether we go on air gets a sentence.
 **The same sentence went into the menu-bar popover**, which had the identical gap one level
 up: it said what the feeder was doing *now* ("Idle") and never whether anything would change
 that. An install with the schedule switched off sits at "Idle" indefinitely and looks exactly
-like one that is five minutes from going live. It turns orange only when the schedule is both
-inert *and* in charge — under a manual override the schedule isn't governing, and the override
-has its own controls two lines below.
+like one that is five minutes from going live.
 
-> **Not verified on a machine.** No Swift toolchain in the environment this was written in —
-> no build, no `swift test`, no run. The logic changes are pure and unit-tested *as written*;
-> the SwiftUI is plain, version-agnostic API (`buttonStyle(.plain)`, `background`, `overlay`,
-> `help`, the `accessibility*` modifiers), but per this notebook's own rule, look at the
-> settings window once before the next service.
+### Then the same bug turned out to be in the popover's controls (same day, on review)
+
+First run on a real Mac produced the right question: *what does "Follow schedule" do, and why
+is it separate from the "Enable schedule" checkbox?*
+
+It's a fair question because the UI never answered it. There are two switches, and the
+popover's three buttons hid which one they were:
+
+| | Where | Decides |
+|---|---|---|
+| **When to publish** (`manualOverride`) | popover | whether the schedule is consulted **at all** |
+| **Enable schedule** + days + times | settings | what "Schedule" mode *does* |
+
+The mode is the **outer** switch, and "Follow schedule" read like a sibling of "Enable
+schedule" instead — same words, opposite level. Worse, the mode was never displayed: you
+inferred it from which of `Start now` / `Stop now` was greyed out, and `Follow schedule`
+appeared *only* while an override was active, so the state you were in was the one thing the
+control couldn't show you. That is the exact defect this entry started with, one level up.
+
+Replaced by a segmented **When to publish**: `Schedule | Always on | Always off`. The
+selection *is* the state, there are visibly exactly three of them, and the sentence beneath
+now describes the effective mode (`FeederConfig.modeSummary`), not just the schedule — because
+"Runs Sun, 10:00–12:00" is actively misleading while the mode is *Always off*. It routes
+through the controller's existing `startNow()` / `stopNow()` / `followSchedule()` rather than
+writing `manualOverride`, since two of those also clear a stand-down.
+
+`FeederConfig.willStartUnattended` answers the question neither control answers alone — *will
+anything start this without a person?* — and it is what colours the line orange. For a feeder
+whose whole job is running unattended, that's the sentence worth having.
+
+**Also:** on macOS 26 the grouped-form text fields have no visible bezel, so a field holding a
+value is indistinguishable from a label holding a value — nothing said "you can type here".
+`.textFieldStyle(.roundedBorder)` on the `Form`. Same disease as the weekday chips, third
+instance in one screen: **state and affordance both have to be drawn, not implied.**
+
+**Verified.** `swift test` (45 tests) and `xcodebuild build` both clean on macOS 26 / Swift
+6.3.3, and the settings window was driven by hand: chips toggle visibly, the summary tracks.
+The popover's new mode picker is compiled and tested but **not yet clicked** — nobody launched
+the app to work it, because launching a second feeder takes the room's microphone from
+whoever has it. Work it once before the next service.
 
 ---
 
@@ -303,7 +336,8 @@ home is a real signal.
    `com.apple.security.network.server` must be present.
 4. Launch it, grant the microphone prompt, pick the board and channel.
 5. With `log stream --predicate 'subsystem == "org.kenarnold.audio-feeder"' --style compact`
-   running, hit **Start now** and watch for, in order: `starting pipeline`, an input format
+   running, set **When to publish** to *Always on* (this step said "hit Start now" before the
+   2026-08-05 entry replaced those buttons) and watch for, in order: `starting pipeline`, an input format
    with a plausible sample rate and channel count, `token OK`, `room connected`,
    `publishing as organizer-host`.
 6. Join the session in a browser and confirm you can hear the board.

--- a/macos-audio-feeder/NOTEBOOK.md
+++ b/macos-audio-feeder/NOTEBOOK.md
@@ -10,6 +10,61 @@ cause, the fix.
 
 ---
 
+## 2026-08-05 — the weekday chips were invisible state
+
+**Symptom.** On an older macOS, clicking a day in **Settings → Schedule** changed nothing on
+screen. On a newer one it did highlight, but you still couldn't tell which appearance meant
+"the feeder will run this day" — nor, from that row, whether it would run at all.
+
+**Cause.** The row was seven `Button`s styled `.bordered` and differentiated *only* by
+`.tint(on ? .accentColor : .gray)`. `tint` is a **hint**: AppKit's bordered push button is
+free to ignore it, and older systems do exactly that, so both states rendered as the same
+grey push button. Where it is honoured, the difference is accent-tinted vs grey-tinted — a
+colour difference with no shape, no glyph and no label saying which one is "on". The state
+was there in the config the whole time; the UI just never committed to showing it.
+
+**Fix, two halves.**
+
+- **Draw the state ourselves.** `WeekdayButton` is a `.buttonStyle(.plain)` chip with its own
+  fill, border, weight and glyph: filled accent + checkmark + semibold when scheduled,
+  outlined + dash + regular when skipped. Nothing about it is a hint, so it renders the same
+  on every system we deploy to, and it survives the loss of colour (colour-blind operator,
+  washed-out booth monitor). It also gained a tooltip and proper accessibility label/value —
+  it was previously an unlabelled `Sun` with no selected state exposed at all.
+- **Say the outcome in words.** `Schedule.summary` renders one sentence — *"Runs Sun,
+  10:00–12:00."* — under the times, orange when the schedule can never fire. This is the half
+  that answers the second complaint, because *no* chip appearance can distinguish these three
+  do-nothing configurations, which look identical in the row:
+
+  | Configuration | Chip row shows | Summary says |
+  |---|---|---|
+  | `enabled == false` | a full week of chips | Schedule off — the feeder runs only when you press Start now. |
+  | `days.isEmpty` | nothing selected | No days selected — the schedule will never start the feeder. |
+  | `startMinute == stopMinute` | a full week of chips | Start and stop are the same time — the schedule will never start the feeder. |
+
+  It also spells out the wrapping window (*"Runs Sat, 23:00–01:00 the next day."*), which is
+  the one place `days` doesn't mean "runs on this day" — `Scheduler.isWithinWindow` anchors a
+  wrapping run to its **start** day, so Sunday 00:30 belongs to Saturday's window. Nothing in
+  the UI had ever said so.
+
+**Where it lives.** The sentence is built in `Schedule` (`AudioFeederCore`), not the view, so
+`swift test` covers it with no Xcode and no UI. `ConfigTests` pins each inert case, and
+`testWillEverRunAgreesWithScheduler` sweeps a full week minute-by-minute through the real
+`Scheduler.shouldRun` to prove that "will never start the feeder" is the truth and not a
+second, drifting opinion about the schedule.
+
+**Rule this earns:** if a control's state is only a `tint`, the app has no state on screen.
+Anything the operator has to read at the booth gets a shape or a glyph, and anything that
+decides whether we go on air gets a sentence.
+
+> **Not verified on a machine.** No Swift toolchain in the environment this was written in —
+> no build, no `swift test`, no run. The logic changes are pure and unit-tested *as written*;
+> the SwiftUI is plain, version-agnostic API (`buttonStyle(.plain)`, `background`, `overlay`,
+> `help`, the `accessibility*` modifiers), but per this notebook's own rule, look at the
+> settings window once before the next service.
+
+---
+
 ## 2026-07-30 — the feeder now notices when it stops publishing (#97)
 
 **Symptom.** The app could stop publishing and never find out. The menu bar kept saying

--- a/macos-audio-feeder/NOTEBOOK.md
+++ b/macos-audio-feeder/NOTEBOOK.md
@@ -123,15 +123,24 @@ Fixed in two places, because two different mutations were in play:
 style. Anything that mutates controller state from a `Binding` setter needs the same hop.
 
 **Verified.** `swift test` (45 tests) and `xcodebuild build` clean on macOS 26 / Swift 6.3.3;
-settings window driven by hand (chips toggle visibly, summary tracks). The popover **could not
-be driven from a script** — three attempts to open it via System Events (`click` and `AXPress`
-on the status item) reported success and opened nothing, because `NSStatusItem` + `NSPopover`
-wants a real mouse event. So the runtime warning's *absence* after this fix is reasoned, not
-observed: re-click the segments in Xcode to confirm. An honest note, per the rule above about
-first runs.
+settings window and popover both driven by hand, and the warning is gone after the fix.
 
-**Unrelated observation from that launch, recorded because it may matter:** the app logged
-`5 input device(s)` on a MacBook Pro with no external audio hardware attached.
+Note for whoever automates this later: the popover **cannot be driven from a script** the
+obvious way. Three attempts via System Events (`click` and `AXPress` on the status item)
+reported success and opened nothing — `NSStatusItem` + `NSPopover` wants a real mouse event.
+A human clicked it.
+
+**Still open, separate from all of the above:** the **channel count** reported for the
+built-in microphone grows across repeated start/stop cycles (a 1-channel mic showing 3). Not
+the *device* count — a MacBook with virtual audio drivers installed legitimately enumerates
+several input devices, so `5 input device(s)` in the log is expected and not a symptom.
+Suspects, in order: `AudioCapture` setting `kAudioOutputUnitProperty_CurrentDevice` on the
+shared AUHAL (which binds both input and output scopes — see 2026-07-27), and
+`DeviceMonitor.stopMonitoring()` passing a *different* block to
+`AudioObjectRemovePropertyListenerBlock` than was added, so the listener is never actually
+removed and stale registrations accumulate. That second one is listed under 2026-07-27 as
+"currently harmless — nothing calls it"; a channel count that only grows *after cycling* is
+reason to re-check that assumption rather than trust it.
 
 ---
 

--- a/macos-audio-feeder/README.md
+++ b/macos-audio-feeder/README.md
@@ -89,8 +89,25 @@ selected, and a start time equal to the stop time.
 
 Days are the days the window **starts** on. A window whose stop time is earlier than its start
 time wraps past midnight and finishes the next morning, which the summary spells out
-(*"Runs Sat, 23:00–01:00 the next day."*). Manual **Start now** / **Stop now** always wins over
-whatever the schedule says.
+(*"Runs Sat, 23:00–01:00 the next day."*).
+
+### Schedule vs. the menu bar's "When to publish"
+
+These are two different switches and it's worth being clear which is which:
+
+| Control | Where | What it decides |
+|---|---|---|
+| **When to publish**: Schedule / Always on / Always off | menu-bar popover | Whether the schedule is consulted **at all** |
+| **Enable schedule** + days + times | Settings → Schedule | What "Schedule" mode *does*, when it's selected |
+
+**When to publish** is the outer switch. *Always on* publishes continuously and ignores
+everything in the Schedule section; *Always off* stays down and ignores it too; only
+*Schedule* hands the decision to the settings above. So a perfectly good schedule does nothing
+if the mode is *Always off*, and a completely blank one is irrelevant if the mode is
+*Always on*. The line under the picker always states which of those you're in.
+
+(This replaced three buttons — *Start now* / *Stop now* / *Follow schedule* — that set the same
+three modes without ever showing which one you were in.)
 
 ## Write key
 

--- a/macos-audio-feeder/README.md
+++ b/macos-audio-feeder/README.md
@@ -75,6 +75,23 @@ open AudioFeeder.xcodeproj # then just hit Run
 Re-run `xcodegen generate` after changing `project.yml` (or after adding source files, since
 the file list is captured at generation time).
 
+## Setting the schedule
+
+**Settings → Schedule** picks the days and the daily window. A day chip is **filled, with a
+checkmark**, when the schedule will start the feeder that day; it is **outlined, with a dash**,
+when that day is skipped. (Don't go by colour alone — the row is deliberately readable without
+it, because the old tint-only highlight rendered as no change at all on some macOS versions.)
+
+Under the times, one line states the outcome in words — *"Runs Sun, 10:00–12:00."* — and turns
+orange when the schedule can never start anything. That covers the three configurations that
+look identical in the chip row but do nothing: **Enable schedule** switched off, no days
+selected, and a start time equal to the stop time.
+
+Days are the days the window **starts** on. A window whose stop time is earlier than its start
+time wraps past midnight and finishes the next morning, which the summary spells out
+(*"Runs Sat, 23:00–01:00 the next day."*). Manual **Start now** / **Stop now** always wins over
+whatever the schedule says.
+
 ## Write key
 
 Publishing takes the room's microphone — and because every broadcaster shares the

--- a/macos-audio-feeder/Sources/AudioFeederApp/AppController.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/AppController.swift
@@ -59,6 +59,7 @@ final class AppController: ObservableObject {
     private var retryTimer: Timer?
     private var retryAfter: Date?
     private var retryBackoff: TimeInterval = 2
+    private var evaluatePending = false
 
     init() {
         self.config = store.load()
@@ -133,7 +134,30 @@ final class AppController: ObservableObject {
 
     private func configChanged() {
         store.save(config)
-        evaluate()
+        scheduleEvaluate()
+    }
+
+    /// Re-evaluate on the next runloop turn rather than inside this `didSet`.
+    ///
+    /// `config` is `@Published` and every settings control writes it through a `Binding`, so
+    /// this `didSet` can run **inside SwiftUI's view-update pass** — and `evaluate()` mutates
+    /// other `@Published` state (`status`, `devices`, `standDown`). That combination is what
+    /// "Publishing changes from within view updates is not allowed, this will cause undefined
+    /// behavior" is complaining about. A segmented `Picker` is what finally tripped it (it
+    /// writes its selection during the update pass, where a `Button` action closure would
+    /// not), but the defect was latent for every text field, toggle and stepper in the
+    /// settings window.
+    ///
+    /// Hopping to the next turn also coalesces bursts: every keystroke in the settings window
+    /// is a config mutation, and `evaluate()` does a full synchronous CoreAudio device
+    /// enumeration.
+    private func scheduleEvaluate() {
+        guard !evaluatePending else { return }
+        evaluatePending = true
+        Task { @MainActor in
+            evaluatePending = false
+            evaluate()
+        }
     }
 
     /// Decide whether we should be running and reconcile the capture/publish lifecycle.

--- a/macos-audio-feeder/Sources/AudioFeederApp/ConfigView.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/ConfigView.swift
@@ -12,6 +12,9 @@ struct ConfigView: View {
             Text("Audio Feeder Settings").font(.headline).padding()
             Divider()
             Form {
+                // Recent macOS draws form text fields without a visible bezel, so a field
+                // holding a value looks exactly like a label holding a value — nothing says
+                // "you can type here". `.roundedBorder` puts the box back.
                 Section("Server") {
                     TextField("Server URL", text: $controller.config.serverURL)
                     TextField("Doc id (blank = today's doc-YYYY-MM-DD)",
@@ -58,8 +61,15 @@ struct ConfigView: View {
                         .font(.caption)
                         .foregroundStyle(controller.config.schedule.willEverRun ? Color.secondary : Color.orange)
                         .fixedSize(horizontal: false, vertical: true)
-                    Text("Manual override always wins over the schedule.")
+                    // The two controls people confuse. Say the relationship in the place the
+                    // second one isn't: this checkbox only matters in Schedule mode.
+                    Text("""
+                         The menu bar's “When to publish” decides whether this schedule is \
+                         used at all — it must be set to Schedule. Always on and Always off \
+                         ignore everything above.
+                         """)
                         .font(.caption).foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 Section("Service") {
@@ -72,6 +82,7 @@ struct ConfigView: View {
                 }
             }
             .formStyle(.grouped)
+            .textFieldStyle(.roundedBorder)
 
             Divider()
             HStack {

--- a/macos-audio-feeder/Sources/AudioFeederApp/ConfigView.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/ConfigView.swift
@@ -7,8 +7,6 @@ struct ConfigView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var launchAtLogin = LoginItem.isEnabled
 
-    private let weekdaySymbols = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] // index 0 => weekday 1
-
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Audio Feeder Settings").font(.headline).padding()
@@ -52,6 +50,14 @@ struct ConfigView: View {
                     weekdayPicker
                     MinuteField(label: "Start", minute: $controller.config.schedule.startMinute)
                     MinuteField(label: "Stop", minute: $controller.config.schedule.stopMinute)
+                    // The one line that says what the settings above actually add up to,
+                    // including the ways a full week of buttons still never runs.
+                    Label(controller.config.schedule.summary,
+                          systemImage: controller.config.schedule.willEverRun
+                              ? "calendar.badge.clock" : "calendar.badge.exclamationmark")
+                        .font(.caption)
+                        .foregroundStyle(controller.config.schedule.willEverRun ? Color.secondary : Color.orange)
+                        .fixedSize(horizontal: false, vertical: true)
                     Text("Manual override always wins over the schedule.")
                         .font(.caption).foregroundStyle(.secondary)
                 }
@@ -87,21 +93,88 @@ struct ConfigView: View {
     }
 
     private var weekdayPicker: some View {
-        HStack(spacing: 4) {
-            ForEach(0..<7, id: \.self) { idx in
-                let weekday = idx + 1
-                let on = controller.config.schedule.days.contains(weekday)
-                Button(weekdaySymbols[idx]) {
-                    if on { controller.config.schedule.days.remove(weekday) }
-                    else { controller.config.schedule.days.insert(weekday) }
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Days the schedule starts on")
+                .font(.caption).foregroundStyle(.secondary)
+            HStack(spacing: 4) {
+                ForEach(1...7, id: \.self) { weekday in
+                    WeekdayButton(weekday: weekday,
+                                  isOn: controller.config.schedule.days.contains(weekday)) {
+                        toggleDay(weekday)
+                    }
                 }
-                .buttonStyle(.bordered)
-                .tint(on ? .accentColor : .gray)
-                .font(.caption)
             }
         }
     }
 
+    private func toggleDay(_ weekday: Int) {
+        if controller.config.schedule.days.contains(weekday) {
+            controller.config.schedule.days.remove(weekday)
+        } else {
+            controller.config.schedule.days.insert(weekday)
+        }
+    }
+}
+
+/// One day in the weekday row: a checkbox that happens to be shaped like a chip.
+///
+/// It draws its own selected/unselected appearance instead of leaning on
+/// `.buttonStyle(.bordered).tint(...)`, which was the previous approach and showed **no
+/// visible change at all** on some macOS versions — AppKit's bordered push button honours a
+/// tint only on newer systems, so on the tech booth Mac every day looked identically
+/// unselected and there was no way to tell what you had picked. A filled shape and a
+/// checkmark are drawn by us, so they look the same on every system we deploy to.
+///
+/// Selection is signalled three ways on purpose — fill, checkmark, and weight — because
+/// colour alone is exactly what failed, and it is also the thing a colour-blind operator or
+/// a washed-out projector-lit screen can't rely on.
+private struct WeekdayButton: View {
+    /// `Calendar` weekday: 1 = Sunday ... 7 = Saturday.
+    let weekday: Int
+    let isOn: Bool
+    let toggle: () -> Void
+
+    var body: some View {
+        Button(action: toggle) {
+            VStack(spacing: 1) {
+                Text(Schedule.weekdaySymbol(weekday))
+                    .font(.caption.weight(isOn ? .semibold : .regular))
+                Image(systemName: isOn ? "checkmark" : "minus")
+                    .font(.system(size: 8, weight: .bold))
+                    .opacity(isOn ? 1 : 0.45)
+            }
+            .foregroundStyle(isOn ? Color.white : Color.secondary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(isOn ? Color.accentColor : Color.secondary.opacity(0.12))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .strokeBorder(isOn ? Color.accentColor : Color.secondary.opacity(0.45),
+                                  lineWidth: 1)
+            )
+            // The whole chip is the hit target, not just the glyphs inside it.
+            .contentShape(RoundedRectangle(cornerRadius: 5))
+        }
+        .buttonStyle(.plain)
+        .help(helpText)
+        .accessibilityLabel(name)
+        .accessibilityValue(stateText)
+        .accessibilityAddTraits(isOn ? [.isSelected] : [])
+    }
+
+    // Spelled out as `String`s rather than inline ternaries so the `help`/`accessibility*`
+    // overloads have one obvious argument type to resolve against.
+    private var name: String { Schedule.weekdayName(weekday) }
+
+    private var stateText: String { isOn ? "Scheduled" : "Skipped" }
+
+    private var helpText: String {
+        isOn ? "\(name): the schedule starts the feeder this day. Click to skip it."
+             : "\(name): the schedule skips this day. Click to run it."
+    }
 }
 
 /// An `HH:mm` text field over a minutes-since-midnight value.

--- a/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
@@ -121,14 +121,23 @@ struct MenuContentView: View {
     /// Routes through the controller's existing methods rather than writing `manualOverride`
     /// directly: `startNow()` and `followSchedule()` also clear a stand-down, and skipping
     /// that would leave the feeder standing down in a mode that says it shouldn't be.
+    ///
+    /// The hop off the current runloop turn is required, not stylistic. SwiftUI writes a
+    /// `Picker`'s selection through this binding **during its view-update pass**, and all
+    /// three of these methods mutate `@Published` state on the controller (`standDown` here,
+    /// `config` → `status` downstream) — which is "Publishing changes from within view
+    /// updates is not allowed". A `Button`'s action closure runs outside that pass, which is
+    /// why the three buttons this replaced never tripped it.
     private var modeBinding: Binding<ManualOverride> {
         Binding(
             get: { controller.config.manualOverride },
             set: { mode in
-                switch mode {
-                case .off: controller.followSchedule()
-                case .forceOn: controller.startNow()
-                case .forceOff: controller.stopNow()
+                Task { @MainActor in
+                    switch mode {
+                    case .off: controller.followSchedule()
+                    case .forceOn: controller.startNow()
+                    case .forceOff: controller.stopNow()
+                    }
                 }
             })
     }

--- a/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
@@ -32,6 +32,7 @@ struct MenuContentView: View {
             }
 
             deviceSummary
+            scheduleSummary
 
             Divider()
 
@@ -103,6 +104,30 @@ struct MenuContentView: View {
             }
         }
         .font(.caption)
+    }
+
+    /// What the schedule will do next, in the place the operator actually looks.
+    ///
+    /// The popover shows what the feeder is doing *now* ("Idle") but never said whether
+    /// anything was going to change that. An install with the schedule switched off, or with
+    /// no days picked, sits at "Idle" forever and looks exactly like one that's five minutes
+    /// from going live — which is the wrong thing to discover at a service.
+    private var scheduleSummary: some View {
+        HStack(spacing: 6) {
+            Image(systemName: scheduleIsStranded ? "calendar.badge.exclamationmark" : "calendar")
+            Text(controller.config.schedule.summary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .font(.caption)
+        .foregroundStyle(scheduleIsStranded ? Color.orange : Color.secondary)
+        .help(controller.config.schedule.summary)
+    }
+
+    /// The schedule can't fire *and* it's the only thing in charge — so nothing will start
+    /// the feeder until a person does. Under a manual override the schedule isn't governing,
+    /// so an inert one isn't news; the override has its own controls right below.
+    private var scheduleIsStranded: Bool {
+        controller.config.manualOverride == .off && !controller.config.schedule.willEverRun
     }
 
     private var statusColor: Color {

--- a/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
@@ -32,21 +32,11 @@ struct MenuContentView: View {
             }
 
             deviceSummary
-            scheduleSummary
 
             Divider()
 
-            // Manual override controls (your "manual + scheduled" choice).
-            HStack {
-                Button("Start now") { controller.startNow() }
-                    .disabled(controller.config.manualOverride == .forceOn)
-                Button("Stop now") { controller.stopNow() }
-                    .disabled(controller.config.manualOverride == .forceOff)
-                if controller.config.manualOverride != .off {
-                    Button("Follow schedule") { controller.followSchedule() }
-                }
-            }
-            .font(.callout)
+            modePicker
+            modeSummary
 
             // A stand-down waits for a person, so it needs a person-shaped way out. "Start
             // now" can't serve: it's disabled whenever the override is already .forceOn,
@@ -106,28 +96,61 @@ struct MenuContentView: View {
         .font(.caption)
     }
 
-    /// What the schedule will do next, in the place the operator actually looks.
+    /// What decides whether the feeder runs — as a control whose selection *is* the state.
     ///
-    /// The popover shows what the feeder is doing *now* ("Idle") but never said whether
-    /// anything was going to change that. An install with the schedule switched off, or with
-    /// no days picked, sits at "Idle" forever and looks exactly like one that's five minutes
-    /// from going live — which is the wrong thing to discover at a service.
-    private var scheduleSummary: some View {
+    /// This replaced three buttons ("Start now" / "Stop now" / "Follow schedule", the last
+    /// appearing only while an override was active). Two problems with that: the mode was
+    /// never on screen, only inferable from which button was disabled; and "Follow schedule"
+    /// read as a *sibling* of Settings' "Enable schedule" checkbox, when it is actually the
+    /// outer switch — it decides whether the schedule is consulted at all, and changes
+    /// nothing about the schedule itself. Segments make the mode visible, and make it clear
+    /// there are exactly three ways this can go.
+    private var modePicker: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("When to publish").font(.caption).foregroundStyle(.secondary)
+            Picker("When to publish", selection: modeBinding) {
+                Text("Schedule").tag(ManualOverride.off)
+                Text("Always on").tag(ManualOverride.forceOn)
+                Text("Always off").tag(ManualOverride.forceOff)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+        }
+    }
+
+    /// Routes through the controller's existing methods rather than writing `manualOverride`
+    /// directly: `startNow()` and `followSchedule()` also clear a stand-down, and skipping
+    /// that would leave the feeder standing down in a mode that says it shouldn't be.
+    private var modeBinding: Binding<ManualOverride> {
+        Binding(
+            get: { controller.config.manualOverride },
+            set: { mode in
+                switch mode {
+                case .off: controller.followSchedule()
+                case .forceOn: controller.startNow()
+                case .forceOff: controller.stopNow()
+                }
+            })
+    }
+
+    /// What the selected mode will actually do — including the cases where it will do nothing.
+    ///
+    /// The popover said what the feeder was doing *now* ("Idle") but never whether anything
+    /// would change that. An install in Schedule mode with the schedule switched off sits at
+    /// "Idle" indefinitely and looks exactly like one that is five minutes from going live.
+    private var modeSummary: some View {
         HStack(spacing: 6) {
-            Image(systemName: scheduleIsStranded ? "calendar.badge.exclamationmark" : "calendar")
-            Text(controller.config.schedule.summary)
+            Image(systemName: controller.config.willStartUnattended
+                  ? "calendar" : "calendar.badge.exclamationmark")
+            Text(controller.config.modeSummary)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .font(.caption)
-        .foregroundStyle(scheduleIsStranded ? Color.orange : Color.secondary)
-        .help(controller.config.schedule.summary)
-    }
-
-    /// The schedule can't fire *and* it's the only thing in charge — so nothing will start
-    /// the feeder until a person does. Under a manual override the schedule isn't governing,
-    /// so an inert one isn't news; the override has its own controls right below.
-    private var scheduleIsStranded: Bool {
-        controller.config.manualOverride == .off && !controller.config.schedule.willEverRun
+        // Orange only when nothing will start the feeder on its own. "Always off" earns it
+        // too: it is a deliberate choice, but it is also the one an unattended install can
+        // be left in by accident after a service.
+        .foregroundStyle(controller.config.willStartUnattended ? Color.secondary : Color.orange)
+        .help(controller.config.modeSummary)
     }
 
     private var statusColor: Color {

--- a/macos-audio-feeder/Sources/AudioFeederCore/Config.swift
+++ b/macos-audio-feeder/Sources/AudioFeederCore/Config.swift
@@ -45,6 +45,78 @@ public struct Schedule: Codable, Equatable, Sendable {
               (0..<24).contains(h), (0..<60).contains(m) else { return nil }
         return h * 60 + m
     }
+
+    // MARK: - Describing the schedule in words
+    //
+    // The settings window can't rely on a highlight alone to say when the feeder will run:
+    // a tinted button is invisible on some macOS versions, ambiguous on the rest, and says
+    // nothing at all about the cases where a fully-selected week still never starts (schedule
+    // off, empty window). So the UI also states the outcome in words, and the sentence is
+    // built here — pure, and covered by `swift test` with no Xcode and no UI.
+    //
+    // English-only on purpose: the app is a single-operator utility with a hard-coded English
+    // UI throughout, and localized weekday symbols would reorder against the fixed Sun-first
+    // button row.
+
+    /// Three-letter weekday labels, indexed by `Calendar` weekday (1 = Sunday ... 7 = Saturday).
+    public static let weekdaySymbols = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+    /// Full weekday names, indexed by `Calendar` weekday (1 = Sunday ... 7 = Saturday).
+    public static let weekdayNames = ["Sunday", "Monday", "Tuesday", "Wednesday",
+                                      "Thursday", "Friday", "Saturday"]
+
+    /// `"Sun"` for weekday 1 ... `"Sat"` for weekday 7; `"?"` for anything out of range.
+    public static func weekdaySymbol(_ weekday: Int) -> String {
+        (1...7).contains(weekday) ? weekdaySymbols[weekday - 1] : "?"
+    }
+
+    /// `"Sunday"` for weekday 1 ... `"Saturday"` for weekday 7; `"?"` for anything out of range.
+    public static func weekdayName(_ weekday: Int) -> String {
+        (1...7).contains(weekday) ? weekdayNames[weekday - 1] : "?"
+    }
+
+    /// The selected days, ignoring anything outside `1...7`.
+    public var activeDays: Set<Int> {
+        days.filter { (1...7).contains($0) }
+    }
+
+    /// Whether this schedule can ever start the feeder on its own. False for all three inert
+    /// shapes: switched off, no days picked, or a zero-length window.
+    public var willEverRun: Bool {
+        enabled && !activeDays.isEmpty && startMinute != stopMinute
+    }
+
+    /// The selected days as a phrase: `"every day"`, `"weekdays"`, `"weekends"`,
+    /// `"Sun, Wed"`, or `"no days"`. Always in Sunday-first calendar order.
+    public var daysDescription: String {
+        let selected = activeDays
+        if selected.isEmpty { return "no days" }
+        if selected.count == 7 { return "every day" }
+        if selected == [2, 3, 4, 5, 6] { return "weekdays" }
+        if selected == [1, 7] { return "weekends" }
+        return selected.sorted().map(Schedule.weekdaySymbol).joined(separator: ", ")
+    }
+
+    /// One sentence stating whether — and when — the schedule will start the feeder.
+    ///
+    /// Names every way a schedule can be inert, because each of them looks identical in the
+    /// day-button row: turned off, no days picked, or a zero-length window.
+    public var summary: String {
+        guard enabled else {
+            return "Schedule off — the feeder runs only when you press Start now."
+        }
+        if activeDays.isEmpty {
+            return "No days selected — the schedule will never start the feeder."
+        }
+        if startMinute == stopMinute {
+            return "Start and stop are the same time — the schedule will never start the feeder."
+        }
+        let window = "\(Schedule.formatHHMM(startMinute))–\(Schedule.formatHHMM(stopMinute))"
+        // A wrapping window is anchored to its start day (see `Scheduler.isWithinWindow`), so
+        // the selected days are start days, and the run finishes on the following morning.
+        let tail = startMinute < stopMinute ? "" : " the next day"
+        return "Runs \(daysDescription), \(window)\(tail)."
+    }
 }
 
 /// User-editable settings for the feeder. Persisted as JSON.

--- a/macos-audio-feeder/Sources/AudioFeederCore/Config.swift
+++ b/macos-audio-feeder/Sources/AudioFeederCore/Config.swift
@@ -103,7 +103,10 @@ public struct Schedule: Codable, Equatable, Sendable {
     /// day-button row: turned off, no days picked, or a zero-length window.
     public var summary: String {
         guard enabled else {
-            return "Schedule off — the feeder runs only when you press Start now."
+            // Deliberately doesn't name the way out: this sentence shows in both the settings
+            // window (where the checkbox is right there) and the menu bar (where the mode
+            // picker is), and naming one of them would be wrong in the other place.
+            return "Schedule off — nothing will start the feeder on its own."
         }
         if activeDays.isEmpty {
             return "No days selected — the schedule will never start the feeder."
@@ -163,5 +166,34 @@ public struct FeederConfig: Codable, Equatable, Sendable {
         }
         let c = calendar.dateComponents([.year, .month, .day], from: now)
         return String(format: "doc-%04d-%02d-%02d", c.year ?? 0, c.month ?? 0, c.day ?? 0)
+    }
+
+    /// One sentence for what will actually govern the feeder, override included.
+    ///
+    /// Two separate controls decide this — the schedule's own **Enable schedule**, and the
+    /// menu bar's **mode** (this `manualOverride`) — and they are easy to confuse, because
+    /// each can independently stop the feeder from ever starting. The mode is the outer one:
+    /// it decides *whether the schedule is consulted at all*, and only `.off` (mode
+    /// "Schedule") hands the decision to `Schedule`. So: read the mode first, and only then
+    /// does the schedule's own summary mean anything.
+    public var modeSummary: String {
+        switch manualOverride {
+        case .forceOn:
+            return "Always on — publishing regardless of the schedule."
+        case .forceOff:
+            return "Always off — the schedule is ignored until you switch back to Schedule."
+        case .off:
+            return schedule.summary
+        }
+    }
+
+    /// Whether anything will start the feeder without a person clicking — the question that
+    /// matters for an unattended install, and one neither control answers on its own.
+    public var willStartUnattended: Bool {
+        switch manualOverride {
+        case .forceOn: return true
+        case .forceOff: return false
+        case .off: return schedule.willEverRun
+        }
     }
 }

--- a/macos-audio-feeder/Tests/AudioFeederCoreTests/ConfigTests.swift
+++ b/macos-audio-feeder/Tests/AudioFeederCoreTests/ConfigTests.swift
@@ -36,6 +36,94 @@ final class ConfigTests: XCTestCase {
         XCTAssertNil(Schedule.parseHHMM("10:60"))
     }
 
+    // MARK: - The sentence the settings window shows under the day buttons
+    //
+    // This is the part of the UI that says whether the feeder will actually run, so it is
+    // worth pinning: the highlight on a day button can't distinguish "Wednesday is selected"
+    // from "Wednesday is selected and the schedule is switched off".
+
+    func testWeekdayLabels() {
+        XCTAssertEqual(Schedule.weekdaySymbol(1), "Sun")
+        XCTAssertEqual(Schedule.weekdaySymbol(7), "Sat")
+        XCTAssertEqual(Schedule.weekdayName(4), "Wednesday")
+        // Out of range is a bug elsewhere, but must not trap in a view body.
+        XCTAssertEqual(Schedule.weekdaySymbol(0), "?")
+        XCTAssertEqual(Schedule.weekdayName(8), "?")
+    }
+
+    func testDaysDescriptionCollapsesCommonSets() {
+        func days(_ d: Set<Int>) -> String { Schedule(days: d).daysDescription }
+        XCTAssertEqual(days([1, 2, 3, 4, 5, 6, 7]), "every day")
+        XCTAssertEqual(days([2, 3, 4, 5, 6]), "weekdays")
+        XCTAssertEqual(days([1, 7]), "weekends")
+        XCTAssertEqual(days([]), "no days")
+        // Otherwise: listed, always in Sunday-first calendar order.
+        XCTAssertEqual(days([4, 1]), "Sun, Wed")
+    }
+
+    func testSummaryNamesEveryWayAScheduleCanBeInert() {
+        // Switched off, however full the day row looks.
+        XCTAssertEqual(Schedule(enabled: false, days: [1, 2, 3, 4, 5, 6, 7]).summary,
+                       "Schedule off — the feeder runs only when you press Start now.")
+        XCTAssertFalse(Schedule(enabled: false, days: [1]).willEverRun)
+
+        // Enabled, sane window, but nothing selected.
+        XCTAssertEqual(Schedule(enabled: true, days: []).summary,
+                       "No days selected — the schedule will never start the feeder.")
+        XCTAssertFalse(Schedule(enabled: true, days: []).willEverRun)
+
+        // Enabled, days selected, but an empty window (`Scheduler` treats start == stop as off).
+        let noWindow = Schedule(enabled: true, days: [1], startMinute: 600, stopMinute: 600)
+        XCTAssertEqual(noWindow.summary,
+                       "Start and stop are the same time — the schedule will never start the feeder.")
+        XCTAssertFalse(noWindow.willEverRun)
+    }
+
+    func testSummaryDescribesALiveSchedule() {
+        let sunday = Schedule(enabled: true, days: [1], startMinute: 10 * 60, stopMinute: 12 * 60)
+        XCTAssertEqual(sunday.summary, "Runs Sun, 10:00–12:00.")
+        XCTAssertTrue(sunday.willEverRun)
+
+        // A window that wraps past midnight is anchored to its start day, so say so.
+        let overnight = Schedule(enabled: true, days: [7], startMinute: 23 * 60, stopMinute: 60)
+        XCTAssertEqual(overnight.summary, "Runs Sat, 23:00–01:00 the next day.")
+        XCTAssertTrue(overnight.willEverRun)
+    }
+
+    /// `willEverRun` must agree with the thing that actually decides: `Scheduler.shouldRun`.
+    func testWillEverRunAgreesWithScheduler() {
+        // 2024-01-07 is a Sunday, so day 7...13 is one full Sun-to-Sat week.
+        func date(dayOffset: Int, minuteOfDay: Int) -> Date {
+            var c = DateComponents()
+            c.year = 2024; c.month = 1; c.day = 7 + dayOffset
+            c.hour = minuteOfDay / 60; c.minute = minuteOfDay % 60
+            return utc.date(from: c)!
+        }
+
+        let inert = [Schedule(enabled: false, days: [1, 2, 3, 4, 5, 6, 7], startMinute: 0, stopMinute: 1439),
+                     Schedule(enabled: true, days: [], startMinute: 0, stopMinute: 1439),
+                     Schedule(enabled: true, days: [1, 2, 3, 4, 5, 6, 7], startMinute: 600, stopMinute: 600)]
+        for schedule in inert {
+            XCTAssertFalse(schedule.willEverRun)
+            // Sweep a whole week at minute resolution: nothing anywhere should start it.
+            for dayOffset in 0..<7 {
+                for minute in 0..<(24 * 60) {
+                    XCTAssertFalse(Scheduler.shouldRun(now: date(dayOffset: dayOffset, minuteOfDay: minute),
+                                                       schedule: schedule,
+                                                       manualOverride: .off,
+                                                       calendar: utc),
+                                   "\(schedule) claimed inert but runs on day \(dayOffset) at minute \(minute)")
+                }
+            }
+        }
+
+        // And the converse: a schedule that says it will run, does.
+        let live = Schedule(enabled: true, days: [1], startMinute: 10 * 60, stopMinute: 12 * 60)
+        XCTAssertTrue(live.willEverRun)
+        XCTAssertTrue(Scheduler.shouldRun(now: date(dayOffset: 0, minuteOfDay: 11 * 60),
+                                          schedule: live, manualOverride: .off, calendar: utc))
+    }
+
     func testConfigCodableRoundTrip() throws {
         let cfg = FeederConfig(serverURL: "https://example.org",
                                docIDOverride: "doc-x",

--- a/macos-audio-feeder/Tests/AudioFeederCoreTests/ConfigTests.swift
+++ b/macos-audio-feeder/Tests/AudioFeederCoreTests/ConfigTests.swift
@@ -64,7 +64,7 @@ final class ConfigTests: XCTestCase {
     func testSummaryNamesEveryWayAScheduleCanBeInert() {
         // Switched off, however full the day row looks.
         XCTAssertEqual(Schedule(enabled: false, days: [1, 2, 3, 4, 5, 6, 7]).summary,
-                       "Schedule off — the feeder runs only when you press Start now.")
+                       "Schedule off — nothing will start the feeder on its own.")
         XCTAssertFalse(Schedule(enabled: false, days: [1]).willEverRun)
 
         // Enabled, sane window, but nothing selected.
@@ -122,6 +122,62 @@ final class ConfigTests: XCTestCase {
         XCTAssertTrue(live.willEverRun)
         XCTAssertTrue(Scheduler.shouldRun(now: date(dayOffset: 0, minuteOfDay: 11 * 60),
                                           schedule: live, manualOverride: .off, calendar: utc))
+    }
+
+    // MARK: - Mode (the override) vs the schedule's own switch
+    //
+    // These are the two controls that get confused for each other, so pin which one wins:
+    // the mode decides whether the schedule is consulted at all.
+
+    func testModeSummaryReportsTheOverrideNotTheSchedule() {
+        // A live schedule says nothing about what happens while an override is in force.
+        let live = Schedule(enabled: true, days: [1], startMinute: 600, stopMinute: 720)
+        XCTAssertEqual(FeederConfig(schedule: live, manualOverride: .forceOn).modeSummary,
+                       "Always on — publishing regardless of the schedule.")
+        XCTAssertEqual(FeederConfig(schedule: live, manualOverride: .forceOff).modeSummary,
+                       "Always off — the schedule is ignored until you switch back to Schedule.")
+        // Only in Schedule mode does the schedule get to speak.
+        XCTAssertEqual(FeederConfig(schedule: live, manualOverride: .off).modeSummary,
+                       live.summary)
+    }
+
+    func testWillStartUnattendedCombinesBothControls() {
+        let live = Schedule(enabled: true, days: [1], startMinute: 600, stopMinute: 720)
+        let off = Schedule(enabled: false, days: [1], startMinute: 600, stopMinute: 720)
+
+        // Force-on runs even with no usable schedule at all; force-off never runs, however
+        // good the schedule is. This is the asymmetry the old UI never showed.
+        XCTAssertTrue(FeederConfig(schedule: off, manualOverride: .forceOn).willStartUnattended)
+        XCTAssertFalse(FeederConfig(schedule: live, manualOverride: .forceOff).willStartUnattended)
+
+        // In Schedule mode it defers entirely to the schedule.
+        XCTAssertTrue(FeederConfig(schedule: live, manualOverride: .off).willStartUnattended)
+        XCTAssertFalse(FeederConfig(schedule: off, manualOverride: .off).willStartUnattended)
+    }
+
+    /// `willStartUnattended` must not become a second opinion: if it says nothing will start
+    /// the feeder, `Scheduler.shouldRun` must agree across a whole week.
+    func testWillStartUnattendedAgreesWithScheduler() {
+        func date(dayOffset: Int, minuteOfDay: Int) -> Date {
+            var c = DateComponents()
+            c.year = 2024; c.month = 1; c.day = 7 + dayOffset   // 2024-01-07 is a Sunday
+            c.hour = minuteOfDay / 60; c.minute = minuteOfDay % 60
+            return utc.date(from: c)!
+        }
+        let allWeek = Schedule(enabled: true, days: [1, 2, 3, 4, 5, 6, 7], startMinute: 0, stopMinute: 1439)
+        let configs = [FeederConfig(schedule: allWeek, manualOverride: .forceOff),
+                       FeederConfig(schedule: Schedule(enabled: false), manualOverride: .off)]
+        for config in configs {
+            XCTAssertFalse(config.willStartUnattended)
+            for dayOffset in 0..<7 {
+                for minute in stride(from: 0, to: 24 * 60, by: 7) {
+                    XCTAssertFalse(Scheduler.shouldRun(now: date(dayOffset: dayOffset, minuteOfDay: minute),
+                                                       schedule: config.schedule,
+                                                       manualOverride: config.manualOverride,
+                                                       calendar: utc))
+                }
+            }
+        }
     }
 
     func testConfigCodableRoundTrip() throws {


### PR DESCRIPTION
## The problem

Two complaints about **Settings → Schedule** in the macOS Audio Feeder:

1. On an older macOS, clicking a weekday button showed **no visible change at all**.
2. Even where it did show, it wasn't clear which appearance meant "the schedule will run this day".

The row was seven `Button`s styled `.bordered`, differentiated *only* by `.tint(on ? .accentColor : .gray)`. Tint is a hint AppKit's bordered push button is free to ignore, and older systems do exactly that — both states render as the same grey push button. Where it *is* honoured, the difference is accent-tinted vs grey-tinted: a colour difference with no shape, no glyph, and no label saying which one is "on". The state was in the config the whole time; the UI never committed to showing it.

## The fix, two halves

**Draw the state instead of hinting at it.** `WeekdayButton` (`ConfigView.swift`) is a `.buttonStyle(.plain)` chip that renders its own fill, border, font weight and glyph — filled accent + checkmark + semibold when scheduled, outlined + dash + regular when skipped. Nothing about it is a hint, so it renders identically on every system we deploy to, and it survives the loss of colour (colour-blind operator, washed-out booth monitor). It also picked up a tooltip and a proper accessibility label / value / `.isSelected` trait — previously it was an unlabelled `Sun` with no selected state exposed at all.

**Say the outcome in words.** `Schedule.summary` renders one sentence under the times, orange when the schedule can never fire. This is the half that answers complaint (2), because *no* chip appearance can distinguish these three do-nothing configurations:

| Configuration | Chip row shows | Summary says |
|---|---|---|
| `enabled == false` | a full week of chips | Schedule off — the feeder runs only when you press Start now. |
| `days.isEmpty` | nothing selected | No days selected — the schedule will never start the feeder. |
| `startMinute == stopMinute` | a full week of chips | Start and stop are the same time — the schedule will never start the feeder. |

A live schedule reads *"Runs Sun, 10:00–12:00."* The summary also spells out the wrapping window — *"Runs Sat, 23:00–01:00 the next day."* — which is the one place `days` doesn't mean "runs on this day": `Scheduler.isWithinWindow` anchors a wrapping run to its **start** day, so Sunday 00:30 belongs to Saturday's window. Nothing in the UI had ever said so. The row is now labelled "Days the schedule starts on" for the same reason.

## Where the logic lives

The sentence is built in `Schedule` (`AudioFeederCore`), not the view, so `swift test` covers it with no Xcode and no UI — same split as the rest of the core.

- `ConfigTests` pins each inert case and each phrasing (`every day` / `weekdays` / `weekends` / `Sun, Wed`).
- `testWillEverRunAgreesWithScheduler` sweeps a full week minute-by-minute through the real `Scheduler.shouldRun`, so "will never start the feeder" is the truth rather than a second, drifting opinion about the schedule.

No behaviour change to scheduling itself — `Scheduler` is untouched.

## Testing

⚠️ **Not built or run.** There is no Swift toolchain in this environment — no build, no `swift test`, no launch. The logic changes are pure and unit-tested as written; the SwiftUI is plain, version-agnostic API (`buttonStyle(.plain)`, `background`, `overlay`, `help`, the `accessibility*` modifiers). Per the notebook's own rule, please run `swift test` and open the settings window once before the next service.

`docs/SMOKE_TEST.md`: no sections touched — this changes only the macOS Audio Feeder's settings window.

## Docs

- `macos-audio-feeder/README.md` — new "Setting the schedule" section: what filled vs outlined means, what the summary line covers, and that days are *start* days.
- `macos-audio-feeder/NOTEBOOK.md` — dated entry with the symptom, why `tint` was the cause, and the rule it earns: if a control's state is only a `tint`, the app has no state on screen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz9TmohBXwR9FRtzREPFRA)_