### PR TITLE
Share one reading font size between transcripts and translations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import "./App.css";
 
 import { useAtom } from "jotai";
 import { editorDeniedAtom, fontSizeAtom, isEditorAtom, languages } from "./configAtoms";
+import { FontSizeControls } from "./FontSizeControls";
 import { useStrings, resolveLocale, LANGUAGE_BCP47 } from "./useLocale";
 import {
   LISTEN_LANGUAGE_CODES,
@@ -174,7 +175,7 @@ function HomePage() {
 }
 
 function PagePart({ componentStr, onReplace }: { componentStr: string; onReplace: (newName: string) => void }) {
-  const [fontSize, setFontSize] = useAtom(fontSizeAtom);
+  const [fontSize] = useAtom(fontSizeAtom);
   const ydoc = useYDoc();
   // eslint-disable-next-line react-hooks/immutability, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
   (window as any).ydoc = ydoc; // Expose YDoc on window for debugging
@@ -187,29 +188,7 @@ function PagePart({ componentStr, onReplace }: { componentStr: string; onReplace
 
   const langDisplayNames = new Intl.DisplayNames([locale], { type: 'language' });
 
-  const fontSizeControls = (
-    <>
-      <div className="flex-1" />
-      <button
-        type="button"
-        aria-label={s.decreaseFontSize}
-        onClick={() => setFontSize(Math.max(10, (fontSize || 16) - 2))}
-      >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" role="img" aria-label={s.decreaseFontSize}>
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-        </svg>
-      </button>
-      <button
-        type="button"
-        aria-label={s.increaseFontSize}
-        onClick={() => setFontSize(Math.min(32, (fontSize || 16) + 2))}
-      >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" role="img" aria-label={s.increaseFontSize}>
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-        </svg>
-      </button>
-    </>
-  );
+  const fontSizeControls = <FontSizeControls />;
 
   const languageSelector = (prefix: string, language: string) => (
     <select
@@ -324,6 +303,7 @@ function PagePart({ componentStr, onReplace }: { componentStr: string; onReplace
         <div className="flex items-center">
           <h2 className="font-semibold text-xs text-gray-500 dark:text-gray-300 leading-tight mb-0">{s.listenLive}</h2>
           {listenLanguageSelector(validLanguage)}
+          {fontSizeControls}
         </div>
         <React.Suspense fallback={<div className="flex-1 flex items-center justify-center text-xs text-gray-400">{s.connecting}</div>}>
           <ListenViewer key={validLanguage} language={validLanguage} />

--- a/src/BroadcastControl.tsx
+++ b/src/BroadcastControl.tsx
@@ -16,6 +16,7 @@ import { LocalAudioTrack, Track } from "livekit-client";
 import { isEditorAtom } from "./configAtoms";
 import { useStrings } from "./useLocale";
 import { LiveTranscript } from "./LiveTranscript";
+import { FontSizeControls } from "./FontSizeControls";
 import { getDocId } from "./getDocId";
 import { apiFetch } from "./writeKey";
 
@@ -110,9 +111,12 @@ function BroadcastDashboard({ docId }: { docId: string }) {
         </span>
       </div>
       <MicLevelMeter />
-      <h3 className="text-xs font-semibold text-gray-500 dark:text-gray-300">
-        {s.englishTranscript}
-      </h3>
+      <div className="flex items-center">
+        <h3 className="text-xs font-semibold text-gray-500 dark:text-gray-300">
+          {s.englishTranscript}
+        </h3>
+        <FontSizeControls />
+      </div>
       <LiveTranscript langCode={SOURCE_TRANSCRIPT_CODE} />
       <div className="overflow-auto max-h-40">
         <h3 className="text-xs font-semibold text-gray-500 dark:text-gray-300 mb-1">

--- a/src/FontSizeControls.test.tsx
+++ b/src/FontSizeControls.test.tsx
@@ -1,0 +1,52 @@
+// The shared −/+ control: it writes the one `fontSizeAtom` every reading pane
+// (translated text, bilingual, live transcript) renders at, and clamps to a range
+// that stays legible without blowing the pane apart.
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider, createStore } from 'jotai';
+import { fontSizeAtom } from './configAtoms';
+import { FontSizeControls, MIN_FONT_SIZE, MAX_FONT_SIZE } from './FontSizeControls';
+
+const renderAt = (px: number) => {
+  const store = createStore();
+  store.set(fontSizeAtom, px);
+  render(
+    <Provider store={store}>
+      <FontSizeControls />
+    </Provider>
+  );
+  return store;
+};
+
+const bigger = () => screen.getByRole('button', { name: 'Increase font size' });
+const smaller = () => screen.getByRole('button', { name: 'Decrease font size' });
+
+describe('FontSizeControls', () => {
+  it('steps the shared size up and down', async () => {
+    const store = renderAt(20);
+
+    await userEvent.click(bigger());
+    expect(store.get(fontSizeAtom)).toBe(22);
+
+    await userEvent.click(smaller());
+    await userEvent.click(smaller());
+    expect(store.get(fontSizeAtom)).toBe(18);
+  });
+
+  it('will not grow past the maximum', async () => {
+    const store = renderAt(MAX_FONT_SIZE);
+
+    await userEvent.click(bigger());
+
+    expect(store.get(fontSizeAtom)).toBe(MAX_FONT_SIZE);
+  });
+
+  it('will not shrink past the minimum', async () => {
+    const store = renderAt(MIN_FONT_SIZE);
+
+    await userEvent.click(smaller());
+
+    expect(store.get(fontSizeAtom)).toBe(MIN_FONT_SIZE);
+  });
+});

--- a/src/FontSizeControls.tsx
+++ b/src/FontSizeControls.tsx
@@ -1,0 +1,44 @@
+// The −/+ pair that sets the reading font size, shared by every pane that shows
+// text a viewer reads at a distance: the translated/bilingual outline views and the
+// live transcript. One control, one `fontSizeAtom` (persisted per device), so
+// bumping the size in one pane bumps it everywhere — a viewer sets their reading
+// size once, not per pane.
+//
+// Rendered inside a flex header row; the leading spacer pushes the buttons to the
+// right of whatever titles/selectors precede them.
+import { useAtom } from "jotai";
+import { fontSizeAtom } from "./configAtoms";
+import { useStrings } from "./useLocale";
+
+export const MIN_FONT_SIZE = 10;
+export const MAX_FONT_SIZE = 32;
+const FONT_SIZE_STEP = 2;
+
+export function FontSizeControls() {
+  const s = useStrings();
+  const [fontSize, setFontSize] = useAtom(fontSizeAtom);
+
+  return (
+    <>
+      <div className="flex-1" />
+      <button
+        type="button"
+        aria-label={s.decreaseFontSize}
+        onClick={() => setFontSize(Math.max(MIN_FONT_SIZE, (fontSize || 16) - FONT_SIZE_STEP))}
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" role="img" aria-label={s.decreaseFontSize}>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        aria-label={s.increaseFontSize}
+        onClick={() => setFontSize(Math.min(MAX_FONT_SIZE, (fontSize || 16) + FONT_SIZE_STEP))}
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" role="img" aria-label={s.increaseFontSize}>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+        </svg>
+      </button>
+    </>
+  );
+}

--- a/src/LiveTranscript.test.tsx
+++ b/src/LiveTranscript.test.tsx
@@ -4,6 +4,8 @@
 // the threshold itself in transcriptKeys.test.ts.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { Provider, createStore } from 'jotai';
+import { fontSizeAtom } from './configAtoms';
 import { TRANSCRIPT_PAUSE_MS, type TranscriptSegment } from './transcriptKeys';
 
 const segments = vi.hoisted(() => ({ current: [] as TranscriptSegment[] }));
@@ -83,5 +85,49 @@ describe('LiveTranscript pause indicators', () => {
 
     expect(screen.getByText('Waiting for translated speech…')).toBeTruthy();
     expect(pauseLabels()).toEqual([]);
+  });
+});
+
+// The transcript reads the same `fontSizeAtom` the translated/bilingual views do, so
+// the −/+ controls in any pane's header resize it too.
+describe('LiveTranscript font size', () => {
+  const renderAtSize = (px: number) => {
+    const store = createStore();
+    store.set(fontSizeAtom, px);
+    return render(
+      <Provider store={store}>
+        <LiveTranscript langCode="en" />
+      </Provider>
+    );
+  };
+
+  it('renders the text column at the shared reading size', () => {
+    segments.current = [{ text: 'Good morning.' }];
+
+    renderAtSize(28);
+
+    const column = screen.getByText('Good morning.').parentElement;
+    expect(column?.style.fontSize).toBe('28px');
+  });
+
+  it('follows the atom when the size changes', () => {
+    segments.current = [{ text: 'Good morning.' }];
+
+    const store = createStore();
+    store.set(fontSizeAtom, 16);
+    const { rerender } = render(
+      <Provider store={store}>
+        <LiveTranscript langCode="en" />
+      </Provider>
+    );
+    expect(screen.getByText('Good morning.').parentElement?.style.fontSize).toBe('16px');
+
+    store.set(fontSizeAtom, 30);
+    rerender(
+      <Provider store={store}>
+        <LiveTranscript langCode="en" />
+      </Provider>
+    );
+    expect(screen.getByText('Good morning.').parentElement?.style.fontSize).toBe('30px');
   });
 });

--- a/src/LiveTranscript.tsx
+++ b/src/LiveTranscript.tsx
@@ -14,6 +14,8 @@
 // broadcaster — because reading it needs only the Yjs connection, not the audio
 // room.
 import { Fragment, useRef, useState } from "react";
+import { useAtomValue } from "jotai";
+import { fontSizeAtom } from "./configAtoms";
 import { useStrings, resolveLocale } from "./useLocale";
 import { useTranscriptSegments } from "./useTranscriptSegments";
 import { formatPauseGap, isLongPause, type TranscriptSegment } from "./transcriptKeys";
@@ -49,6 +51,11 @@ function PauseDivider({ gapMs }: { gapMs: number }) {
 export function LiveTranscript({ langCode }: { langCode: string }) {
   const s = useStrings();
   const segments: TranscriptSegment[] = useTranscriptSegments(langCode);
+  // The one reading size, shared with the translated/bilingual views (FontSizeControls
+  // writes it). Set on the text column rather than baked into a class, so the −/+
+  // buttons in this pane's header move the transcript too — the measure is in `ch`,
+  // so the line length holds as the size changes.
+  const fontSize = useAtomValue(fontSizeAtom);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const contentEndRef = useRef<HTMLDivElement | null>(null);
 
@@ -71,7 +78,7 @@ export function LiveTranscript({ langCode }: { langCode: string }) {
         className="flex-1 overflow-auto text-gray-800 dark:text-gray-100"
       >
         {hasContent ? (
-          <div className="mx-auto max-w-[60ch] text-lg leading-relaxed">
+          <div className="mx-auto max-w-[60ch] leading-relaxed" style={{ fontSize }}>
             {segments.map((seg, i) => {
               // Fragment, not a wrapper element: the paragraphs' vertical margins
               // collapse against each other, and boxing each one would double the gaps.


### PR DESCRIPTION
The translated/bilingual panes have −/+ font size controls; the live transcript was pinned at `text-lg` with no way to change it. A viewer reading the transcript on a projector or a phone was stuck with whatever size we shipped.

## What changed

- **New `src/FontSizeControls.tsx`** — the −/+ pair, lifted verbatim out of `PagePart` in `App.tsx` where it was inlined. It already wrote the device-persisted `fontSizeAtom`; now that's one component instead of one closure only `App` could reach. Min/max/step are named constants (`MIN_FONT_SIZE` 10, `MAX_FONT_SIZE` 32, step 2 — same numbers as before).
- **`LiveTranscript`** renders its text column at `fontSizeAtom` (`useAtomValue`) instead of the fixed `text-lg`. The measure stays `max-w-[60ch]`, which is relative to the element's font size, so line length holds as the size changes.
- **Controls added where a transcript is shown**: the `listen-` pane header (next to the language picker) and above the broadcaster's English transcript in `BroadcastControl`. The existing translated/bilingual headers are unchanged, now rendering `<FontSizeControls />`.

Because it's the one atom, changing the size in any pane changes it in all of them, and it persists per device as it already did. Default is 20px, a small bump from the transcript's previous 18px.

## Tests

- `src/FontSizeControls.test.tsx` (new): stepping up/down, and clamping at each end.
- `src/LiveTranscript.test.tsx`: the text column renders at the shared size, and follows it when it changes.

`npm test` (455 passed), `npm run typecheck`, and `npm run lint` are all clean.

## Smoke test sections touched

[docs/SMOKE_TEST.md](docs/SMOKE_TEST.md) **§4 Live audio translation** — the listen pane and the broadcaster's transcript view. §2 (block translation) is worth a glance too since the shared control now drives both, but nothing about the translated/bilingual panes changed beyond where the control's code lives.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVKUX1wGdQvPsJ5bf4cKxe)_