### PR TITLE
Show which room the feeder publishes into

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,7 +110,19 @@ writer once each component announces its clientID (planned: via the status heart
   it down, so "nothing is translating" can also mean "nobody is speaking" — preflight then
   needs non-silent audio, not just a connection.
 - **Doc IDs are date-anchored** (`getDocId.ts`, and the Proclaim service anchors to the
-  show's scheduled date), so a service's state lives in one doc per date.
+  show's scheduled date), so a service's state lives in one doc per date. Four components
+  derive that id independently, three of them from *their own machine's* local date —
+  browser, Proclaim service, audio feeder (`FeederConfig.resolvedDocID`). They agree only as
+  far as the machines' clocks do.
+- **Nobody owns creating the doc — the first arrival does.** Y-Sweet has no "create today's
+  session" step: `/api/ys-auth` calls `getOrCreateDocAndToken`, so whichever component shows
+  up first brings the doc into being, and the rest join it. That used to be a person opening
+  the editor, which made it invisible. It no longer is: the audio feeder can go live on a
+  schedule with no human present. So **server-side Yjs writers must create-or-get too**
+  (`ysDocToken.ts` — the transcript writer and the slide-conversation store), because plain
+  `getClientToken` 404s on a doc that doesn't exist yet, and the unattended path is exactly
+  where it would. The corollary to check when something looks wrong: a component pointed at
+  the wrong date doesn't error, it *creates* that doc and works perfectly, alone.
 - **Editor vs viewer** is enforced server-side via Y-Sweet token scope. The `#editor` request
   states an intent; whether it is honored depends on a shared per-device write key
   (`writeAuth.ts`, [WRITE_KEYS.md](WRITE_KEYS.md)) — as does taking the microphone, and the

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -17,6 +17,11 @@ an incident happens that this list would not have caught, add a line.
 - [ ] Open the editor URL (`/...#editor`) on one device, a viewer URL on a second device
       (ideally a phone on cellular, not the LAN).
 
+> **Note the assumption this makes.** Opening the editor first *creates* today's doc, which
+> hides every "who creates the doc" bug from the rest of this list — see §8, which is
+> deliberately run against a cold doc, before this step, on any Sunday the feeder is expected
+> to start on its own.
+
 ## 1. Collaboration & editor
 
 - [ ] Type in the block editor; text appears on the second device within ~1 s.
@@ -123,3 +128,26 @@ Skip entirely when `WRITE_KEYS` is unset (the server logs `write authorization i
       stopping …` in server logs) — no orphaned Gemini sessions burning quota. (With the cost
       path enabled, closing listeners is not enough: the default translator stays up for the
       transcript until the broadcaster also leaves.)
+
+## 8. The unattended start (macOS Audio Feeder)
+
+Only when the feeder is expected to start a service on its own. **Run this before the Setup
+step above**, on a doc no browser has opened yet — that is the whole point of the section,
+and opening the editor first destroys it. The feeder's own desk checklist (build, entitlements,
+device, first connect) lives in
+[macos-audio-feeder/NOTEBOOK.md](../macos-audio-feeder/NOTEBOOK.md#pre-service-checklist);
+this section is only about what the *server* does when the feeder is the first thing to arrive.
+
+- [ ] The room shown in the feeder's menu-bar popover is the doc you intend to run — and reads
+      as today's date, not `pinned`. A pinned room is right only if you pinned it for this
+      service; it is the one setting whose being wrong looks exactly like everything working.
+- [ ] With no editor open and the Proclaim service stopped, let the feeder go live (or set
+      **When to publish** → *Always on*). Server logs show `[SessionManager] Supervisor
+      starting …` and **no** `Failed to get client token … 404 Not Found` — the writers
+      create-or-get the doc (`ysDocToken.ts`), so being first is legal. (The 2026-08-06 bug:
+      they didn't, and the feeder-first path was the only one that hit it.)
+- [ ] Speak into the board for ~30 s, *then* open a viewer for the first time: the transcript
+      is already there, with history, rather than starting from the moment you joined. This is
+      the check that proves the writer reached Yjs and not just its own in-memory doc.
+- [ ] Start the Proclaim service afterwards; it lands in the *same* doc (slides appear next to
+      the transcript). Two docs here means two machines disagree about the date.

--- a/macos-audio-feeder/NOTEBOOK.md
+++ b/macos-audio-feeder/NOTEBOOK.md
@@ -10,6 +10,39 @@ cause, the fix.
 
 ---
 
+## 2026-08-06 — the feeder can create the room it publishes into (and that is the risk)
+
+**Symptom (server-side, not the app).** The feeder came up before anyone had opened the day's
+page and the server logged, per bridge, `Failed to get client token _YSweetError: ServerError:
+Server responded with 404 Not Found. URL: .../doc/doc-2026-08-06/auth`.
+
+**Cause.** Y-Sweet has no "create today's session" step: whichever component arrives first
+creates the doc, via `getOrCreateDocAndToken` behind `/api/ys-auth`. Every attended path does
+that — browser, Proclaim service. The server's own in-process Yjs writers used plain
+`getClientToken`, which 404s on a doc that doesn't exist, so they only worked when someone
+else had already been there. That assumption held for years of human-first services and broke
+on the first feeder-first one. Fixed server-side in `ysDocToken.ts` (`5ea5f12`); nothing in
+the app was wrong.
+
+**Why it belongs in this notebook anyway.** The fix removed the only evidence. Before it, a
+feeder pointed at a doc nobody opens announced itself with a 404; now it connects, publishes,
+and meters audio into an empty room it created itself, and the failure is indistinguishable
+from a good service until someone notices the viewers see nothing. The feeder is the only
+component that can reach that state unsupervised, and the room comes from *this Mac's* clock
+(`resolvedDocID`), so a wrong system date on the booth machine produces it exactly.
+
+**What changed here.** The popover now shows the room, with a `pinned` badge when
+`docIDOverride` is set — Settings already showed it, but an unattended install is judged from
+the popover, and a pin is set for one service and then outlives the reason for it.
+`pinnedDocID` also trims the override, which the raw path didn't: `" doc-x "` used to reach
+LiveKit with its spaces, looking correct in the settings field and matching nothing.
+
+**Verified.** `swift test` (49) and `xcodebuild build` clean. The popover was **not** clicked
+on a real Mac — the desk pass was already spent when this was written, so treat the line's
+appearance as compiled, not observed, and check it on the next install pass.
+
+---
+
 ## 2026-08-05 — the weekday chips were invisible state
 
 **Symptom.** On an older macOS, clicking a day in **Settings → Schedule** changed nothing on
@@ -379,7 +412,9 @@ home is a real signal.
    2026-08-05 entry replaced those buttons) and watch for, in order: `starting pipeline`, an input format
    with a plausible sample rate and channel count, `token OK`, `room connected`,
    `publishing as organizer-host`.
-6. Join the session in a browser and confirm you can hear the board.
+6. Join the session in a browser — **the room named in the popover**, not the one you assume
+   — and confirm you can hear the board. Since the server creates a doc on first arrival, a
+   feeder in the wrong room sounds like silence at the viewer and looks like success here.
 7. Set the schedule, quit, relaunch, and confirm it comes back up on its own.
 
 ---

--- a/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
+++ b/macos-audio-feeder/Sources/AudioFeederApp/MenuContentView.swift
@@ -32,6 +32,7 @@ struct MenuContentView: View {
             }
 
             deviceSummary
+            roomSummary
 
             Divider()
 
@@ -94,6 +95,32 @@ struct MenuContentView: View {
             }
         }
         .font(.caption)
+    }
+
+    /// Which room this will publish into — the fact that decides whether the device, channel
+    /// and schedule above matter at all.
+    ///
+    /// Everything else in this popover reports something that fails loudly when it is wrong: a
+    /// missing device turns orange, a bad key fails the token, an off schedule now says so. A
+    /// wrong room fails silently and looks like success — the feeder connects, publishes, and
+    /// the meter moves, into a room no viewer has open. It is also the only setting derived
+    /// from *this Mac's* clock, so a booth machine with a wrong date produces exactly that.
+    /// Settings already showed the room; an unattended install is judged from the popover.
+    private var roomSummary: some View {
+        HStack(spacing: 6) {
+            Image(systemName: controller.config.pinnedDocID == nil
+                  ? "dot.radiowaves.left.and.right" : "pin.fill")
+            Text(controller.config.resolvedDocID())
+                .lineLimit(1)
+                .truncationMode(.middle)
+            if controller.config.pinnedDocID != nil {
+                // Pinning is rare and usually a one-off, which is precisely why it needs
+                // saying: it is set for one service and then quietly outlives the reason.
+                Text("pinned").foregroundStyle(.orange)
+            }
+        }
+        .font(.caption)
+        .help(controller.config.roomSummary())
     }
 
     /// What decides whether the feeder runs — as a control whose selection *is* the state.

--- a/macos-audio-feeder/Sources/AudioFeederCore/Config.swift
+++ b/macos-audio-feeder/Sources/AudioFeederCore/Config.swift
@@ -159,13 +159,39 @@ public struct FeederConfig: Codable, Equatable, Sendable {
         self.manualOverride = manualOverride
     }
 
+    /// The override, normalized: nil unless it is a non-blank string, and trimmed when it is.
+    ///
+    /// Both halves matter. A cleared text field leaves `""` or `"   "` behind, which has to
+    /// mean "no override" rather than "publish into a room named nothing"; and a stray space
+    /// around a real id would otherwise reach LiveKit intact, putting the feeder in a room
+    /// whose name looks right in the settings field and matches nothing a viewer opens.
+    public var pinnedDocID: String? {
+        guard let trimmed = docIDOverride?.trimmingCharacters(in: .whitespaces),
+              !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
     /// The effective doc id / LiveKit room name for `now`, honoring an override.
     public func resolvedDocID(now: Date = Date(), calendar: Calendar = .current) -> String {
-        if let override = docIDOverride, !override.trimmingCharacters(in: .whitespaces).isEmpty {
-            return override
-        }
+        if let pinned = pinnedDocID { return pinned }
         let c = calendar.dateComponents([.year, .month, .day], from: now)
         return String(format: "doc-%04d-%02d-%02d", c.year ?? 0, c.month ?? 0, c.day ?? 0)
+    }
+
+    /// One sentence naming the room this will publish into, and saying whether that room
+    /// follows the date or has been pinned.
+    ///
+    /// The room is the one setting whose being wrong looks exactly like everything working:
+    /// the feeder connects, publishes, and meters audio into a room nobody opens. Since the
+    /// server creates a session doc on first arrival (`ysDocToken.ts`), the feeder can be the
+    /// thing that creates the empty one — there is no error anywhere to notice. So the room
+    /// has to be legible without opening Settings, and a pin has to announce itself: it is
+    /// set once for a one-off and then outlives the reason for it.
+    public func roomSummary(now: Date = Date(), calendar: Calendar = .current) -> String {
+        let room = resolvedDocID(now: now, calendar: calendar)
+        return pinnedDocID == nil
+            ? "Publishing into \(room) — follows today's date."
+            : "Publishing into \(room) — pinned, so it will not follow the date."
     }
 
     /// One sentence for what will actually govern the feeder, override included.

--- a/macos-audio-feeder/Tests/AudioFeederCoreTests/ConfigTests.swift
+++ b/macos-audio-feeder/Tests/AudioFeederCoreTests/ConfigTests.swift
@@ -28,6 +28,45 @@ final class ConfigTests: XCTestCase {
         XCTAssertEqual(cfg.resolvedDocID(now: now, calendar: utc), "doc-2025-12-31")
     }
 
+    func testOverrideIsTrimmedNotPassedThroughRaw() {
+        // A stray space would otherwise reach LiveKit intact: the settings field looks right
+        // and the feeder publishes into a room name no viewer can type.
+        let cfg = FeederConfig(docIDOverride: "  doc-special  ")
+        XCTAssertEqual(cfg.resolvedDocID(), "doc-special")
+        XCTAssertEqual(cfg.pinnedDocID, "doc-special")
+    }
+
+    func testPinnedDocIDIsNilWhenTheFieldIsBlank() {
+        XCTAssertNil(FeederConfig(docIDOverride: nil).pinnedDocID)
+        XCTAssertNil(FeederConfig(docIDOverride: "").pinnedDocID)
+        XCTAssertNil(FeederConfig(docIDOverride: "   ").pinnedDocID)
+    }
+
+    // MARK: - The room line in the popover
+
+    func testRoomSummarySaysWhetherTheRoomFollowsTheDate() {
+        var c = DateComponents(); c.year = 2026; c.month = 8; c.day = 6
+        let now = utc.date(from: c)!
+
+        XCTAssertEqual(FeederConfig(docIDOverride: nil).roomSummary(now: now, calendar: utc),
+                       "Publishing into doc-2026-08-06 — follows today's date.")
+        XCTAssertEqual(FeederConfig(docIDOverride: "doc-special").roomSummary(now: now, calendar: utc),
+                       "Publishing into doc-special — pinned, so it will not follow the date.")
+    }
+
+    /// The summary must never name a different room than the feeder will actually join —
+    /// that would be worse than showing nothing, since the point of the line is to be trusted.
+    func testRoomSummaryAgreesWithResolvedDocID() {
+        var c = DateComponents(); c.year = 2026; c.month = 8; c.day = 6
+        let now = utc.date(from: c)!
+        for override in [nil, "", "   ", "doc-special", "  doc-padded  "] as [String?] {
+            let cfg = FeederConfig(docIDOverride: override)
+            let room = cfg.resolvedDocID(now: now, calendar: utc)
+            XCTAssertTrue(cfg.roomSummary(now: now, calendar: utc).contains(room),
+                          "summary for override \(String(describing: override)) omits \(room)")
+        }
+    }
+
     func testHHMMRoundTrip() {
         XCTAssertEqual(Schedule.formatHHMM(10 * 60 + 5), "10:05")
         XCTAssertEqual(Schedule.parseHHMM("10:05"), 10 * 60 + 5)


### PR DESCRIPTION
Follow-up to `5ea5f12`, which let the server's in-process Yjs writers create the day's doc instead of 404ing when the feeder arrived before any editor.

That fix was right, but it removed the only evidence. A feeder pointed at a room nobody opens now connects, publishes, and meters audio into an empty doc it created itself — indistinguishable from a good service until someone notices the viewers see nothing. The feeder is the only component that can reach that state unsupervised, and the room is derived from *that Mac's* clock (`resolvedDocID`), so a wrong system date on the booth machine produces it exactly.

Every other fact in the popover fails loudly when it is wrong: a missing device turns orange, a bad key fails the token, a disabled schedule now says so. The room was the exception, and it was only ever shown in Settings — which is not where an unattended install gets judged.

## App

- Popover carries a room line, with a `pinned` badge when `docIDOverride` is set. Pinning is rare, which is the reason to show it: it gets set for one service and then outlives the reason for it.
- `FeederConfig.pinnedDocID` moves the "is it pinned" decision into Core where it can be tested, and **trims the override on the way through**. That is a behavior change: `" doc-x "` previously reached LiveKit with its spaces — looks correct in the settings field, matches nothing a viewer can open.
- `roomSummary` (the tooltip) is tested to always name the same room `resolvedDocID` returns. A line that can disagree with reality is worse than no line, since its only job is to be trusted.

## Docs — the durable half

- **ARCHITECTURE.md**: the lifecycle section said doc ids are date-anchored but never said who *creates* the doc. Now it does, with the corollary worth remembering during an incident: a component on the wrong date doesn't error, it creates that doc and works perfectly, alone. Also notes that four components derive the id independently, three from their own machine's clock.
- **SMOKE_TEST.md**: new **§8 The unattended start**. The checklist had no feeder section at all — it appeared only incidentally under write keys. §8 must run *before* Setup, because Setup opens the editor and thereby creates the doc, hiding this whole class of bug. Setup now says so.
- **NOTEBOOK.md**: an entry for why the app changed, and step 6 of the pre-service checklist now says to join the room the popover names rather than the one you assume.

**Blast radius: §8 (new), and the Setup note.**

## Verification

`swift test` (49, up from 45) and `xcodebuild -scheme AudioFeederApp build` both clean.

**The popover was not clicked on a real Mac** — the desk pass was already spent when this was written. Treat the line's appearance as compiled, not observed, and confirm it on the next install pass. Nothing here reaches the booth machine without a rebuild and reinstall regardless, so this lands in the next install cycle rather than the current season.

🤖 Generated with [Claude Code](https://claude.com/claude-code)