### PR TITLE
Stop the on-air show's date from choosing the doc (#111)

### DIFF
--- a/PROCLAIM_INTEGRATION.md
+++ b/PROCLAIM_INTEGRATION.md
@@ -43,10 +43,8 @@ uv sync
 
 ```bash
 # Make sure Proclaim is running
-# Start the service. By default it targets doc-YYYY-MM-DD using the on-air show's
-# scheduled date (Proclaim's DateGiven), falling back to today's date if the show
-# has no date. This means you can pre-stage a future-dated show: bring it on air in
-# Proclaim and the service syncs to that date's doc automatically.
+# Start the service. By default it targets doc-YYYY-MM-DD for *today* — the same doc
+# id browsers compute — no matter which show is on air.
 uv run proclaim_service.py
 
 # Or specify a custom doc ID (disables date-based selection entirely)
@@ -59,6 +57,9 @@ Environment variables:
 - `PROCLAIM_POLL_INTERVAL` - Polling interval in seconds while on air (default: `0.5`)
 - `PROCLAIM_POLL_INTERVAL_OFF_AIR` - Polling interval while off air (default: `10`)
 - `PROCLAIM_DOC_ID` - Document ID (overridden by command line arg)
+- `PROCLAIM_FOLLOW_SHOW_DATE` - Set to `1` to let the on-air show's own date (Proclaim's
+  `DateGiven`) choose the doc instead of today's date. Off by default; see "Which document"
+  below.
 
 Connection robustness tuning (rarely need changing):
 - `PROCLAIM_OFF_AIR_DISCONNECT_AFTER` - Seconds off air before dropping the Y-Sweet connection (default: `60`)
@@ -84,11 +85,31 @@ reconnects:
 - **Active health checks.** The service pings the websocket each poll so a silently
   dropped connection is detected promptly and triggers a reconnect (the underlying
   library otherwise swallows the disconnect).
-- **Show-dated documents.** When using the default date-based doc, the service anchors
-  the doc to the on-air show's scheduled date (Proclaim's `DateGiven`), so a show
-  prepared the night before still syncs to its own date's doc. When a show has no usable
-  date it falls back to today's date and rolls over at midnight (with a fresh doc) without
-  needing an external restart.
+- **Today's document.** The date-based doc is `doc-<today>`, rolling over at midnight with
+  a fresh doc and no external restart. Which show is on air does not affect it.
+
+### Which document (issue #111)
+
+Three parties decide the doc id independently: browsers ([src/getDocId.ts](src/getDocId.ts))
+use `?doc=` or wall-clock today; this service uses its override or wall-clock today; the
+LiveKit room follows whatever the browser passed. Only this service can see Proclaim's
+`DateGiven`, so a show-dated doc is one **no browser will be looking at** unless every
+viewer is also given a matching `?doc=`.
+
+That is why `DateGiven` is ignored by default. It used to win, and the resolve happened
+once per Y-Sweet session — so opening last week's deck for a moment on a Sunday morning
+pinned the service to last week's doc for the rest of the service, while the congregation
+watched an empty one.
+
+To pre-stage a future-dated show deliberately, either:
+
+- pin the doc explicitly: `uv run proclaim_service.py doc-2026-08-16` (or `PROCLAIM_DOC_ID`),
+  and open browsers on `?doc=doc-2026-08-16`; or
+- set `PROCLAIM_FOLLOW_SHOW_DATE=1` to restore the old show-date behavior, accepting that
+  every browser needs the matching `?doc=`.
+
+The service records the doc it connected to in the session's `status` map under
+`proclaimService.docId`, so an export shows after the fact where the slides went.
 
 ### 3. View Current Slide in Browser
 

--- a/proclaim_service.py
+++ b/proclaim_service.py
@@ -72,6 +72,9 @@ TRANSLATION_SCAN_INTERVAL = float(os.getenv('PROCLAIM_TRANSLATION_SCAN_INTERVAL'
 # Target languages to pre-translate slides into (must match the frontend's configured
 # languages). The translator asks the server to translate the active item into these and
 # writes the reviewed-or-auto results into the per-day slideTranslations map.
+# Let the on-air show's own date (Proclaim's DateGiven) choose the doc, instead of using
+# wall-clock today. Off by default (#111) — see SlideSyncRuntime._resolve_doc_for_session.
+FOLLOW_SHOW_DATE = os.getenv('PROCLAIM_FOLLOW_SHOW_DATE', '').strip().lower() in ('1', 'true', 'yes')
 SLIDE_TRANSLATION_LANGUAGES = [
     lang.strip()
     for lang in os.getenv('SLIDE_TRANSLATION_LANGUAGES', 'French,Haitian Creole,Spanish').split(',')
@@ -168,7 +171,7 @@ def service_version_info(env: Optional[Dict[str, str]] = None) -> Dict[str, Any]
 
 def make_status_announcer(
     version_info: Optional[Dict[str, Any]] = None,
-) -> Callable[[Doc], None]:
+) -> Callable[[Doc, str], None]:
     """Build the runtime's per-session announcement into the shared `status` map (#72/#73).
 
     The version is resolved once, at startup: the launch wrapper's fetch is what makes
@@ -177,15 +180,21 @@ def make_status_announcer(
     Doc, so each session needs its own announcement). The clientId lets a delta recorder
     attribute updates to this writer; the version fields drive the status view's
     "update pending: restart the service" flag.
+
+    ``docId`` records which doc the service believes it is writing into. It is redundant
+    for whoever reads the entry (it's in that doc already) and that is the point: #111 was
+    the service writing into a doc nobody was reading, and the exported session is where
+    that becomes checkable after the fact.
     """
     info = service_version_info() if version_info is None else version_info
     started_at = datetime.now(timezone.utc).isoformat()
 
-    def announce(doc: Doc) -> None:
+    def announce(doc: Doc, doc_id: str) -> None:
         entry = {
             **info,
             'role': 'proclaim-service',
             'clientId': doc.client_id,
+            'docId': doc_id,
             'host': socket.gethostname(),
             'startedAt': started_at,
             'connectedAt': datetime.now(timezone.utc).isoformat(),
@@ -196,7 +205,7 @@ def make_status_announcer(
         pending = ' (update pending — restart to pick it up)' if entry['updatePending'] else ''
         logger.info(
             f"Reporting version {entry['gitShaShort'] or 'unknown'} "
-            f"on {entry['gitBranch'] or 'unknown'}{pending}"
+            f"on {entry['gitBranch'] or 'unknown'} into {doc_id}{pending}"
         )
 
     return announce
@@ -324,6 +333,7 @@ def build_runtime(
         doc_id=doc_id, timing=timing, report_exception=report_exception,
         on_session_start=make_status_announcer(),
         write_key=WRITE_KEY,
+        follow_show_date=FOLLOW_SHOW_DATE,
     )
 
 
@@ -379,6 +389,14 @@ async def main():
     # enforces keys, "no write key configured" is the whole explanation for a service that
     # connects but silently can't write.
     logger.info(f"Write key: {'configured' if WRITE_KEY else 'NOT configured'}")
+    if doc_id:
+        logger.info(f"Doc: {doc_id} (explicit override)")
+    else:
+        logger.info(
+            "Doc: doc-YYYY-MM-DD from "
+            + ("the on-air show's date, falling back to today" if FOLLOW_SHOW_DATE
+               else "today (set PROCLAIM_FOLLOW_SHOW_DATE=1 to use the show's date)")
+        )
     version_info = service_version_info()
     logger.info(
         f"Version: {version_info['gitShaShort'] or 'unknown'} "

--- a/slide_sync_runtime.py
+++ b/slide_sync_runtime.py
@@ -55,8 +55,9 @@ class SlideSyncRuntime:
         doc_id: Optional[str] = None,
         timing: Optional[RuntimeTiming] = None,
         report_exception: Optional[Callable[[Exception], None]] = None,
-        on_session_start: Optional[Callable[[Doc], None]] = None,
+        on_session_start: Optional[Callable[[Doc, str], None]] = None,
         write_key: Optional[str] = None,
+        follow_show_date: bool = False,
     ):
         self.feed = feed
         self.publisher = publisher
@@ -66,12 +67,17 @@ class SlideSyncRuntime:
         # (writable) Y-Sweet token. Optional: while the server runs in observe mode a
         # keyless request is recorded and still served.
         self.write_key = write_key
+        # Whether the on-air show's own date (Proclaim's DateGiven) may choose the doc.
+        # Off by default (#111): browsers resolve the doc from wall-clock today and know
+        # nothing about DateGiven, so a show-dated doc is one no viewer is looking at.
+        self.follow_show_date = follow_show_date
         self.timing = timing or RuntimeTiming()
         self._report_exception = report_exception or (lambda _e: None)
-        # Called with the freshly connected Doc at the start of every session — the seam the
-        # entrypoint uses to announce itself into the shared `status` map (#73). Per-session,
-        # not per-process: a doc rollover makes a new Doc that needs its own announcement.
-        self._on_session_start = on_session_start or (lambda _doc: None)
+        # Called with the freshly connected Doc and the doc id at the start of every session —
+        # the seam the entrypoint uses to announce itself into the shared `status` map (#73).
+        # Per-session, not per-process: a doc rollover makes a new Doc that needs its own
+        # announcement, under a doc id that may differ from the last one.
+        self._on_session_start = on_session_start or (lambda _doc, _doc_id: None)
 
         if doc_id is None:
             self.use_date_based_doc_id = True
@@ -96,15 +102,25 @@ class SlideSyncRuntime:
         return f'doc-{(d or date.today()).isoformat()}'
 
     def _resolve_doc_for_session(self, session: Optional[SessionInfo]) -> None:
-        """Point the date-based doc id at the on-air show's date before connecting.
+        """Choose the date-based doc id for the session about to start.
 
-        Uses the session's date when known, otherwise wall-clock today. Recreates the Doc
-        when the id changes. No-op under an explicit doc_id override.
+        Wall-clock today, unless ``follow_show_date`` is on and the source reports the
+        show's own date. Recreates the Doc when the id changes. No-op under an explicit
+        doc_id override.
+
+        Why today wins by default (#111): the doc id is decided independently by three
+        parties, and only this one can see DateGiven. Browsers use wall-clock today
+        (``src/getDocId.ts``), so following a show's date puts the slides in a doc nobody
+        is reading — and because the resolve happens once per Y-Sweet session, opening
+        last week's deck for a moment could pin the whole service there for the morning.
+        Ignoring the show date makes today's doc the answer no matter which deck goes on
+        air. Pre-staging a future-dated show still works with ``follow_show_date``, but
+        every browser then needs a matching ``?doc=``.
         """
         if not self.use_date_based_doc_id:
             return
 
-        show_date = session.session_date if session else None
+        show_date = session.session_date if (self.follow_show_date and session) else None
         new_date = show_date if show_date is not None else date.today()
         self.doc_date_from_show = show_date is not None
         new_doc_id = self._get_date_based_doc_id(new_date)
@@ -228,7 +244,7 @@ class SlideSyncRuntime:
             logger.info("Connected to Y-Sweet")
             # Force a full re-push of current state onto the freshly connected server.
             self.publisher.bind(self.ydoc)
-            self._on_session_start(self.ydoc)
+            self._on_session_start(self.ydoc, self.doc_id)
 
             bus = SnapshotBus()
             async with anyio.create_task_group() as session_tg:

--- a/tests/test_service_version.py
+++ b/tests/test_service_version.py
@@ -61,13 +61,15 @@ def test_status_announcer_writes_version_and_identity():
     })
     doc = Doc()
 
-    announce(doc)
+    announce(doc, "doc-2026-08-16")
 
     entry = doc.get("status", type=Map)["proclaimService"]
     assert entry["role"] == "proclaim-service"
     assert entry["gitShaShort"] == "aaaaaaa"
     assert entry["updatePending"] is True
     assert entry["clientId"] == doc.client_id
+    # Which doc the service thinks it's writing into — the fact #111 had no record of.
+    assert entry["docId"] == "doc-2026-08-16"
     assert entry["startedAt"] and entry["connectedAt"]
 
 
@@ -79,8 +81,10 @@ def test_status_announcer_reannounces_onto_a_new_doc():
     })
 
     first, second = Doc(), Doc()
-    announce(first)
-    announce(second)
+    announce(first, "doc-2026-08-16")
+    announce(second, "doc-2026-08-17")
 
     assert first.get("status", type=Map)["proclaimService"]["clientId"] == first.client_id
     assert second.get("status", type=Map)["proclaimService"]["clientId"] == second.client_id
+    assert first.get("status", type=Map)["proclaimService"]["docId"] == "doc-2026-08-16"
+    assert second.get("status", type=Map)["proclaimService"]["docId"] == "doc-2026-08-17"

--- a/tests/test_slide_sync_runtime.py
+++ b/tests/test_slide_sync_runtime.py
@@ -43,10 +43,13 @@ def make_runtime(feed, doc_id="doc-test", on_session_start=None):
     return rt
 
 
-def make_date_based_runtime(feed):
+def make_date_based_runtime(feed, follow_show_date=False):
     pub = YjsSlidePublisher()
     tr = SlideTranslator(mock.AsyncMock(return_value=None), ["French"], 0.001)
-    return SlideSyncRuntime(feed, pub, tr, "http://localhost:8000", timing=fast_timing())
+    return SlideSyncRuntime(
+        feed, pub, tr, "http://localhost:8000", timing=fast_timing(),
+        follow_show_date=follow_show_date,
+    )
 
 
 async def test_wait_until_on_air_holds_no_connection():
@@ -163,7 +166,7 @@ async def test_fresh_connection_runs_the_session_start_hook():
     """Every session announces onto the freshly connected doc (#73's version report)."""
     feed = FakeFeed([on_air_snap()])
     seen = []
-    rt = make_runtime(feed, on_session_start=seen.append)
+    rt = make_runtime(feed, on_session_start=lambda doc, doc_id: seen.append((doc, doc_id)))
     ws = FakeWebSocket(fail_ping_after=1)
 
     with patched_connection(ws):
@@ -171,12 +174,51 @@ async def test_fresh_connection_runs_the_session_start_hook():
             with anyio.fail_after(2):
                 await rt._run_session()
 
-    assert seen == [rt.ydoc]
+    # The doc id travels with the Doc so the announcement can record where it landed (#111).
+    assert seen == [(rt.ydoc, "doc-test")]
 
 
-def test_resolve_doc_uses_show_date():
-    """Date-based doc is anchored to the on-air show's date, with a fresh Doc."""
+def test_resolve_doc_ignores_show_date_by_default():
+    """A show's own date must not choose the doc (#111).
+
+    Last week's deck going on air for a moment is the whole bug: it used to repoint the
+    service at last week's doc, where no browser was looking, for the rest of the morning.
+    """
     rt = make_date_based_runtime(FakeFeed([off_air_snap()]))
+    old_doc = rt.ydoc
+    today_doc = SlideSyncRuntime._get_date_based_doc_id(date.today())
+
+    rt._resolve_doc_for_session(SessionInfo("pres-1", date(2030, 1, 15)))
+
+    assert rt.doc_id == today_doc
+    assert rt.doc_date_from_show is False
+    assert rt.current_doc_date == date.today()
+    # Nothing changed, so the Doc (and everything bound to it) is left alone.
+    assert rt.ydoc is old_doc
+
+
+def test_resolve_doc_is_stable_across_a_deck_switch():
+    """Switching to a differently-dated deck mid-morning can't move the doc.
+
+    The resolve runs once per Y-Sweet session, so the guarantee that matters is that
+    *every* session resolves to the same id regardless of which deck is on air.
+    """
+    rt = make_date_based_runtime(FakeFeed([off_air_snap()]))
+    today_doc = SlideSyncRuntime._get_date_based_doc_id(date.today())
+
+    for session in (
+        SessionInfo("last-week", date(2026, 8, 2)),
+        SessionInfo("this-week", date(2026, 8, 9)),
+        SessionInfo("undated", None),
+        None,
+    ):
+        rt._resolve_doc_for_session(session)
+        assert rt.doc_id == today_doc
+
+
+def test_resolve_doc_uses_show_date_when_opted_in():
+    """follow_show_date restores show-dated docs for deliberate pre-staging."""
+    rt = make_date_based_runtime(FakeFeed([off_air_snap()]), follow_show_date=True)
     old_doc = rt.ydoc
 
     rt._resolve_doc_for_session(SessionInfo("pres-1", date(2030, 1, 15)))
@@ -189,8 +231,8 @@ def test_resolve_doc_uses_show_date():
 
 
 def test_resolve_doc_falls_back_to_today_without_show_date():
-    """A session with no date falls back to today and stays midnight-rollable."""
-    rt = make_date_based_runtime(FakeFeed([off_air_snap()]))
+    """An opted-in session with no date falls back to today and stays midnight-rollable."""
+    rt = make_date_based_runtime(FakeFeed([off_air_snap()]), follow_show_date=True)
 
     rt._resolve_doc_for_session(SessionInfo("pres-1", None))
 
@@ -233,7 +275,7 @@ def test_recreate_doc_resets_publisher_translator_and_feed():
 def test_translator_tracks_the_runtime_doc_id_across_rollover():
     """The translator forwards docId to /api/translateItem, so its bound id must follow every
     doc_id change — otherwise a rolled-over day writes conversations into yesterday's doc."""
-    rt = make_date_based_runtime(FakeFeed([off_air_snap()]))
+    rt = make_date_based_runtime(FakeFeed([off_air_snap()]), follow_show_date=True)
     assert rt.translator.doc_id == rt.doc_id
 
     rt._resolve_doc_for_session(SessionInfo("pres-1", date(2030, 1, 15)))


### PR DESCRIPTION
Short-term fix for #111. The long-term "single source of truth for the current doc" design is written up as a comment on the issue and is deliberately **not** in this PR.

## The bug

The doc id is decided independently by three parties, and only this service can see Proclaim's `DateGiven`:

| party | rule |
|---|---|
| browsers | `?doc=` else wall-clock local today (`src/getDocId.ts`) |
| Proclaim service | arg/env else the on-air show's `DateGiven` else today |
| LiveKit rooms | whatever `sessionId` the browser passed |

So following a show's date puts the slides in a doc **no browser is looking at**.

It sticks because the resolve runs once per Y-Sweet session, and a deck switch doesn't end one — `off_air_disconnect_after` exists precisely to *hold* the connection across a switch (`PROCLAIM_INTEGRATION.md`: "a short grace period avoids churn when switching between presentations"). `_poll_until_session_end` never re-reads `snap.session`. On 2026-08-09 that meant last week's deck going on air for a moment repointed the service at `doc-2026-08-02` for the rest of the morning, publishing this week's slides there.

## The change

Ignore `DateGiven` by default: the date-based doc is today's, no matter which deck is on air. That makes the failure *structurally impossible* rather than detected-and-recovered — no mid-session re-resolve needed, and nothing new depends on Proclaim API behavior.

Pre-staging a future-dated show is still available two ways, both requiring the browsers to agree:
- pin it: `uv run proclaim_service.py doc-2026-08-16` (or `PROCLAIM_DOC_ID`), browsers on `?doc=doc-2026-08-16`
- `PROCLAIM_FOLLOW_SHOW_DATE=1` restores the old behavior verbatim

Also, the "and lies about it" half: the service kept no record of which doc it picked, so only the server's auth log knew. It now logs the resolution policy at startup and records `docId` in the `status` map entry, which puts it in the session export.

## Files

- `slide_sync_runtime.py` — `follow_show_date` flag (default off) gating the `DateGiven` read in `_resolve_doc_for_session`; `on_session_start` now receives the doc id
- `proclaim_service.py` — `PROCLAIM_FOLLOW_SHOW_DATE` env var, `docId` in the status entry, startup log line naming the policy
- `PROCLAIM_INTEGRATION.md` — new "Which document" section; the old text promised show-dated docs as a feature
- tests — the default-ignores case, a deck-switch stability test, the opt-in path, and `docId` in the announcer

## Testing

`uv run pytest` — 95 passed. No frontend changes.

## Blast radius

§3 (Proclaim sync). Specifically worth doing on the real thing: bring one deck on air, switch to a differently-dated deck, confirm `/status` and the slide views stay on today's doc.

## Deploying this before Sunday

CLAUDE.md says don't move `proclaim-stable` after Thursday and today is Friday, so this is a deliberate exception to call. `KeepAlive` is true and `proclaim_service_launch.sh` fast-forwards on every launch, so `git push origin main:proclaim-stable` lands on the church Mac the next time the process restarts — no plist edit and no physical access needed. It does **not** land if the machine simply keeps running the current process through Sunday, so restart it remotely if you can, and check `/status` for the SHA.

---
_Generated by [Claude Code](https://claude.ai/code/session_019RDJ1FgJTnnD8FsiUJ7Fcj)_